### PR TITLE
Fix 921 SNLE SNRE code duplication

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -193,7 +193,7 @@ class NeuralInference(ABC):
         x: Tensor,
         exclude_invalid_x: bool = False,
         from_round: int = 0,
-        algorithm: str = "SNLE or SNRE",
+        algorithm: Optional[str] = None,
         data_device: Optional[str] = None,
     ) -> "NeuralInference":
         r"""Store parameters and simulation outputs to use them for later training.
@@ -215,6 +215,8 @@ class NeuralInference(ABC):
                 With default settings, this is not used at all for the inference algorithm. Only when
                 the user later on requests `.train(discard_prior_samples=True)`, we
                 use these indices to find which training data stemmed from the prior.
+            algorithm: Which algorithm is used. This is used to give a more informative
+                warning or error message when invalid simulations are found.
             data_device: Where to store the data, default is on the same device where
                 the training is happening. If training a large dataset on a GPU with not
                 much VRAM can set to 'cpu' to store data on system memory instead.
@@ -229,7 +231,9 @@ class NeuralInference(ABC):
 
         # Check for problematic z-scoring
         warn_if_zscoring_changes_data(x)
-        nle_nre_apt_msg_on_invalid_x(num_nans, num_infs, exclude_invalid_x, algorithm)
+        nle_nre_apt_msg_on_invalid_x(
+            num_nans, num_infs, exclude_invalid_x, algorithm or type(self).__name__
+        )
 
         if data_device is None:
             data_device = self._device

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -187,6 +187,7 @@ class NeuralInference(ABC):
 
         return theta, x, prior_masks
 
+    @abstractmethod
     def append_simulations(
         self,
         theta: Tensor,

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -18,11 +18,7 @@ from sbi import utils as utils
 from sbi.inference import NeuralInference
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
-from sbi.utils import (
-    check_estimator_arg,
-    check_prior,
-    x_shape_from_simulation,
-)
+from sbi.utils import check_estimator_arg, check_prior, x_shape_from_simulation
 
 
 class LikelihoodEstimator(NeuralInference, ABC):

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -21,11 +21,6 @@ from sbi.inference.potentials import likelihood_estimator_based_potential
 from sbi.utils import (
     check_estimator_arg,
     check_prior,
-    handle_invalid_x,
-    mask_sims_from_prior,
-    nle_nre_apt_msg_on_invalid_x,
-    validate_theta_and_x,
-    warn_if_zscoring_changes_data,
     x_shape_from_simulation,
 )
 
@@ -112,30 +107,14 @@ class LikelihoodEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)
-
-        x = x[is_valid_x]
-        theta = theta[is_valid_x]
-
-        # Check for problematic z-scoring
-        warn_if_zscoring_changes_data(x)
-        nle_nre_apt_msg_on_invalid_x(num_nans, num_infs, exclude_invalid_x, "SNLE")
-
-        if data_device is None:
-            data_device = self._device
-        theta, x = validate_theta_and_x(
-            theta, x, data_device=data_device, training_device=self._device
+        return super().append_simulations(
+            theta=theta,
+            x=x,
+            exclude_invalid_x=exclude_invalid_x,
+            from_round=from_round,
+            algorithm="SNLE",
+            data_device=data_device,
         )
-
-        prior_masks = mask_sims_from_prior(int(from_round), theta.size(0))
-
-        self._theta_roundwise.append(theta)
-        self._x_roundwise.append(x)
-        self._prior_masks.append(prior_masks)
-
-        self._data_round_index.append(int(from_round))
-
-        return self
 
     def train(
         self,

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -11,7 +11,6 @@ from pyknos.nflows import flows
 from torch import Tensor, nn, optim
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
-from torch.utils import data
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi import utils as utils
@@ -75,6 +74,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         x: Tensor,
         exclude_invalid_x: bool = False,
         from_round: int = 0,
+        algorithm: str = "SNLE",
         data_device: Optional[str] = None,
     ) -> "LikelihoodEstimator":
         r"""Store parameters and simulation outputs to use them for later training.
@@ -103,12 +103,13 @@ class LikelihoodEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        return super().append_simulations(
+        # pyright false positive, will be fixed with pyright 1.1.310
+        return super().append_simulations(  # type: ignore
             theta=theta,
             x=x,
             exclude_invalid_x=exclude_invalid_x,
             from_round=from_round,
-            algorithm="SNLE",
+            algorithm=algorithm,
             data_device=data_device,
         )
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -83,6 +83,7 @@ class RatioEstimator(NeuralInference, ABC):
         x: Tensor,
         exclude_invalid_x: bool = False,
         from_round: int = 0,
+        algorithm: str = "SNRE",
         data_device: Optional[str] = None,
     ) -> "RatioEstimator":
         r"""Store parameters and simulation outputs to use them for later training.
@@ -111,12 +112,12 @@ class RatioEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        return super().append_simulations(
+        return super().append_simulations(  # type: ignore
             theta=theta,
             x=x,
             exclude_invalid_x=exclude_invalid_x,
             from_round=from_round,
-            algorithm="SNRE",
+            algorithm=algorithm,
             data_device=data_device,
         )
 


### PR DESCRIPTION
Fix for #921.

Moved `append_simulations` to `base.py`. There is some method specific arguments given to the `nle_nre_apt_msg_on_invalid_x` function, but purely for logging. 

So I added an algorithm argument in `base.py` and overwite it for the specific method in the `super()` call.

The `nle_nre_apt_msg_on_invalid_x` function makes `append_simulations` specific to SLNE, SNRE. So an alternative would be to have an intermediate object between `NeuralInference` and the estimators to make this clear?