### PR TITLE
Set embedding nets to eval before single forward pass for batchnorm bug

### DIFF
--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -60,6 +60,7 @@ def build_made(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
@@ -143,6 +144,7 @@ def build_maf(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
@@ -251,6 +253,7 @@ def build_maf_rqs(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
@@ -354,6 +357,7 @@ def build_nsf(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
 
     # Define mask function to alternate between predicted x-dimensions.
@@ -467,6 +471,7 @@ def build_zuko_maf(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
     if x_numel == 1:
         warn(

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -48,6 +48,7 @@ def build_mdn(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     check_data_device(batch_x, batch_y)
     check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
+    embedding_net.eval()
     y_numel = embedding_net(batch_y[:1]).numel()
 
     transform = transforms.IdentityTransform()


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

As raised in #807, if you create an embedding net that contains a `BatchNorm[N]d` layer, the forward passes used to determine embedding net output size fail because the BatchNorm layer checks for batches with more than one datapoint. Manuel suggests either providing more than one datapoint to the forward pass or setting the embedding net to eval mode. Eval mode seems preferable as it also doesn't affect the running statistics potentially tracked by the module, so `embedding_net.eval()` was added where needed. Density estimators are explicitly set to training mode in respective inference methods so this change should not affect anything downstream.

## Does this close any currently open issues?

Fixes #807

## Any relevant code examples, logs, error output, etc?

None

## Any other comments?

None

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
