### PR TITLE
fix black version, remove trailing commas.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,5 +72,5 @@
     "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
     //
     // Signal that we are using shared workspace settings in .vscode
-    "window.title": "sbi.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}"
+    "window.title": "sbi.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}",
 }

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -162,7 +162,7 @@ class NeuralInference(ABC):
             best_validation_log_probs=[],
             validation_log_probs=[],
             train_log_probs=[],
-            epoch_durations_sec=[]
+            epoch_durations_sec=[],
         )
 
     def __call__(self, unused_args):
@@ -485,8 +485,6 @@ class NeuralInference(ABC):
             scalar_value=self._summary["best_validation_log_probs"][-1],
             global_step=round_ + 1,
         )
-
-
 
         # Add validation log prob for every epoch.
         # Offset with all previous epochs.

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -69,10 +69,7 @@ class LikelihoodBasedPosterior(NeuralPosterior):
         )
 
     def log_prob(
-        self,
-        theta: Tensor,
-        x: Optional[Tensor] = None,
-        track_gradients: bool = False,
+        self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False
     ) -> Tensor:
         r"""
         Returns the log-probability of $p(x|\theta) \cdot p(\theta).$
@@ -358,11 +355,7 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self,
-        prior,
-        likelihood_nn: nn.Module,
-        x: Tensor,
-        mcmc_method: str,
+        self, prior, likelihood_nn: nn.Module, x: Tensor, mcmc_method: str
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -67,10 +67,7 @@ class RatioBasedPosterior(NeuralPosterior):
         super().__init__(**kwargs)
 
     def log_prob(
-        self,
-        theta: Tensor,
-        x: Optional[Tensor] = None,
-        track_gradients: bool = False,
+        self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False
     ) -> Tensor:
         r"""
         Returns the log-probability of $p(x|\theta) \cdot p(\theta).$

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -167,9 +167,10 @@ class SNPE_A(PosteriorEstimator):
             Density estimator that approximates the distribution $p(\theta|x)$.
         """
 
-        assert (
-            not retrain_from_scratch_each_round
-        ), "Retraining from scratch is not supported in SNPE-A yet. The reason for this is that, if we reininitialized the density estimator, the z-scoring would change, which would break the posthoc correction. This is a pure implementation issue."
+        assert not retrain_from_scratch_each_round, """Retraining from scratch is not supported in SNPE-A yet. The reason for
+        this is that, if we reininitialized the density estimator, the z-scoring would
+        change, which would break the posthoc correction. This is a pure implementation
+        issue."""
 
         kwargs = utils.del_entries(
             locals(),
@@ -729,7 +730,8 @@ class SNPE_A_MDN(nn.Module):
                 eig_d = torch.symeig(d, eigenvectors=False).eigenvalues
                 assert (
                     eig_d > 0
-                ).all(), "The precision matrix of the density estimator is not positive definite!"
+                ).all(), """The precision matrix of the density estimator is not
+                positive definite!"""
 
         precisions_pp_rep = precisions_pp.repeat_interleave(num_comps_d, dim=1)
         precisions_d_rep = precisions_d.repeat(1, num_comps_p, 1, 1)
@@ -825,7 +827,8 @@ class SNPE_A_MDN(nn.Module):
         r"""
         Return the component weights (i.e. logits) of the MoG posterior.
 
-        $\alpha_k^\prime = \frac{ \alpha_k exp(-0.5 c_k) }{ \sum{j} \alpha_j exp(-0.5 c_j) } $
+        $\alpha_k^\prime = \frac{ \alpha_k exp(-0.5 c_k) }{ \sum{j} \alpha_j exp(-0.5
+        c_j) } $
         with
         $c_k = logdet(S_k) - logdet(S_0) - logdet(S_k^\prime) +
              + m_k^T P_k m_k - m_0^T P_0 m_0 - m_k^\prime^T P_k^\prime m_k^\prime$

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -84,7 +84,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._summary.update({"rejection_sampling_acceptance_rates": []})  # type:ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, proposal: Optional[Any] = None,
+        self, theta: Tensor, x: Tensor, proposal: Optional[Any] = None
     ) -> "PosteriorEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -223,7 +223,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         )
 
         # Dataset is shared for training and validation loaders.
-        dataset = data.TensorDataset(theta, x, prior_masks,)
+        dataset = data.TensorDataset(theta, x, prior_masks)
 
         # Set the proposal to the last proposal that was passed by the user. For
         # atomic SNPE, it does not matter what the proposal is. For non-atomic
@@ -263,7 +263,7 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         if not resume_training:
             self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()), lr=learning_rate,
+                list(self._neural_net.parameters()), lr=learning_rate
             )
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
@@ -286,7 +286,7 @@ class PosteriorEstimator(NeuralInference, ABC):
 
                 batch_loss = torch.mean(
                     self._loss(
-                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
+                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel
                     )
                 )
 
@@ -295,7 +295,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                 batch_loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(), max_norm=clip_max_norm
                     )
                 self.optimizer.step()
 
@@ -317,7 +317,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                     )
                     # Take negative loss here to get validation log_prob.
                     batch_log_prob = -self._loss(
-                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
+                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel
                     )
                     log_prob_sum += batch_log_prob.sum().item()
 
@@ -338,9 +338,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._summary["best_validation_log_probs"].append(self._best_val_log_prob)
 
         # Update tensorboard and summary dict.
-        self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
-        )
+        self._summarize(round_=self._round, x_o=None, theta_bank=theta, x_bank=x)
 
         # Update description for progress bar.
         if show_train_summary:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIRED = [
 EXTRAS = {
     "dev": [
         "autoflake",
-        "black",
+        "black>=20.8bo",
         "deepdiff",
         "flake8",
         "isort",

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -56,7 +56,7 @@ def test_z_scoring_warning(snpe_method: type):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("method", "exclude_invalid_x", "percent_nans"),
-    ((SNPE_C, True, 0.05), (SNL, True, 0.05), (SRE, True, 0.05),),
+    ((SNPE_C, True, 0.05), (SNL, True, 0.05), (SRE, True, 0.05)),
 )
 def test_inference_with_nan_simulator(
     method: type, exclude_invalid_x: bool, percent_nans: float, set_seed

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -24,7 +24,7 @@ def test_simulate_in_batches(
     simulator,
     prior=BoxUniform(zeros(5), ones(5)),
 ):
-    """Test combinations of num_sims and simulation_batch_size. """
+    """Test combinations of num_sims and simulation_batch_size."""
 
     simulator, prior = prepare_for_sbi(simulator, prior)
     theta = prior.sample((num_sims,))


### PR DESCRIPTION
fix `black` to version [`20.8.b`](https://black.readthedocs.io/en/stable/change_log.html?highlight=trailing%20comma) to avoid conflicts in handling of trailing commas. 

- run `black` and `isort` on `sbi/` and `tests/`.