### PR TITLE
Allow Apple MPS as GPU device

### DIFF
--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -85,7 +85,7 @@ def check_device(device: str) -> None:
             f"""Could not instantiate torch.randn(1, device={device}). Make sure
              the device is set up properly and that you are passing the
              corresponding device string. It should be something like 'cuda',
-             'cuda:0', or 'mps'."""
+             'cuda:0', or 'mps'. Error message: {exc}."""
         ) from exc
 
 

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -3,6 +3,7 @@
 
 """Test PyTorch utility functions."""
 from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np
@@ -200,7 +201,7 @@ def test_dkl_gauss():
         )
 
 
-@pytest.mark.parametrize("device_input", ("cpu", "gpu", "cuda", "cuda:0", "mps", ))
+@pytest.mark.parametrize("device_input", ("cpu", "gpu", "cuda", "cuda:0", "mps"))
 def test_process_device(device_input: str) -> None:
     """Test whether the device is processed correctly."""
 


### PR DESCRIPTION
## Problem
We only support CUDA as GPU devices, but PyTorch 2.1 now supports Apple MPS chips as well (to some extend, see below). 

https://pytorch.org/docs/stable/notes/mps.html 

## Solution
This PR changes the processing of passed device arguments to also allow MPS, e.g., instead of using `cuda` in the tests, we use `gpu` and parse the string to `mps:0` or `cuda:0` accordingly. 

## Additional comments
- there is a problem when using MPS with `VIPosterior`, `q="nsf"` and `num_dims>1`. Sampling `q` then produces NaNs, see #948 
- PyTorch MPS backend is not implemented for a number of functions, e.g., `torch.linalg.cholesky`. So it uses CPU as a fallback there
- PyTorch MPS only supports float32 and `nflows` requires float64 (see here: https://github.com/bayesiains/nflows/blob/3b122e5bbc14ed196301969c12d1c2d94fdfba47/nflows/distributions/normal.py#L19-L20)
- thus, unless we make a PR in `nflows` to remove the hard coding of float64 and add an option to set the default float type globally, using MPS will not work. 