### PR TITLE
Clarify tutorial on multi-round

### DIFF
--- a/tutorials/03_multiround_inference.ipynb
+++ b/tutorials/03_multiround_inference.ipynb
@@ -37,9 +37,9 @@
     "# that were sampled from the obtained posterior.\n",
     "num_rounds = 2\n",
     "# The specific observation we want to focus the inference on.\n",
-    "x_o = torch.zeros(\n",
-    "    3,\n",
-    ")\n",
+    "x_o = torch.zeros(3,)\n",
+    "\n",
+    "inference = SNPE(prior)\n",
     "\n",
     "posteriors = []\n",
     "proposal = prior\n",
@@ -279,7 +279,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -293,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The inference object did not get instantiated in the multi round tutorial.

Closes #916 