### PR TITLE
Profile slow and GPU tests

### DIFF
--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -21,6 +21,9 @@ def process_device(device: str) -> str:
     Throws an AssertionError if the prior is not matching the training device not.
     """
 
+    # NOTE: we might want to add support for other devices in the future, e.g., MPS
+    gpu_devices = ["cuda", "gpu"]
+
     if device == "cpu":
         return "cpu"
     else:
@@ -31,7 +34,7 @@ def process_device(device: str) -> str:
             "only for large neural networks with operations that are fast on the "
             "GPU, e.g., for a CNN or RNN `embedding_net`."
         )
-        if device == "cuda":
+        if device in gpu_devices:
             assert torch.cuda.is_available(), "CUDA is not available."
             current_gpu_index = torch.cuda.current_device()
             return f"cuda:{current_gpu_index}"
@@ -42,7 +45,7 @@ def process_device(device: str) -> str:
             except RuntimeError:
                 raise RuntimeError(
                     f"""Could not instantiate torch.randn(1, device={device}). Please
-                    use 'cuda', or cuda:<index> with <index> <
+                    use one in {gpu_devices}, or cuda:<index> with <index> <
                     {torch.cuda.device_count()}."""
                 )
             torch.cuda.set_device(device)

--- a/tests/linearGaussian_mdn_test.py
+++ b/tests/linearGaussian_mdn_test.py
@@ -66,13 +66,19 @@ def mdn_inference_with_different_methods(method):
             likelihood_estimator=estimator, prior=prior, x_o=x_o
         )
         posterior = MCMCPosterior(
-            potential_fn=potential_fn, theta_transform=theta_transform, proposal=prior
+            potential_fn=potential_fn,
+            theta_transform=theta_transform,
+            proposal=prior,
+            method="slice_np_vectorized",
+            num_chains=20,
+            warmup_steps=50,
+            thin=5,
         )
 
     samples = posterior.sample((num_samples,), x=x_o)
 
     # Compute the c2st and assert it is near chance level of 0.5.
-    check_c2st(samples, target_samples, alg=f"{method}")
+    check_c2st(samples, target_samples, alg=f"{method.__name__}")
 
 
 def test_mdn_with_1D_uniform_prior():

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -148,7 +148,7 @@ def test_c2st_and_map_snl_on_linearGaussian_different(num_dim: int, prior_str: s
 
     """
     num_samples = 500
-    num_simulations = 4500
+    num_simulations = 5000
     trials_to_test = [1]
 
     # likelihood_mean will be likelihood_shift+theta
@@ -219,8 +219,6 @@ def test_c2st_and_map_snl_on_linearGaussian_different(num_dim: int, prior_str: s
             show_progress_bars=False,
         )
 
-        # TODO: we do not have a test for SNL log_prob(). This is because the output
-        # TODO: density is not normalized, so KLd does not make sense.
         if prior_str == "uniform":
             # Check whether the returned probability outside of the support is zero.
             posterior_prob = get_prob_outside_uniform_prior(posterior, prior, num_dim)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -44,11 +44,7 @@ from .test_utils import (
 @pytest.mark.parametrize("snpe_method", [SNPE_A, SNPE_C])
 @pytest.mark.parametrize(
     "num_dim, prior_str",
-    (
-        (2, "gaussian"),
-        (2, "uniform"),
-        (1, "gaussian"),
-    ),
+    ((2, "gaussian"), (2, "uniform"), (1, "gaussian")),
 )
 def test_c2st_snpe_on_linearGaussian(snpe_method, num_dim: int, prior_str: str):
     """Test whether SNPE infers well a simple example with available ground truth."""
@@ -398,8 +394,7 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
     (
         ("mcmc", "slice_np", "gaussian"),
         ("mcmc", "slice", "gaussian"),
-        # XXX (True, "slice", "uniform"),
-        # XXX takes very long. fix when refactoring pyro sampling
+        ("mcmc", "slice_np_vectorized", "gaussian"),
         ("rejection", "rejection", "uniform"),
     ),
 )
@@ -440,6 +435,9 @@ def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str):
             theta_transform=theta_transform,
             proposal=prior,
             method=mcmc_method,
