### PR TITLE
Allow for the potential_fn to be a Callable

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -12,6 +12,7 @@ from sbi.types import Array, Shape, TorchTransform
 from sbi.utils import gradient_ascent
 from sbi.utils.torchutils import ensure_theta_batched, process_device
 from sbi.utils.user_input_checks import process_x
+from sbi.inference.potentials.base_potential import BasePotential
 
 
 class NeuralPosterior(ABC):
@@ -38,6 +39,18 @@ class NeuralPosterior(ABC):
                 `potential_fn.device` is used.
             x_shape: Shape of the observed data.
         """
+        if not isinstance(potential_fn, BasePotential):
+            callable_potential = potential_fn
+
+            class CallablePotentialWrapper(BasePotential):
+                """If `potential_fn` is a callable it gets wrapped as this."""
+                allow_iid_x = True
+                
+                def __call__(self, theta, **kwargs):
+                    return callable_potential(theta=theta, x_o=self.x_o, **kwargs)
+
+            potential_fn = CallablePotentialWrapper(None, None)
+
 
         # Ensure device string.
         self._device = process_device(potential_fn.device if device is None else device)

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -7,6 +7,7 @@ from torch import Tensor
 
 from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.importance.importance_sampling import importance_sample
 from sbi.samplers.importance.sir import sampling_importance_resampling
 from sbi.types import Shape, TorchTransform
@@ -24,7 +25,7 @@ class ImportanceSamplingPosterior(NeuralPosterior):
 
     def __init__(
         self,
-        potential_fn: Callable,
+        potential_fn: Union[Callable, BasePotential],
         proposal: Any,
         theta_transform: Optional[TorchTransform] = None,
         method: str = "sir",
@@ -35,7 +36,8 @@ class ImportanceSamplingPosterior(NeuralPosterior):
     ):
         """
         Args:
