### PR TITLE
Add kwargs to SNPE_A.build_posterior to match base class API

### DIFF
--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -275,7 +275,7 @@ class SNPE_A(PosteriorEstimator):
         self,
         density_estimator: Optional[TorchModule] = None,
         prior: Optional[Distribution] = None,
-        **kwargs
+        **kwargs,
     ) -> "DirectPosterior":
         r"""Build posterior from the neural density estimator.
 

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -275,6 +275,7 @@ class SNPE_A(PosteriorEstimator):
         self,
         density_estimator: Optional[TorchModule] = None,
         prior: Optional[Distribution] = None,
+        **kwargs
     ) -> "DirectPosterior":
         r"""Build posterior from the neural density estimator.
 
@@ -300,9 +301,10 @@ class SNPE_A(PosteriorEstimator):
         wrapped_density_estimator = self.correct_for_proposal(
             density_estimator=density_estimator
         )
-        self._posterior = DirectPosterior(
+        self._posterior = super.build_posterior(
             posterior_estimator=wrapped_density_estimator,  # type: ignore
             prior=prior,
+            **kwargs,
         )
         return deepcopy(self._posterior)
 

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -302,11 +302,11 @@ class SNPE_A(PosteriorEstimator):
             density_estimator=density_estimator
         )
         self._posterior = super().build_posterior(
-            density_estimator=wrapped_density_estimator,  # type: ignore
+            density_estimator=wrapped_density_estimator,
             prior=prior,
             **kwargs,
-        )
-        return deepcopy(self._posterior)
+        ) 
+        return deepcopy(self._posterior) # type: ignore
 
     def _log_prob_proposal_posterior(
         self,

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -305,7 +305,7 @@ class SNPE_A(PosteriorEstimator):
             density_estimator=wrapped_density_estimator,
             prior=prior,
             **kwargs,
-        ) 
+        )
         return deepcopy(self._posterior) # type: ignore
 
     def _log_prob_proposal_posterior(

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -302,7 +302,7 @@ class SNPE_A(PosteriorEstimator):
             density_estimator=density_estimator
         )
         self._posterior = super().build_posterior(
-            posterior_estimator=wrapped_density_estimator,  # type: ignore
+            density_estimator=wrapped_density_estimator,  # type: ignore
             prior=prior,
             **kwargs,
         )

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -301,7 +301,7 @@ class SNPE_A(PosteriorEstimator):
         wrapped_density_estimator = self.correct_for_proposal(
             density_estimator=density_estimator
         )
-        self._posterior = super.build_posterior(
+        self._posterior = super().build_posterior(
             posterior_estimator=wrapped_density_estimator,  # type: ignore
             prior=prior,
             **kwargs,

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -306,7 +306,7 @@ class SNPE_A(PosteriorEstimator):
             prior=prior,
             **kwargs,
         )
-        return deepcopy(self._posterior) # type: ignore
+        return deepcopy(self._posterior)  # type: ignore
 
     def _log_prob_proposal_posterior(
         self,


### PR DESCRIPTION
Adds a `**kwargs` to `SNPE_A.build_posterior(...)` and then does 

```python
self._posterior = super.build_posterior(
            posterior_estimator=wrapped_density_estimator,  # type: ignore
            prior=prior,
            **kwargs,
        )
```

instead of building the posterior directly with `DirectPosterior(...)`. 

Fixes #988

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