+            num_chains=10 if mcmc_method == "slice_np_vectorized" else 1,
+            warmup_steps=10,
+            thin=1,
         )
     elif sample_with == "rejection":
         posterior = RejectionPosterior(

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -513,6 +513,12 @@ def test_sample_conditional():
     num_dim = 3
     dim_to_sample_1 = 0
     dim_to_sample_2 = 2
+    num_simulations = 6000
+    num_conditional_samples = 500
+
+    mcmc_parameters = dict(
+        method="slice_np_vectorized", num_chains=20, warmup_steps=50, thin=5
+    )
 
     x_o = zeros(1, num_dim)
 
@@ -535,7 +541,9 @@ def test_sample_conditional():
     inference = SNPE_C(prior, density_estimator=net, show_progress_bars=False)
 
     # We need a pretty big dataset to properly model the bimodality.
-    theta, x = simulate_for_sbi(simulator, prior, 10000)
+    theta, x = simulate_for_sbi(
+        simulator, prior, num_simulations, simulation_batch_size=num_simulations
+    )
     posterior_estimator = inference.append_simulations(theta, x).train(
         max_num_epochs=60
     )
@@ -565,8 +573,9 @@ def test_sample_conditional():
         potential_fn=conditioned_potential_fn,
         theta_transform=restricted_tf,
         proposal=restricted_prior,
+        **mcmc_parameters,
     )
-    cond_samples = mcmc_posterior.sample((500,))
+    cond_samples = mcmc_posterior.sample((num_conditional_samples,))
 
     _ = analysis.pairplot(
         cond_samples,

--- a/tests/multiprocessing_test.py
+++ b/tests/multiprocessing_test.py
@@ -16,6 +16,7 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def slow_linear_gaussian(theta):
+    """Linear Gaussian simulator with a sleep statement."""
     x = []
     for th in theta:
         time.sleep(0.05)
@@ -27,7 +28,8 @@ def slow_linear_gaussian(theta):
 @pytest.mark.slow
 @pytest.mark.parametrize("num_workers", [10, -2])
 @pytest.mark.parametrize("sim_batch_size", ((1, 10, 100)))
-def test_benchmarking_sp(sim_batch_size, num_workers):
+def test_benchmarking_parallel_simulation(sim_batch_size, num_workers):
+    """Test whether joblib is faster than serial processing."""
     num_simulations = 100
     theta = torch.zeros(num_simulations, 2)
     show_pbar = True
@@ -52,5 +54,5 @@ def test_benchmarking_sp(sim_batch_size, num_workers):
     )
     toc_joblib = time.time() - tic
 
-    # Allow joblib to be 10 percent slower.
+    # Allow joblib to be 10 percent slower due to overhead.
     assert toc_joblib <= toc_sp * 1.1

--- a/tests/sbc_test.py
+++ b/tests/sbc_test.py
@@ -112,15 +112,22 @@ def test_sbc_checks():
     """Test the uniformity checks for SBC."""
 
     num_dim = 2
-    N = 10000
-    L = 1000
+    num_posterior_samples = 1500
 
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    # Daps and ranks from prior for testing.
-    daps = prior.sample((N,))
-    ranks = torch.distributions.Uniform(zeros(num_dim), L * ones(num_dim)).sample((N,))
+    # Data averaged posterior samples should be distributed as prior.
+    daps = prior.sample((num_posterior_samples,))
+    # Ranks should be distributed uniformly in [0, num_posterior_samples]
+    ranks = torch.distributions.Uniform(
+        zeros(num_dim), num_posterior_samples * ones(num_dim)
+    ).sample((num_posterior_samples,))
 
-    checks = check_sbc(ranks, prior.sample((N,)), daps, num_posterior_samples=L)
+    checks = check_sbc(
+        ranks,
+        prior.sample((num_posterior_samples,)),
+        daps,
+        num_posterior_samples=num_posterior_samples,
+    )
     assert (checks["ks_pvals"] > 0.05).all()
     assert (checks["c2st_ranks"] < 0.55).all()
     assert (checks["c2st_dap"] < 0.55).all()


### PR DESCRIPTION
Problem: running `pytest -m "slow" tests/` currently takes for hours. 

This PR speeds up slow tests by
- removing duplicate test cases
- using fewer simulations or samples where possible
- using better mcmc params (-> `slice_np_vectorized` 🚀 )

TODO: 
- [x] compare `main` vs PR on GPU machine `pytest -m "slow" tests/` (includes some GPU tests): down from 04:43:35 to 01:04:56 👍 
- [x] refactor `pytest -m "gpu" tests/` on GPU machine: down from 1:16:29 to 00:08:51 👍  
- [x] compare `main` vs PR speed on MBPro M3: `pytest -m "slow and not gpu" tests/`: down from 00:25:11 to 00:12:51 👍 

Note: the speed up may seem suspicious, but I really did remove only a couple of tests where I was sure they are duplicates or not needed. Changing from default arg mcmc sampling to vectorized with better args just has a really big impact on speed (important note for #910) 