### PR TITLE
nn module as base class for density estimator

### DIFF
--- a/sbi/neural_nets/density_estimators/__init__.py
+++ b/sbi/neural_nets/density_estimators/__init__.py
@@ -1,1 +1,2 @@
+from sbi.neural_nets.density_estimators.base import DensityEstimator
 from sbi.neural_nets.density_estimators.flow import NFlowsFlow

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -135,7 +135,7 @@ class DensityEstimator(nn.Module):
             raise ValueError(
                 f"Dimensionality of condition is to small and does not match the\
                 expected input dimensionality {len(self._condition_shape)}, as provided\
-                by x_shape."
+                by condition_shape."
             )
         else:
             condition_shape = condition.shape[-len(self._condition_shape) :]
@@ -143,5 +143,5 @@ class DensityEstimator(nn.Module):
                 raise ValueError(
                     f"Shape of condition {tuple(condition_shape)} does not match the \
                     expected input dimensionality {tuple(self._condition_shape)}, as \
-                    provided by x_shape. Please reshape it accordingly."
+                    provided by condition_shape. Please reshape it accordingly."
                 )

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -63,10 +63,12 @@ class DensityEstimator(nn.Module):
     def sample_and_log_prob(
         self, sample_shape: torch.Size, condition: Tensor, **kwargs
     ) -> Tuple[Tensor, Tensor]:
-        r"""Return samples from the density estimator.
+        r"""Return samples and their density from the density estimator.
 
-        Note: For some density estimators, computing log_probs for current samples is
-              more efficient than computing them separately (then override this).
+        Note:
+            For some density estimators, computing log_probs for samples is
+            more efficient than computing them separately. This method should
+            then be overwritten to provide a more efficient implementation.
 
         Args:
             sample_shape: Shape of the samples to return.

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -1,7 +1,7 @@
+from typing import Tuple
+
 import torch
 from torch import Tensor, nn
-
-from typing import Tuple
 
 
 class DensityEstimator(nn.Module):

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -8,14 +8,14 @@ class DensityEstimator(nn.Module):
     r"""Base class for density estimators.
 
     The density estimator class is a wrapper around neural networks that
-    allows to evaluate the `log_prob`, `sample`, and provide the `loss` of $theta,x$
-    pairs.
+    allows to evaluate the `log_prob`, `sample`, and provide the `loss` of $\theta,x$
+    pairs. Here $\theta$ would be the `input` and $x$ would be the `condition`.
 
     Note:
         We assume that the input to the density estimator is a tensor of shape
-        (batch_size, d), where d is the dimensionality of the input. The condition
-        is a tensor of shape (batch_size, *condition_shape), where condition_shape
-        is the shape of the condition tensor.
+        (batch_size, input_size), where input_size is the dimensionality of the input. 
+        The condition is a tensor of shape (batch_size, *condition_shape), where 
+        condition_shape is the shape of the condition tensor.
 
     """
 
@@ -39,16 +39,23 @@ class DensityEstimator(nn.Module):
             This function should support PyTorch's automatic broadcasting. This means
             the function should behave as follows for different input and condition
             shapes:
-            - (d,) + (b,*condition_shape) -> (b,)
-            - (b, d) + (*condition_shape) -> (b,)
-            - (b, d) + (b, *condition_shape) -> (b,)
-            - (b1, d) + (b2, *condition_shape) -> RuntimeError i.e. not broadcastable
-            - (b1,1, d) + (b2, *condition_shape) -> (b1,b2)
-            - (b1, d) + (b2,1, *condition_shape) -> (b2,b1)
+            - (input_size,) + (batch_size,*condition_shape) -> (batch_size,)
+            - (batch_size, input_size) + (*condition_shape) -> (batch_size,)
+            - (batch_size, input_size) + (batch_size, *condition_shape) -> (batch_size,)
+            - (batch_size1, input_size) + (batch_size2, *condition_shape)
+                                                  -> RuntimeError i.e. not broadcastable
+            - (batch_size1,1, input_size) + (batch_size2, *condition_shape) 
+                                                  -> (batch_size1,batch_size2)
+            - (batch_size1, input_size) + (batch_size2,1, *condition_shape) 
+                                                  -> (batch_size2,batch_size1)
 
         Args:
