### PR TITLE
Cache dependencies in Github Action (#1027)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache dependency
+      id: cache-dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,9 +42,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        key: ${{ runner.os }}-pip
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
With this change, Github Action will look for a cached dependency installation based on the same `pyproject.toml`, load it from its cache and not need to install it again. This should make all CI tests run faster.

## Checklist
- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I rebased on `main` (or there are no conflicts with `main`)