### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Please add a minimal code example that reproduces the problem:
-1. Name python version and SBI version
+1. Name Python version and SBI version
 2. Minimal code example
 3. [Optional]: error message
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please add a minimal code example that reproduces the problem:
+1. Name python version and SBI version
+2. Minimal code example
+3. [Optional]: error message
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: Question
+about: Ask a question or report a problem
+title: ''
+labels: question
+assignees: ''
+
+---
+
+Describe your question or problem here. Please provide reproducible code
+examples if applicable.
+
+If this is a general question about SBI, please consider [opening a Discussion
+instead](https://github.com/sbi-dev/sbi/discussions).


### PR DESCRIPTION
Add standard issue templates for bugs and features. 

We might want to something more general, e.g., a template for "Question / use case problem"? With a pointer to create a discussion instead of an issue. 

Any thoughts? 