-            input: Inputs to evaluate the log probability on.
-            condition: Conditions.
+            input: Inputs to evaluate the log probability on of shape 
+                    (*batch_shape1, input_size).
+            condition: Conditions of shape (*batch_shape2, *condition_shape). 
+                       
+        Raises:
+            RuntimeError: If batch_shape1 and batch_shape2 are not broadcastable.
 
         Returns:
             Sample-wise log probabilities.
@@ -64,7 +71,7 @@ class DensityEstimator(nn.Module):
             condition: Conditions of shape (batch_size, *condition_shape).
 
         Returns:
-            Loss.
+            Loss of shape (batch_size,)
         """
 
         raise NotImplementedError
@@ -76,14 +83,15 @@ class DensityEstimator(nn.Module):
             This function should support batched conditions and should admit the
             following behavior for different condition shapes:
             - (*condition_shape) -> (*sample_shape,d)
-            - (*batch_shapes, *condition_shape) -> (*batch_shapes, *sample_shape, d)
+            - (*batch_shapes, *condition_shape) 
+                                        -> (*batch_shapes, *sample_shape, input_size)
 
         Args:
             sample_shape: Shape of the samples to return.
-            condition: Conditions.
+            condition: Conditions of shape (*batch_shape, *condition_shape).
 
         Returns:
-            Samples.
+            Samples of shape (*batch_shape, *sample_shape, input_size).
         """
 
         raise NotImplementedError
@@ -100,7 +108,8 @@ class DensityEstimator(nn.Module):
 
         Args:
             sample_shape: Shape of the samples to return.
-            condition: Conditions.
+            condition: Conditions of shape (*batch_shape, *condition_shape).
+            
         Returns:
             Samples and associated log probabilities.
         """
@@ -113,7 +122,7 @@ class DensityEstimator(nn.Module):
         r"""This method checks whether the condition has the correct shape.
 
         Args:
-            condition: Conditions.
+            condition: Conditions of shape (*batch_shape, *condition_shape).
 
         Raises:
             ValueError: If the condition has a dimensionality that does not match

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -10,25 +10,45 @@ class DensityEstimator(nn.Module):
     The density estimator class is a wrapper around neural networks that
     allows to evaluate the `log_prob`, `sample`, and provide the `loss` of $theta,x$
     pairs.
+
+    Note:
+        We assume that the input to the density estimator is a tensor of shape
+        (batch_size, d), where d is the dimensionality of the input. The condition
+        is a tensor of shape (batch_size, *condition_shape), where condition_shape
+        is the shape of the condition tensor.
+
     """
 
-    def __init__(self, net: nn.Module, x_shape: torch.Size) -> None:
+    def __init__(self, net: nn.Module, condition_shape: torch.Size) -> None:
         r"""Base class for density estimators.
 
         Args:
             net: Neural network.
-            x_shape: Shape of the input. If not provided, it will assume a 1D input.
+            condition_shape: Shape of the input. If not provided, it will assume a 1D
+                             input.
         """
         super().__init__()
         self.net = net
-        self._x_shape = x_shape
+        self._condition_shape = condition_shape
 
     def log_prob(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
-        r"""Return the batched log probabilities of the inputs given the conditions.
+        r"""Return the log probabilities of the inputs given a condition or multiple
+        i.e. batched conditions.
+
+        Note:
+            This function should support PyTorch's automatic broadcasting. This means
+            the function should behave as follows for different input and condition
+            shapes:
+            - (d,) + (b,*condition_shape) -> (b,)
+            - (b, d) + (*condition_shape) -> (b,)
+            - (b, d) + (b, *condition_shape) -> (b,)
+            - (b1, d) + (b2, *condition_shape) -> RuntimeError i.e. not broadcastable
+            - (b1,1, d) + (b2, *condition_shape) -> (b1,b2)
+            - (b1, d) + (b2,1, *condition_shape) -> (b2,b1)
 
         Args:
-            input: Inputs to evaluate the log probability of. Must have batch dimension.
-            x: Conditions. Must have batch dimension.
+            input: Inputs to evaluate the log probability on.
+            condition: Conditions.
 
         Returns:
             Sample-wise log probabilities.
@@ -40,8 +60,8 @@ class DensityEstimator(nn.Module):
         r"""Return the loss for training the density estimator.
 
         Args:
