### PR TITLE
Deprecate simple interface (#277)

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,7 +1,30 @@
 import pytest
 import torch
 
-from sbi.inference import SNPE
+from sbi import utils
+from sbi.inference import SNPE, infer
+
+
+def test_infer():
+    # Example is taken from 00_getting_started.ipynb
+    num_dim = 3
+    prior = utils.BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+
+    def simulator(parameter_set):
+        return 1.0 + parameter_set + torch.randn(parameter_set.shape) * 0.1
+
+    posterior = infer(simulator, prior, method="SNPE_A", num_simulations=10)
+    assert posterior is not None, "Most basic use of 'infer' failed"
+    posterior = infer(
+        simulator,
+        prior,
+        method="SNPE_A",
+        num_simulations=10,
+        init_kwargs={'num_components': 5},
+    )
+    assert (
+        posterior is not None
+    ), "Using 'infer' and passing keyword arguments to `__init__` failed"
 
 
 @pytest.mark.parametrize("training_batch_size", (1, 10, 100))

--- a/tutorials/00_getting_started.ipynb
+++ b/tutorials/00_getting_started.ipynb
@@ -97,7 +97,8 @@
    ],
    "source": [
     "# Other methods are \"SNLE\" or \"SNRE\".\n",
-    "posterior = infer(simulator, prior, method=\"SNPE\", num_simulations=1000)"
+    "posterior = infer(simulator, prior, method=\"SNPE\", num_simulations=1000)\n",
+    "# Using `init_kwargs` and `call_kwargs`, you can also pass additional keyword arguments to `__init__` and `build_posterior` of the inference method. But we recommend to use the flexible interface which is introduced in a later tutorial."
    ]
   },
   {


### PR DESCRIPTION
Adds `init_kwargs` and `call_kwargs` to pass additional keyword arguments but also discourages people from using it. 
- Do we want to add the same note to `minimal.py` as we now have in `getting_started`? 
- `09_sensitivity_analysis.ipynb` uses the simple interface currently. Should we open an additional issue for changing that?

Fixes #277
Test runs in ~900ms. We could half it by only doing the first `assert`.

## Checklist

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
