### PR TITLE
pin pre-commit to 3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "jupyter",
     "nbconvert",
     # Lint
-    "pre-commit",
+    "pre-commit == 3.5.0",
     "pyyaml",
     "pyright >=1.1.300,<1.1.306",
     "ruff",


### PR DESCRIPTION
Problem: when setting things up with python 3.9 or higher, it will install `pre-commit` v3.6.0 or higher, which causes a lot of formatting changes. We don't want those for now (the hackathon). 

Solution: pin pre-commit to 3.5.0. This will work with higher Python versions as well, (but not the other way around). 