-            input: Inputs to evaluate the loss on.
-            condition: Conditions.
+            input: Inputs to evaluate the loss on of shape (batch_size, d).
+            condition: Conditions of shape (batch_size, *condition_shape).
 
         Returns:
             Loss.
@@ -51,6 +71,12 @@ class DensityEstimator(nn.Module):
 
     def sample(self, sample_shape: torch.Size, condition: Tensor, **kwargs) -> Tensor:
         r"""Return samples from the density estimator.
+
+        Note:
+            This function should support batched conditions and should admit the
+            following behavior for different condition shapes:
+            - (*condition_shape) -> (*sample_shape,d)
+            - (*batch_shapes, *condition_shape) -> (*batch_shapes, *sample_shape, d)
 
         Args:
             sample_shape: Shape of the samples to return.
@@ -83,23 +109,29 @@ class DensityEstimator(nn.Module):
         log_prob = self.log_prob(x, condition, **kwargs)
         return x, log_prob
 
-    def _check_for_invalid_condition_shape(self, condition: Tensor):
+    def _check_condition_shape(self, condition: Tensor):
         r"""This method checks whether the condition has the correct shape.
 
         Args:
-            condition (Tensor): Given condition.
+            condition: Conditions.
 
         Raises:
-            ValueError: If the condition has a dimensionality that does not match the expected input dimensionality.
-            ValueError: If the shape of the condition does not match the expected input dimensionality.
+            ValueError: If the condition has a dimensionality that does not match
+                        the expected input dimensionality.
+            ValueError: If the shape of the condition does not match the expected
+                        input dimensionality.
         """
-        if len(condition.shape) < len(self._x_shape):
+        if len(condition.shape) < len(self._condition_shape):
             raise ValueError(
-                f"Dimensionality of condition is to small and does not match the expected input dimensionality {len(self._x_shape)}, as provided by x_shape."
+                f"Dimensionality of condition is to small and does not match the\
+                expected input dimensionality {len(self._condition_shape)}, as provided\
+                by x_shape."
             )
         else:
-            x_shape = condition.shape[-len(self._x_shape) :]
-            if tuple(x_shape) != tuple(self._x_shape):
+            condition_shape = condition.shape[-len(self._condition_shape) :]
+            if tuple(condition_shape) != tuple(self._condition_shape):
                 raise ValueError(
-                    f"Shape of condition {tuple(x_shape)} does not match the expected input dimensionality {tuple(self._x_shape)}, as provided by x_shape. Please reshape it accordingly."
+                    f"Shape of condition {tuple(condition_shape)} does not match the \
+                    expected input dimensionality {tuple(self._condition_shape)}, as \
+                    provided by x_shape. Please reshape it accordingly."
                 )

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -13,8 +13,8 @@ class DensityEstimator(nn.Module):
 
     Note:
         We assume that the input to the density estimator is a tensor of shape
-        (batch_size, input_size), where input_size is the dimensionality of the input. 
-        The condition is a tensor of shape (batch_size, *condition_shape), where 
+        (batch_size, input_size), where input_size is the dimensionality of the input.
+        The condition is a tensor of shape (batch_size, *condition_shape), where
         condition_shape is the shape of the condition tensor.
 
     """
@@ -44,16 +44,16 @@ class DensityEstimator(nn.Module):
             - (batch_size, input_size) + (batch_size, *condition_shape) -> (batch_size,)
             - (batch_size1, input_size) + (batch_size2, *condition_shape)
                                                   -> RuntimeError i.e. not broadcastable
-            - (batch_size1,1, input_size) + (batch_size2, *condition_shape) 
+            - (batch_size1,1, input_size) + (batch_size2, *condition_shape)
                                                   -> (batch_size1,batch_size2)
-            - (batch_size1, input_size) + (batch_size2,1, *condition_shape) 
+            - (batch_size1, input_size) + (batch_size2,1, *condition_shape)
                                                   -> (batch_size2,batch_size1)
 
         Args:
-            input: Inputs to evaluate the log probability on of shape 
+            input: Inputs to evaluate the log probability on of shape
                     (*batch_shape1, input_size).
-            condition: Conditions of shape (*batch_shape2, *condition_shape). 
-                       
+            condition: Conditions of shape (*batch_shape2, *condition_shape).
+
         Raises:
             RuntimeError: If batch_shape1 and batch_shape2 are not broadcastable.
 
