### PR TITLE
MAP property for posteriors

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -248,16 +248,15 @@ class DirectPosterior(NeuralPosterior):
         save_best_every: int = 10,
         show_progress_bars: bool = False,
         force_update: bool = False,
-        warn_about_cached: bool = True,
     ) -> Tensor:
         r"""Returns the maximum-a-posteriori estimate (MAP).
 
         The method can be interrupted (Ctrl-C) when the user sees that the
-        log-probability converges. The best estimate will be saved in `self.map_`.
-        The MAP is obtained by running gradient ascent from a given number of starting
-        positions (samples from the posterior with the highest log-probability). After
-        the optimization is done, we select the parameter set that has the highest
-        log-probability after the optimization.
+        log-probability converges. The best estimate will be saved in `self._map` and
+        can be accessed with `self.map()`. The MAP is obtained by running gradient
+        ascent from a given number of starting positions (samples from the posterior
+        with the highest log-probability). After the optimization is done, we select the
+        parameter set that has the highest log-probability after the optimization.
 
         Warning: The default values used by this function are not well-tested. They
         might require hand-tuning for the problem at hand.
@@ -266,7 +265,7 @@ class DirectPosterior(NeuralPosterior):
         in unbounded space and transform the result back into bounded space.
 
         Args:
-            x: Observed data at which to evaluate the MAP.
+            x: Deprecated - use `.set_default_x()` prior to `.map()`.
             num_iter: Number of optimization steps that the algorithm takes
                 to find the MAP.
             learning_rate: Learning rate of the optimizer.
@@ -285,10 +284,8 @@ class DirectPosterior(NeuralPosterior):
                 (thus, the default is `10`.)
             show_progress_bars: Whether or not to show a progressbar for sampling from
                 the posterior.
-            force_update: Whether or not to re-calculate the MAP when x is unchanged and
+            force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.
-            warn_about_cached: Whether or not to show warning that we are using the
-                stored value for the MAP.
             log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain
                 {'norm_posterior': True} for SNPE.
 
@@ -305,5 +302,4 @@ class DirectPosterior(NeuralPosterior):
             save_best_every=save_best_every,
             show_progress_bars=show_progress_bars,
             force_update=force_update,
-            warn_about_cached=warn_about_cached,
         )

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -510,16 +510,15 @@ class MCMCPosterior(NeuralPosterior):
         save_best_every: int = 10,
         show_progress_bars: bool = False,
         force_update: bool = False,
-        warn_about_cached: bool = True,
     ) -> Tensor:
         r"""Returns the maximum-a-posteriori estimate (MAP).
 
         The method can be interrupted (Ctrl-C) when the user sees that the
-        log-probability converges. The best estimate will be saved in `self.map_`.
-        The MAP is obtained by running gradient ascent from a given number of starting
-        positions (samples from the posterior with the highest log-probability). After
-        the optimization is done, we select the parameter set that has the highest
-        log-probability after the optimization.
+        log-probability converges. The best estimate will be saved in `self._map` and
+        can be accessed with `self.map()`. The MAP is obtained by running gradient
+        ascent from a given number of starting positions (samples from the posterior
+        with the highest log-probability). After the optimization is done, we select the
+        parameter set that has the highest log-probability after the optimization.
 
         Warning: The default values used by this function are not well-tested. They
         might require hand-tuning for the problem at hand.
@@ -528,14 +527,14 @@ class MCMCPosterior(NeuralPosterior):
         in unbounded space and transform the result back into bounded space.
 
         Args:
-            x: Observed data at which to evaluate the MAP.
+            x: Deprecated - use `.set_default_x()` prior to `.map()`.
             num_iter: Number of optimization steps that the algorithm takes
                 to find the MAP.
             learning_rate: Learning rate of the optimizer.
             init_method: How to select the starting parameters for the optimization. If
-                it is a string, it can be either [`posterior`, `proposal`], which
-                samples the respective distribution `num_init_samples` times. If it is
-                a tensor, the tensor will be used as init locations.
+                it is a string, it can be either [`posterior`, `prior`], which samples
+                the respective distribution `num_init_samples` times. If it is a
+                tensor, the tensor will be used as init locations.
             num_init_samples: Draw this number of samples from the posterior and
                 evaluate the log-probability of all of them.
             num_to_optimize: From the drawn `num_init_samples`, use the
@@ -547,10 +546,8 @@ class MCMCPosterior(NeuralPosterior):
                 (thus, the default is `10`.)
             show_progress_bars: Whether or not to show a progressbar for sampling from
                 the posterior.
-            force_update: Whether or not to re-calculate the MAP when x is unchanged and
+            force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.
-            warn_about_cached: Whether or not to show warning that we are using the
-                stored value for the MAP.
             log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain
                 {'norm_posterior': True} for SNPE.
 
@@ -567,7 +564,6 @@ class MCMCPosterior(NeuralPosterior):
             save_best_every=save_best_every,
             show_progress_bars=show_progress_bars,
             force_update=force_update,
