### PR TITLE
Fix 1029 - SNPE without prior not working

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -569,8 +569,16 @@ def within_support(distribution: Any, samples: Tensor) -> Tensor:
         Tensor of bools indicating whether each sample was within the support.
     """
     # Try to check using the support property, use log prob method otherwise.
+    # Before torch v1.7.0, `support.check()` returned bools for every element.
+    # From v1.8.0 on, it directly considers all dimensions of a sample. E.g.,
+    # for a single sample in 3D, v1.7.0 would return [[True, True, True]] and
+    # v1.8.0 would return [True]. However, Pyro distributions would still
+    # return [[True, True, True]]. This is relevant for `ImproperEmpirical`
+    # distributions in SBI, which are used in SNPE.
     try:
         sample_check = distribution.support.check(samples)
+        if sample_check.shape == samples.shape:
+            sample_check = torch.all(sample_check, dim=-1)
         return sample_check
 
     # Falling back to log prob method of either the NeuralPosterior's net, or of a


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

SNPE was broken when a prior was not explicitly defined. This is caused by `within_prior` check which is called by `restriction_posterior`. When no prior is explicitly defined, SNPE uses an `ImproperEmpirical` prior, which inherits from Pyro distributions, which has a different `distribution.support.check` functionality. The change in this PR ensures that `within_prior` always returns the correct dimensionality, regardless of whether the distribution has a torch backend or Pyro backend.

## Does this close any currently open issues?

Fixes # 1029

## Any relevant code examples, logs, error output, etc?

...

## Any other comments?

...

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