@@ -83,7 +83,7 @@ class DensityEstimator(nn.Module):
             This function should support batched conditions and should admit the
             following behavior for different condition shapes:
             - (*condition_shape) -> (*sample_shape,d)
-            - (*batch_shapes, *condition_shape) 
+            - (*batch_shapes, *condition_shape)
                                         -> (*batch_shapes, *sample_shape, input_size)
 
         Args:
@@ -109,7 +109,7 @@ class DensityEstimator(nn.Module):
         Args:
             sample_shape: Shape of the samples to return.
             condition: Conditions of shape (*batch_shape, *condition_shape).
-            
+
         Returns:
             Samples and associated log probabilities.
         """

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -1,6 +1,8 @@
 import torch
 from torch import Tensor, nn
 
+from typing import Tuple
+
 
 class DensityEstimator(nn.Module):
     r"""Base class for density estimators.
@@ -60,7 +62,7 @@ class DensityEstimator(nn.Module):
 
     def sample_and_log_prob(
         self, sample_shape: torch.Size, condition: Tensor, **kwargs
-    ) -> Tensor:
+    ) -> Tuple[Tensor, Tensor]:
         r"""Return samples from the density estimator.
 
         Note: For some density estimators, computing log_probs for current samples is

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor, nn
 
 
-class DensityEstimator:
+class DensityEstimator(nn.Module):
     r"""Base class for density estimators.
 
     The density estimator class is a wrapper around neural networks that
@@ -16,7 +16,7 @@ class DensityEstimator:
         Args:
             net: Neural network.
         """
-
+        super().__init__()
         self.net = net
 
     def log_prob(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
@@ -50,9 +50,29 @@ class DensityEstimator:
 
         Args:
             sample_shape: Shape of the samples to return.
+            condition: Conditions.
 
         Returns:
             Samples.
         """
 
         raise NotImplementedError
+
+    def sample_and_log_prob(
+        self, sample_shape: torch.Size, condition: Tensor, **kwargs
+    ) -> Tensor:
+        r"""Return samples from the density estimator.
+
+        Note: For some density estimators, computing log_probs for current samples is
+              more efficient than computing them separately (then override this).
+
+        Args:
+            sample_shape: Shape of the samples to return.
+            condition: Conditions.
+        Returns:
+            Samples and associated log probabilities.
+        """
+
+        x = self.sample(sample_shape, condition, **kwargs)
+        log_prob = self.log_prob(x, condition, **kwargs)
+        return x, log_prob

--- a/sbi/neural_nets/density_estimators/flow.py
+++ b/sbi/neural_nets/density_estimators/flow.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+
 import torch
 from pyknos.nflows import flows
 from torch import Tensor
@@ -62,14 +63,16 @@ class NFlowsFlow(DensityEstimator):
         return self.net.sample(num_samples, context=condition).reshape(
             (*sample_shape, -1)
         )
-        
-    def sample_and_log_prob(self, sample_shape: torch.Size, condition: Tensor, **kwargs) -> Tuple:
-        
+
+    def sample_and_log_prob(
+        self, sample_shape: torch.Size, condition: Tensor, **kwargs
+    ) -> Tuple:
+
         sample = self.sample(sample_shape, condition, **kwargs)
         if condition.shape[0] != sample_shape[0]:
             # If the condition is not batched, repeat it to match the sample_shape.
             # This is necessary because nflows.log_prob() expects conditions to be batched.
             condition = condition.repeat(sample_shape[0], 1)
         log_prob = self.log_prob(sample, condition, **kwargs)
-        
+
         return sample, log_prob

--- a/sbi/neural_nets/density_estimators/flow.py
+++ b/sbi/neural_nets/density_estimators/flow.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import torch
 from pyknos.nflows import flows
 from torch import Tensor
@@ -61,3 +62,14 @@ class NFlowsFlow(DensityEstimator):
         return self.net.sample(num_samples, context=condition).reshape(
             (*sample_shape, -1)
         )
+        
+    def sample_and_log_prob(self, sample_shape: torch.Size, condition: Tensor, **kwargs) -> Tuple:
+        
+        sample = self.sample(sample_shape, condition, **kwargs)
+        if condition.shape[0] != sample_shape[0]:
+            # If the condition is not batched, repeat it to match the sample_shape.
+            # This is necessary because nflows.log_prob() expects conditions to be batched.
+            condition = condition.repeat(sample_shape[0], 1)
+        log_prob = self.log_prob(sample, condition, **kwargs)
+        
+        return sample, log_prob

