### PR TITLE
947 vi coupling flows fail for num dim=3

### DIFF
--- a/sbi/samplers/vi/vi_pyro_flows.py
+++ b/sbi/samplers/vi/vi_pyro_flows.py
@@ -202,7 +202,8 @@ def init_affine_coupling(dim: int, device: str = "cpu", **kwargs):
     nonlinearity = kwargs.pop("nonlinearity", nn.ReLU())
     split_dim = kwargs.get("split_dim", dim // 2)
     hidden_dims = kwargs.pop("hidden_dims", [5 * dim + 20, 5 * dim + 20])
-    arn = DenseNN(split_dim, hidden_dims, nonlinearity=nonlinearity).to(device)
+    params_dims = (dim - split_dim, dim - split_dim)
+    arn = DenseNN(split_dim, hidden_dims,params_dims, nonlinearity=nonlinearity).to(device)
     return [split_dim, arn], {"log_scale_min_clip": -3.0}
 
 

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -19,6 +19,11 @@ from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_pr
 from sbi.utils import MultipleIndependent
 from tests.test_utils import check_c2st
 
+from sbi.samplers.vi.vi_pyro_flows import get_flow_builder, get_default_flows
+
+# Tests should be run for all default flows
+FLOWS = get_default_flows()
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
@@ -75,7 +80,7 @@ def test_c2st_vi_on_Gaussian(num_dim: int, vi_method: str, sampling_method: str)
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
-@pytest.mark.parametrize("q", ("maf", "nsf", "gaussian_diag", "gaussian", "mcf", "scf"))
+@pytest.mark.parametrize("q", FLOWS)
 def test_c2st_vi_flows_on_Gaussian(num_dim: int, q: str):
     """Test VI on Gaussian, comparing to ground truth target via c2st.
 
@@ -180,7 +185,7 @@ def test_c2st_vi_external_distributions_on_Gaussian(num_dim: int):
     check_c2st(samples, target_samples, alg="slice_np")
 
 
-@pytest.mark.parametrize("q", ("maf", "nsf", "gaussian_diag", "gaussian", "mcf", "scf"))
+@pytest.mark.parametrize("q", FLOWS)
 def test_deepcopy_support(q: str):
     """Tests if the variational does support deepcopy.
 
@@ -336,3 +341,28 @@ def test_vi_with_multiple_independent_prior():
         sample_shape=(10,),
         show_progress_bars=False,
     )
+
+
+@pytest.mark.parametrize("num_dim", (1, 2,3,4,5,10,25,33))
+@pytest.mark.parametrize("q", FLOWS)
+def test_vi_flow_builders(num_dim:int, q:str):
+    """ Test if the flow builder build the flows correctly, such that at least sampling and log_prob works."""
+    
+    try:
+        q = get_flow_builder(q)((num_dim,), torch.distributions.transforms.identity_transform)
+    except AssertionError:
+        # If the flow is not defined for the dimensionality, we pass the test
+        return
+    
+    # Without sample_shape
+    
+    sample = q.sample()
+    assert sample.shape == (num_dim,), "The sample shape is not as expected"
+    log_prob = q.log_prob(sample)
+    assert log_prob.shape == (), "The log_prob shape is not as expected"
+    
+    # With sample_shape
+    sample_batch = q.sample((10,))
+    assert sample_batch.shape == (10, num_dim), "The sample shape is not as expected"
+    log_prob_batch = q.log_prob(sample_batch)
+    assert log_prob_batch.shape == (10,), "The log_prob shape is not as expected"


### PR DESCRIPTION
Fixing issues with MCFs.
Adding cheap tests for minimal requirements of vi-flow-builder with a larger set of configurations.
Automatically include any new default flow builder into vi-tests.