-            warn_about_cached=warn_about_cached,
         )
 
 

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -174,16 +174,15 @@ class RejectionPosterior(NeuralPosterior):
         save_best_every: int = 10,
         show_progress_bars: bool = False,
         force_update: bool = False,
-        warn_about_cached: bool = True,
     ) -> Tensor:
         r"""Returns the maximum-a-posteriori estimate (MAP).
 
         The method can be interrupted (Ctrl-C) when the user sees that the
-        log-probability converges. The best estimate will be saved in `self.map_`.
-        The MAP is obtained by running gradient ascent from a given number of starting
-        positions (samples from the posterior with the highest log-probability). After
-        the optimization is done, we select the parameter set that has the highest
-        log-probability after the optimization.
+        log-probability converges. The best estimate will be saved in `self._map` and
+        can be accessed with `self.map()`. The MAP is obtained by running gradient
+        ascent from a given number of starting positions (samples from the posterior
+        with the highest log-probability). After the optimization is done, we select the
+        parameter set that has the highest log-probability after the optimization.
 
         Warning: The default values used by this function are not well-tested. They
         might require hand-tuning for the problem at hand.
@@ -192,7 +191,7 @@ class RejectionPosterior(NeuralPosterior):
         in unbounded space and transform the result back into bounded space.
 
         Args:
-            x: Observed data at which to evaluate the MAP.
+            x: Deprecated - use `.set_default_x()` prior to `.map()`.
             num_iter: Number of optimization steps that the algorithm takes
                 to find the MAP.
             learning_rate: Learning rate of the optimizer.
@@ -211,10 +210,8 @@ class RejectionPosterior(NeuralPosterior):
                 (thus, the default is `10`.)
             show_progress_bars: Whether or not to show a progressbar for sampling from
                 the posterior.
-            force_update: Whether or not to re-calculate the MAP when x is unchanged and
+            force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.
-            warn_about_cached: Whether or not to show warning that we are using the
-                stored value for the MAP.
             log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain
                 {'norm_posterior': True} for SNPE.
 
@@ -231,5 +228,4 @@ class RejectionPosterior(NeuralPosterior):
             save_best_every=save_best_every,
             show_progress_bars=show_progress_bars,
             force_update=force_update,
-            warn_about_cached=warn_about_cached,
         )

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -521,15 +521,16 @@ class VIPosterior(NeuralPosterior):
         num_init_samples: int = 10_000,
         save_best_every: int = 10,
         show_progress_bars: bool = False,
+        force_update: bool = False,
     ) -> Tensor:
         r"""Returns the maximum-a-posteriori estimate (MAP).
 
         The method can be interrupted (Ctrl-C) when the user sees that the
-        log-probability converges. The best estimate will be saved in `self.map_`.
-        The MAP is obtained by running gradient ascent from a given number of starting
-        positions (samples from the posterior with the highest log-probability). After
-        the optimization is done, we select the parameter set that has the highest
-        log-probability after the optimization.
+        log-probability converges. The best estimate will be saved in `self._map` and
+        can be accessed with `self.map()`. The MAP is obtained by running gradient
+        ascent from a given number of starting positions (samples from the posterior
+        with the highest log-probability). After the optimization is done, we select the
+        parameter set that has the highest log-probability after the optimization.
 
         Warning: The default values used by this function are not well-tested. They
         might require hand-tuning for the problem at hand.
@@ -538,7 +539,7 @@ class VIPosterior(NeuralPosterior):
         in unbounded space and transform the result back into bounded space.
 
         Args:
-            x: Observed data at which to evaluate the MAP.
+            x: Deprecated - use `.set_default_x()` prior to `.map()`.
             num_iter: Number of optimization steps that the algorithm takes
                 to find the MAP.
             learning_rate: Learning rate of the optimizer.
@@ -557,8 +558,10 @@ class VIPosterior(NeuralPosterior):
                 (thus, the default is `10`.)
             show_progress_bars: Whether or not to show a progressbar for sampling from
                 the posterior.
+            force_update: Whether to re-calculate the MAP when x is unchanged and
+                have a cached value.
             log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain
-                {`norm_posterior`: True} for SNPE.
+                {'norm_posterior': True} for SNPE.
 
         Returns:
             The MAP estimate.
@@ -573,4 +576,5 @@ class VIPosterior(NeuralPosterior):
             num_init_samples=num_init_samples,
             save_best_every=save_best_every,
             show_progress_bars=show_progress_bars,
+            force_update=force_update,
         )

--- a/sbi/samplers/mcmc/init_strategy.py
+++ b/sbi/samplers/mcmc/init_strategy.py
@@ -4,7 +4,7 @@
 from typing import Any, Callable
 
 import torch
-from pyknos import nflows
+import torch.distributions.transforms as torch_tf
 from torch import Tensor
 
 


### PR DESCRIPTION
The new map() only calculates the MAP if there is no value stored for the default_x, or if a an x that is different to the default_x is specified. If the stored value is used, a warning is printed.

Somewhat related question:
Right now, we are allowing posterior.map(x) to run without setting default_x. But the calls to sample() required to compute the MAP need a default_x, so this throws an error anyway. Do we want to pass the specified x to the sample() method? Or require default_x to be set before calling map()?