--- a/sbi/neural_nets/density_estimators/flow.py
+++ b/sbi/neural_nets/density_estimators/flow.py
@@ -28,16 +28,16 @@ class NFlowsFlow(DensityEstimator):
             - (batch_size, input_size) + (batch_size, *condition_shape) -> (batch_size,)
             - (batch_size1, input_size) + (batch_size2, *condition_shape)
                                                   -> RuntimeError i.e. not broadcastable
-            - (batch_size1,1, input_size) + (batch_size2, *condition_shape) 
+            - (batch_size1,1, input_size) + (batch_size2, *condition_shape)
                                                   -> (batch_size1,batch_size2)
-            - (batch_size1, input_size) + (batch_size2,1, *condition_shape) 
+            - (batch_size1, input_size) + (batch_size2,1, *condition_shape)
                                                   -> (batch_size2,batch_size1)
 
         Args:
-            input: Inputs to evaluate the log probability on of shape 
+            input: Inputs to evaluate the log probability on of shape
                     (*batch_shape1, input_size).
-            condition: Conditions of shape (*batch_shape2, *condition_shape). 
-                       
+            condition: Conditions of shape (*batch_shape2, *condition_shape).
+
         Raises:
             RuntimeError: If batch_shape1 and batch_shape2 are not broadcastable.
 
@@ -82,7 +82,7 @@ class NFlowsFlow(DensityEstimator):
             This function should support batched conditions and should admit the
             following behavior for different condition shapes:
             - (*condition_shape) -> (*sample_shape,d)
-            - (*batch_shapes, *condition_shape) 
+            - (*batch_shapes, *condition_shape)
                                         -> (*batch_shapes, *sample_shape, input_size)
 
         Args:
@@ -126,7 +126,7 @@ class NFlowsFlow(DensityEstimator):
         Args:
             sample_shape: Shape of the samples to return.
             condition: Conditions of shape (*batch_shape, *condition_shape).