-            potential_fn: The potential function from which to draw samples.
+            potential_fn: The potential function from which to draw samples. Must be a
+                `BasePotential` or a `Callable` which takes `theta` and `x_o` as inputs.
             proposal: The proposal distribution.
             theta_transform: Transformation that is applied to parameters. Is not used
                 during but only when calling `.map()`.

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -31,6 +31,7 @@ from sbi.simulators.simutils import tqdm_joblib
 from sbi.types import Shape, TorchTransform
 from sbi.utils import pyro_potential_wrapper, tensor2numpy, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.inference.potentials.base_potential import BasePotential
 
 
 class MCMCPosterior(NeuralPosterior):

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -18,6 +18,7 @@ from torch import multiprocessing as mp
 from tqdm.auto import tqdm
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.mcmc import (
     IterateParameters,
     Slice,
@@ -41,7 +42,7 @@ class MCMCPosterior(NeuralPosterior):
 
     def __init__(
         self,
-        potential_fn: Callable,
+        potential_fn: Union[Callable, BasePotential],
         proposal: Any,
         theta_transform: Optional[TorchTransform] = None,
         method: str = "slice_np",
@@ -57,7 +58,8 @@ class MCMCPosterior(NeuralPosterior):
     ):
         """
         Args:
-            potential_fn: The potential function from which to draw samples.
+            potential_fn: The potential function from which to draw samples. Must be a
+                `BasePotential` or a `Callable` which takes `theta` and `x_o` as inputs.
             proposal: Proposal distribution that is used to initialize the MCMC chain.
             theta_transform: Transformation that will be applied during sampling.
                 Allows to perform MCMC in unconstrained space.

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -31,7 +31,6 @@ from sbi.simulators.simutils import tqdm_joblib
 from sbi.types import Shape, TorchTransform
 from sbi.utils import pyro_potential_wrapper, tensor2numpy, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched
-from sbi.inference.potentials.base_potential import BasePotential
 
 
 class MCMCPosterior(NeuralPosterior):

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -9,6 +9,7 @@ from torch import Tensor
 
 from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.rejection.rejection import rejection_sample
 from sbi.types import Shape, TorchTransform
 from sbi.utils.torchutils import ensure_theta_batched
@@ -22,7 +23,7 @@ class RejectionPosterior(NeuralPosterior):
 
     def __init__(
         self,
-        potential_fn: Callable,
+        potential_fn: Union[Callable, BasePotential],
         proposal: Any,
         theta_transform: Optional[TorchTransform] = None,
         max_sampling_batch_size: int = 10_000,
@@ -34,7 +35,8 @@ class RejectionPosterior(NeuralPosterior):
     ):
         """
         Args:
-            potential_fn: The potential function from which to draw samples.
+            potential_fn: The potential function from which to draw samples. Must be a
+                `BasePotential` or a `Callable` which takes `theta` and `x_o` as inputs.
             proposal: The proposal distribution.
             theta_transform: Transformation that is applied to parameters. Is not used
                 during but only when calling `.map()`.

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -115,7 +115,7 @@ class VIPosterior(NeuralPosterior):
             self._prior = q._prior
         else:
             raise ValueError(
-                "We could not find a suitable prior distribution within `potential_fn`"
+                "We could not find a suitable prior distribution within `potential_fn` "
                 "or `q` (if a VIPosterior is given). Please explicitly specify a prior."
             )
         move_all_tensor_to_device(self._prior, device)
@@ -461,9 +461,12 @@ class VIPosterior(NeuralPosterior):
                 self.evaluate(quality_control_metric=quality_control_metric)
             except Exception as e:
                 print(
-                    f"Quality control did not work, we reset the variational \
-                        posterior,please check your setting. \
-                        \n Following error occured {e}"
+                    f"Quality control showed a low quality of the variational "
+                    f"posterior. We are automatically retraining the variational "
+                    f"posterior from scratch with a smaller learning rate. "
+                    f"Alternatively, if you want to skip quality control, please "
+                    f"retrain with `VIPosterior.train(..., quality_control=False)`. "
+                    f"\nThe error that occured is: {e}"
                 )
                 self.train(
                     learning_rate=learning_rate * 0.1,

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -11,6 +11,7 @@ from torch.distributions import Distribution
 from tqdm.auto import tqdm
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.vi import (
     adapt_variational_distribution,
     check_variational_distribution,
@@ -47,7 +48,7 @@ class VIPosterior(NeuralPosterior):
 
     def __init__(
         self,
-        potential_fn: Callable,
+        potential_fn: Union[Callable, BasePotential],
         prior: Optional[TorchDistribution] = None,
         q: Union[str, PyroTransformedDistribution, "VIPosterior", Callable] = "maf",
         theta_transform: Optional[TorchTransform] = None,
@@ -59,7 +60,8 @@ class VIPosterior(NeuralPosterior):
     ):
         """
         Args:
-            potential_fn: The potential function from which to draw samples.
+            potential_fn: The potential function from which to draw samples. Must be a
+                `BasePotential` or a `Callable` which takes `theta` and `x_o` as inputs.
             prior: This is the prior distribution. Note that this is only
                 used to check/construct the variational distribution or within some
                 quality metrics. Please make sure that this matches with the prior

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -9,7 +9,7 @@ from sbi.utils.user_input_checks import process_x
 
 class BasePotential(metaclass=ABCMeta):
     def __init__(
-        self, prior: Distribution, x_o: Optional[Tensor] = None, device: str = "cpu"
+        self, prior: Optional[Distribution], x_o: Optional[Tensor] = None, device: str = "cpu"
     ):
         """Initialize potential function.
 

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -9,7 +9,10 @@ from sbi.utils.user_input_checks import process_x
 
 class BasePotential(metaclass=ABCMeta):
     def __init__(
-        self, prior: Optional[Distribution], x_o: Optional[Tensor] = None, device: str = "cpu"
+        self,
+        prior: Optional[Distribution],
+        x_o: Optional[Tensor] = None,
+        device: str = "cpu",
     ):
         """Initialize potential function.
 
@@ -61,3 +64,22 @@ class BasePotential(metaclass=ABCMeta):
         `self._x_o` is `None`.
         """
         return self._x_o
+
+
+class CallablePotentialWrapper(BasePotential):
+    """If `potential_fn` is a callable it gets wrapped as this."""
+
+    allow_iid_x = True  # type: ignore
+
+    def __init__(
+        self,
+        callable_potential,
+        prior: Optional[Distribution],
+        x_o: Optional[Tensor] = None,
+        device: str = "cpu",
+    ):
+        super().__init__(prior, x_o, device)
+        self.callable_potential = callable_potential
+
+    def __call__(self, theta, **kwargs):
+        return self.callable_potential(theta=theta, x_o=self.x_o, **kwargs)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Optional
 
+import torch
 from torch import Tensor
 from torch.distributions import Distribution
 
@@ -81,5 +82,6 @@ class CallablePotentialWrapper(BasePotential):
         super().__init__(prior, x_o, device)
         self.callable_potential = callable_potential
 
-    def __call__(self, theta, **kwargs):
-        return self.callable_potential(theta=theta, x_o=self.x_o, **kwargs)
+    def __call__(self, theta, track_gradients: bool = True):
+        with torch.set_grad_enabled(track_gradients):
+            return self.callable_potential(theta=theta, x_o=self.x_o)

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -96,7 +96,7 @@ class LikelihoodBasedPotential(BasePotential):
             track_gradients=track_gradients,
         )
 
-        return log_likelihood_trial_sum + self.prior.log_prob(theta)
+        return log_likelihood_trial_sum + self.prior.log_prob(theta)  # type: ignore
 
 
 def _log_likelihoods_over_trials(
@@ -201,4 +201,4 @@ class MixedLikelihoodBasedPotential(LikelihoodBasedPotential):
                 self.x_o.shape[0], -1
             ).sum(0)
 
-        return log_likelihood_trial_sum + self.prior.log_prob(theta)
+        return log_likelihood_trial_sum + self.prior.log_prob(theta)  # type: ignore

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -92,7 +92,7 @@ class RatioBasedPotential(BasePotential):
         )
 
         # Move to cpu for comparison with prior.
-        return log_likelihood_trial_sum + self.prior.log_prob(theta)
+        return log_likelihood_trial_sum + self.prior.log_prob(theta)  # type: ignore
 
 
 def _log_ratios_over_trials(

--- a/tests/potential_test.py
+++ b/tests/potential_test.py
@@ -1,0 +1,60 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import eye, ones, zeros
+from torch.distributions import MultivariateNormal
+
+from sbi.inference import (
+    ImportanceSamplingPosterior,
+    MCMCPosterior,
+    RejectionPosterior,
+    VIPosterior,
+)
+
+
+@pytest.mark.parametrize(
+    "sampling_method",
+    [ImportanceSamplingPosterior, MCMCPosterior, RejectionPosterior, VIPosterior],
+)
+def test_callable_potential(sampling_method):
+    dim = 2
+    mean = 2.5
+    cov = 2.0
+    x_o = 1 * ones((dim,))
+    target_density = MultivariateNormal(mean * ones((dim,)), cov * eye(dim))
+
+    def potential(theta, x_o, **kwargs):
+        return target_density.log_prob(theta + x_o)
+
+    proposal = MultivariateNormal(zeros((dim,)), 5 * eye(dim))
+
+    if sampling_method == ImportanceSamplingPosterior:
+        approx_density = sampling_method(
+            potential_fn=potential, proposal=proposal, method="sir"
+        )
+        approx_samples = approx_density.sample((1024,), oversampling_factor=1024, x=x_o)
+    elif sampling_method == MCMCPosterior:
+        approx_density = sampling_method(potential_fn=potential, proposal=proposal)
+        approx_samples = approx_density.sample(
+            (1024,), x=x_o, num_chains=100, method="slice_np_vectorized"
+        )
+    elif sampling_method == VIPosterior:
+        approx_density = sampling_method(
+            potential_fn=potential, prior=proposal
+        ).set_default_x(x_o)
+        approx_density = approx_density.train()
+        approx_samples = approx_density.sample((1024,))
+    elif sampling_method == RejectionPosterior:
+        approx_density = sampling_method(
+            potential_fn=potential, proposal=proposal
+        ).set_default_x(x_o)
+        approx_samples = approx_density.sample((1024,))
+
+    sample_mean = torch.mean(approx_samples, dim=0)
+    sample_std = torch.std(approx_samples, dim=0)
+    assert torch.allclose(sample_mean, torch.as_tensor(mean) - x_o, atol=0.2)
+    assert torch.allclose(sample_std, torch.sqrt(torch.as_tensor(cov)), atol=0.1)

--- a/tests/potential_test.py
+++ b/tests/potential_test.py
@@ -21,6 +21,7 @@ from sbi.inference import (
     [ImportanceSamplingPosterior, MCMCPosterior, RejectionPosterior, VIPosterior],
 )
 def test_callable_potential(sampling_method):
+    """Test whether callable potentials can be used to sample from a Gaussian."""
     dim = 2
     mean = 2.5
     cov = 2.0

--- a/tests/potential_test.py
+++ b/tests/potential_test.py
@@ -28,7 +28,7 @@ def test_callable_potential(sampling_method):
     x_o = 1 * ones((dim,))
     target_density = MultivariateNormal(mean * ones((dim,)), cov * eye(dim))
 
-    def potential(theta, x_o, **kwargs):
+    def potential(theta, x_o):
         return target_density.log_prob(theta + x_o)
 
     proposal = MultivariateNormal(zeros((dim,)), 5 * eye(dim))


### PR DESCRIPTION
We now only require that the `potential_fn` takes `theta` and `x_o` as inputs.
```python
def potential(theta, x_o):
    return sim.log_prob(theta, x_o) + prior.log_prob(theta)


posterior = MCMCPosterior(
    potential_fn=potential,
    proposal=posterior.set_default_x(x_o),
)
samples = posterior.sample((100,), x=x_o)
```

The newly added tests take `2.14 seconds` in total.

Closes #765 