-            
+
         Returns:
             Samples and associated log probabilities.
         """

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -53,3 +53,7 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         nsamples_test,
         input_dim,
     ), "samples shape is not correct"
+    
+    samples, log_probs = estimator.sample_and_log_prob((nsamples_test,), batch_context[0])
+    assert samples.shape == (nsamples_test, input_dim), "samples shape is not correct"
+    assert log_probs.shape == (nsamples_test,), "log_prob shape is not correct"

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -38,34 +38,77 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
     net = build_nsf(batch_input, batch_context, hidden_features=10, num_transforms=2)
     estimator = density_estimator(net)
 
-    log_probs = estimator.log_prob(batch_input, batch_context)
-    assert log_probs.shape == (nsamples,), "log_prob shape is not correct"
-
+    # Loss is only required to work for batched inputs and contexts
     loss = estimator.loss(batch_input, batch_context)
-    assert loss.shape == (nsamples,), "loss shape is not correct"
+    assert loss.shape == (
+        nsamples,
+    ), f"Loss shape is not correct. It is of shape {loss.shape}, but should be {(nsamples, )}"
 
+    # Same for log_prob
+    log_probs = estimator.log_prob(batch_input, batch_context)
+    assert log_probs.shape == (
+        nsamples,
+    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should be {(nsamples, )}"
+
+    # Sample and log_prob should work for batched and unbatched contexts
+
+    # Unbatched context
     samples = estimator.sample((nsamples_test,), batch_context[0])
-    assert samples.shape == (nsamples_test, input_dim), "samples shape is not correct"
+    assert samples.shape == (
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(nsamples_test, input_dim)}"
+
+    samples = estimator.sample((1, nsamples_test), batch_context[0])
+    assert samples.shape == (
+        1,
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(1, nsamples_test, input_dim)}"
 
     samples = estimator.sample((2, nsamples_test), batch_context[0])
     assert samples.shape == (
         2,
         nsamples_test,
         input_dim,
-    ), "samples shape is not correct"
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(batch_context.shape[0], nsamples_test, input_dim)}"
 
+    # Batched context
     samples = estimator.sample((nsamples_test,), batch_context)
     assert samples.shape == (
         batch_context.shape[0],
         nsamples_test,
         input_dim,
-    ), "samples shape is not correct with batched context"
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(batch_context.shape[0], nsamples_test, input_dim)}"
 
+    samples = estimator.sample((nsamples_test,), batch_context[0].unsqueeze(0))
+    assert samples.shape == (
+        1,
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(batch_context.shape[0], nsamples_test, input_dim)}"
+
+    # Both batched
+    samples = estimator.sample((2, nsamples_test), batch_context.unsqueeze(0))
+    assert samples.shape == (
+        1,
+        batch_context.shape[0],
+        2,
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(1,batch_context.shape[0],2,nsamples_test,input_dim)}"
+
+    # Sample and log_prob work for batched and unbatched contexts
     samples, log_probs = estimator.sample_and_log_prob(
         (nsamples_test,), batch_context[0]
     )
-    assert samples.shape == (nsamples_test, input_dim), "samples shape is not correct"
-    assert log_probs.shape == (nsamples_test,), "log_prob shape is not correct"
+    assert samples.shape == (
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(nsamples_test, input_dim)}"
+    assert log_probs.shape == (
+        nsamples_test,
+    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should be {(nsamples_test, )}"
 
     samples, log_probs = estimator.sample_and_log_prob((nsamples_test,), batch_context)
 
@@ -73,8 +116,29 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         batch_context.shape[0],
         nsamples_test,
         input_dim,
-    ), "samples shape is not correct with batched context"
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(batch_context.shape[0], nsamples_test, input_dim)}"
     assert log_probs.shape == (
         batch_context.shape[0],
         nsamples_test,
-    ), "log_prob shape is not correct with batched context"
+    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should be {(batch_context.shape[0], nsamples_test)}"
+
+    samples, log_probs = estimator.sample_and_log_prob(
+        (
+            2,
+            nsamples_test,
+        ),
+        batch_context.unsqueeze(0),
+    )
+    assert samples.shape == (
+        1,
+        batch_context.shape[0],
+        2,
+        nsamples_test,
+        input_dim,
+    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be {(1,batch_context.shape[0],2,nsamples_test,input_dim)}"
+    assert log_probs.shape == (
+        1,
+        batch_context.shape[0],
+        2,
+        nsamples_test,
+    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should be {(1,batch_context.shape[0],2,nsamples_test)}"

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -53,7 +53,9 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         nsamples_test,
         input_dim,
     ), "samples shape is not correct"
-    
-    samples, log_probs = estimator.sample_and_log_prob((nsamples_test,), batch_context[0])
+
+    samples, log_probs = estimator.sample_and_log_prob(
+        (nsamples_test,), batch_context[0]
+    )
     assert samples.shape == (nsamples_test, input_dim), "samples shape is not correct"
     assert log_probs.shape == (nsamples_test,), "log_prob shape is not correct"

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -53,3 +53,5 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         nsamples_test,
         input_dim,
     ), "samples shape is not correct"
+    
+    

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -54,8 +54,27 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         input_dim,
     ), "samples shape is not correct"
 
+    samples = estimator.sample((nsamples_test,), batch_context)
+    assert samples.shape == (
+        batch_context.shape[0],
+        nsamples_test,
+        input_dim,
+    ), "samples shape is not correct with batched context"
+
     samples, log_probs = estimator.sample_and_log_prob(
         (nsamples_test,), batch_context[0]
     )
     assert samples.shape == (nsamples_test, input_dim), "samples shape is not correct"
     assert log_probs.shape == (nsamples_test,), "log_prob shape is not correct"
+
+    samples, log_probs = estimator.sample_and_log_prob((nsamples_test,), batch_context)
+
+    assert samples.shape == (
+        batch_context.shape[0],
+        nsamples_test,
+        input_dim,
+    ), "samples shape is not correct with batched context"
+    assert log_probs.shape == (
+        batch_context.shape[0],
+        nsamples_test,
+    ), "log_prob shape is not correct with batched context"

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -53,5 +53,3 @@ def test_api_density_estimator(density_estimator, input_dim, context_dim):
         nsamples_test,
         input_dim,
     ), "samples shape is not correct"
-    
-    


### PR DESCRIPTION
Density Estimators inherit nn.Module.
Also added sample_and_log_prob, with a naive implementation that can be easily overriden (following Zuko API).

Limitations:
- `net` must be a nn.Module (which is fine and consistent with the type hints).