### PR TITLE
Shape conventions for all DensityEstimators

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -11,6 +11,10 @@ from sbi.inference.potentials.posterior_based_potential import (
     posterior_estimator_based_potential,
 )
 from sbi.neural_nets.density_estimators.base import DensityEstimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.samplers.rejection.rejection import accept_reject_sample
 from sbi.sbi_types import Shape
 from sbi.utils import check_prior, within_support
@@ -101,17 +105,13 @@ class DirectPosterior(NeuralPosterior):
         """
 
         num_samples = torch.Size(sample_shape).numel()
-        condition_shape = self.posterior_estimator._condition_shape
         x = self._x_else_default_x(x)
 
-        try:
-            x = x.reshape(*condition_shape)
-        except RuntimeError as err:
-            raise ValueError(
-                f"Expected a single `x` which should broadcastable to shape \
-                  {condition_shape}, but got {x.shape}. For batched eval \
-                  see issue #990"
-            ) from err
+        # [1:] because we remove batch dimension for `reshape_to_batch_event`.
+        # Note: This line will break if `x_shape` is `None` and if `x` is passed without
+        # batch dimension.
+        x_shape = self._x_shape[1:] if self._x_shape is not None else x.shape[1:]
+        x = reshape_to_batch_event(x, event_shape=x_shape)
 
         max_sampling_batch_size = (
             self.max_sampling_batch_size
@@ -171,24 +171,29 @@ class DirectPosterior(NeuralPosterior):
             support of the prior, -∞ (corresponding to 0 probability) outside.
         """
         x = self._x_else_default_x(x)
-        condition_shape = self.posterior_estimator._condition_shape
-        try:
-            x = x.reshape(*condition_shape)
-        except RuntimeError as err:
-            raise ValueError(
-                f"Expected a single `x` which should broadcastable to shape \
-                  {condition_shape}, but got {x.shape}. For batched eval \
-                  see issue #990"
-            ) from err
 
-        # TODO Train exited here, entered after sampling?
-        self.posterior_estimator.eval()
+        # [1:] to remove batch dimension for `reshape_to_sample_batch_event`.
+        x_shape = self._x_shape[1:] if self._x_shape is not None else x.shape[1:]
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
+        theta_density_estimator = reshape_to_sample_batch_event(
+            theta, theta.shape[1:], leading_is_sample=True
+        )
+        x_density_estimator = reshape_to_batch_event(x, x_shape)
+        assert (
+            x_density_estimator.shape[0] == 1
+        ), ".log_prob() supports only `batchsize == 1`."
+
+        self.posterior_estimator.eval()
 
         with torch.set_grad_enabled(track_gradients):
             # Evaluate on device, move back to cpu for comparison with prior.
-            unnorm_log_prob = self.posterior_estimator.log_prob(theta, condition=x)
+            unnorm_log_prob = self.posterior_estimator.log_prob(
+                theta_density_estimator, condition=x_density_estimator
+            )
+            # `log_prob` supports only a single observation (i.e. `batchsize==1`).
+            # We now remove this additional dimension.
+            unnorm_log_prob = unnorm_log_prob.squeeze(dim=1)
 
             # Force probability to be zero outside prior support.
             in_prior_support = within_support(self.prior, theta)
@@ -238,6 +243,8 @@ class DirectPosterior(NeuralPosterior):
         """
 
         def acceptance_at(x: Tensor) -> Tensor:
+            # [1:] to remove batch-dimension for `reshape_to_batch_event`.
+            x_shape = self._x_shape[1:] if self._x_shape is not None else x.shape[1:]
             return accept_reject_sample(
                 proposal=self.posterior_estimator,
                 accept_reject_fn=lambda theta: within_support(self.prior, theta),
@@ -245,7 +252,9 @@ class DirectPosterior(NeuralPosterior):
                 show_progress_bars=show_progress_bars,
                 sample_for_correction_factor=True,
                 max_sampling_batch_size=rejection_sampling_batch_size,
-                proposal_sampling_kwargs={"condition": x},
+                proposal_sampling_kwargs={
+                    "condition": reshape_to_batch_event(x, x_shape)
+                },
             )[1]
 
         # Check if the provided x matches the default x (short-circuit on identity).

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -9,6 +9,10 @@ from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.neural_nets.density_estimators import DensityEstimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.sbi_types import TorchTransform
 from sbi.utils import mcmc_transform
@@ -110,8 +114,8 @@ def _log_likelihoods_over_trials(
     Repeats `x` and $\theta$ to cover all their combinations of batch entries.
 
     Args:
-        x: batch of iid data.
-        theta: batch of parameters.
+        x: Batch of iid data of shape `(iid_dim, *event_shape)`.
+        theta: Batch of parameters of shape `(batch_dim, *event_shape)`.
         estimator: DensityEstimator.
         track_gradients: Whether to track gradients.
 
@@ -119,19 +123,33 @@ def _log_likelihoods_over_trials(
         log_likelihood_trial_sum: log likelihood for each parameter, summed over all
             batch entries (iid trials) in `x`.
     """
-    # unsqueeze to ensure that the x-batch dimension is the first dimension for the
-    # broadcasting of the density estimator.
-    x = torch.as_tensor(x).reshape(-1, x.shape[-1]).unsqueeze(1)
+    # Shape of `x` is (iid_dim, *event_shape).
+    x = reshape_to_sample_batch_event(
+        x, event_shape=x.shape[1:], leading_is_sample=True
+    )
+
+    # Match the number of `x` to the number of conditions (`theta`). This is important
+    # if the potential is simulataneously evaluated at multiple `theta` (e.g.
+    # multi-chain MCMC).
+    theta_batch_size = theta.shape[0]
+    trailing_minus_ones = [-1 for _ in range(x.dim() - 2)]
+    x = x.expand(-1, theta_batch_size, *trailing_minus_ones)
+
     assert (
         next(estimator.parameters()).device == x.device and x.device == theta.device
     ), f"""device mismatch: estimator, x, theta: \
         {next(estimator.parameters()).device}, {x.device},
         {theta.device}."""
 
+    # Shape of `theta` is (batch_dim, *event_shape). Therefore, the call below should
+    # not change anything, and we just have it as "best practice" before calling
+    # `DensityEstimator.log_prob`.
+    theta = reshape_to_batch_event(theta, event_shape=theta.shape[1:])
+
     # Calculate likelihood in one batch.
     with torch.set_grad_enabled(track_gradients):
         log_likelihood_trial_batch = estimator.log_prob(x, condition=theta)
-        # Reshape to (-1, theta_batch_size), sum over trial-log likelihoods.
+        # Sum over trial-log likelihoods.
         log_likelihood_trial_sum = log_likelihood_trial_batch.sum(0)
 
     return log_likelihood_trial_sum
@@ -170,28 +188,40 @@ def mixed_likelihood_estimator_based_potential(
 class MixedLikelihoodBasedPotential(LikelihoodBasedPotential):
     def __init__(
         self,
-        likelihood_estimator: MixedDensityEstimator,  # type: ignore TODO fix pyright
+        likelihood_estimator: MixedDensityEstimator,
         prior: Distribution,
         x_o: Optional[Tensor],
         device: str = "cpu",
     ):
-        # TODO Fix pyright issue by making MixedDensityEstimator a subclass
-        # of DensityEstimator
-        super().__init__(likelihood_estimator, prior, x_o, device)  # type: ignore
+        super().__init__(likelihood_estimator, prior, x_o, device)
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
+        prior_log_prob = self.prior.log_prob(theta)  # type: ignore
+
+        # Shape of `x` is (iid_dim, *event_shape)
+        theta = reshape_to_batch_event(theta, event_shape=theta.shape[1:])
+        x = reshape_to_sample_batch_event(
+            self.x_o, event_shape=self.x_o.shape[1:], leading_is_sample=True
+        )
+        theta_batch_dim = theta.shape[0]
+        # Match the number of `x` to the number of conditions (`theta`). This is
+        # importantif the potential is simulataneously evaluated at multiple `theta`
+        # (e.g. multi-chain MCMC).
+        trailing_minus_ones = [-1 for _ in range(x.dim() - 2)]
+        x = x.expand(-1, theta_batch_dim, *trailing_minus_ones)
+
         # Calculate likelihood in one batch.
         with torch.set_grad_enabled(track_gradients):
             # Call the specific log prob method of the mixed likelihood estimator as
             # this optimizes the evaluation of the discrete data part.
-            # TODO: how to fix pyright issues?
-            log_likelihood_trial_batch = self.likelihood_estimator.log_prob_iid(
-                x=self.x_o,
-                context=theta.to(self.device),
-            )  # type: ignore
+            # TODO log_prob_iid
+            log_likelihood_trial_batch = self.likelihood_estimator.log_prob(
+                input=x,
+                condition=theta.to(self.device),
+            )
             # Reshape to (x-trials x parameters), sum over trial-log likelihoods.
             log_likelihood_trial_sum = log_likelihood_trial_batch.reshape(
                 self.x_o.shape[0], -1
             ).sum(0)
 
-        return log_likelihood_trial_sum + self.prior.log_prob(theta)  # type: ignore
+        return log_likelihood_trial_sum + prior_log_prob

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -9,6 +9,10 @@ from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.neural_nets.density_estimators import DensityEstimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.sbi_types import TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.sbiutils import within_support
@@ -98,14 +102,24 @@ class PosteriorBasedPotential(BasePotential):
                 the potential or manually set self._x_o."
             )
 
-        theta = ensure_theta_batched(torch.as_tensor(theta))
-        theta, x = theta.to(self.device), self.x_o.to(self.device)
+        theta = ensure_theta_batched(torch.as_tensor(theta)).to(self.device)
 
         with torch.set_grad_enabled(track_gradients):
-            posterior_log_prob = self.posterior_estimator.log_prob(theta, condition=x)
-
             # Force probability to be zero outside prior support.
             in_prior_support = within_support(self.prior, theta)
+
+            x = reshape_to_batch_event(self.x_o, event_shape=self.x_o.shape[1:])
+            assert (
+                x.shape[0] == 1
+            ), f"`x` has batchsize {x.shape[0]}. Only `batchsize == 1` is supported."
+            theta = reshape_to_sample_batch_event(
+                theta, event_shape=theta.shape[1:], leading_is_sample=True
+            )
+            # We assume that a single `x` is passed (i.e. batchsize==1), so we squeeze
+            # the batch dimension of the log-prob with `.squeeze(dim=1)`.
+            posterior_log_prob = self.posterior_estimator.log_prob(
+                theta, condition=x
+            ).squeeze(dim=1)
 
             posterior_log_prob = torch.where(
                 in_prior_support,

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -107,10 +107,11 @@ def _log_ratios_over_trials(
     Repeats `x` and $\theta$ to cover all their combinations of batch entries.
 
     Args:
-        x: batch of iid data.
-        theta: batch of parameters
+        x: Batch of iid data of shape `(iid_dim, *event_shape)`.
+        theta: Batch of parameters of shape `(batch_dim, *event_shape)`.
         net: neural net representing the classifier to approximate the ratio.
         track_gradients: Whether to track gradients.
+
     Returns:
         log_ratio_trial_sum: log ratio for each parameter, summed over all
             batch entries (iid trials) in `x`.

--- a/sbi/inference/snle/mnle.py
+++ b/sbi/inference/snle/mnle.py
@@ -11,6 +11,10 @@ from torch.distributions import Distribution
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import mixed_likelihood_estimator_based_potential
 from sbi.inference.snle.snle_base import LikelihoodEstimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
 from sbi.utils import check_prior, del_entries
@@ -205,4 +209,6 @@ class MNLE(LikelihoodEstimator):
         Returns:
             Negative log prob.
         """
-        return -self._neural_net.log_prob(x, context=theta)
+        theta = reshape_to_batch_event(theta, event_shape=theta.shape[1:])
+        x = reshape_to_sample_batch_event(x, event_shape=self._x_shape[1:])
+        return -self._neural_net.log_prob(x, condition=theta)

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -16,6 +16,10 @@ from sbi.inference import NeuralInference
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
 from sbi.neural_nets import DensityEstimator, likelihood_nn
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.utils import check_estimator_arg, check_prior, x_shape_from_simulation
 
 
@@ -366,4 +370,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
         Returns:
             Negative log prob.
         """
+        theta = reshape_to_batch_event(theta, event_shape=theta.shape[1:])
+        x = reshape_to_sample_batch_event(
+            x, event_shape=self._x_shape[1:], leading_is_sample=False
+        )
         return self._neural_net.loss(x, condition=theta)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -13,6 +13,10 @@ from torch.distributions import Distribution, MultivariateNormal, Uniform
 from sbi import utils as utils
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_batch_event,
+    reshape_to_sample_batch_event,
+)
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils import (
     batched_mixture_mv,
@@ -318,7 +322,6 @@ class SNPE_C(PosteriorEstimator):
         Returns:
             Log-probability of the proposal posterior.
         """
-
         batch_size = theta.shape[0]
 
         num_atoms = int(
@@ -343,15 +346,19 @@ class SNPE_C(PosteriorEstimator):
             batch_size * num_atoms, -1
         )
 
-        # Evaluate large batch giving (batch_size * num_atoms) log prob posterior evals.
-        log_prob_posterior = self._neural_net.log_prob(atomic_theta, repeated_x)
-        utils.assert_all_finite(log_prob_posterior, "posterior eval")
-        log_prob_posterior = log_prob_posterior.reshape(batch_size, num_atoms)
-
         # Get (batch_size * num_atoms) log prob prior evals.
         log_prob_prior = self._prior.log_prob(atomic_theta)
         log_prob_prior = log_prob_prior.reshape(batch_size, num_atoms)
         utils.assert_all_finite(log_prob_prior, "prior eval")
+
+        # Evaluate large batch giving (batch_size * num_atoms) log prob posterior evals.
+        atomic_theta = reshape_to_sample_batch_event(
+            atomic_theta, atomic_theta.shape[1:]
+        )
+        repeated_x = reshape_to_batch_event(repeated_x, self._x_shape[1:])
+        log_prob_posterior = self._neural_net.log_prob(atomic_theta, repeated_x)
+        utils.assert_all_finite(log_prob_posterior, "posterior eval")
+        log_prob_posterior = log_prob_posterior.reshape(batch_size, num_atoms)
 
         # Compute unnormalized proposal posterior.
         unnormalized_log_prob = log_prob_posterior - log_prob_prior
@@ -364,7 +371,12 @@ class SNPE_C(PosteriorEstimator):
 
         # XXX This evaluates the posterior on _all_ prior samples
         if self._use_combined_loss:
+            theta = reshape_to_sample_batch_event(theta, theta.shape[1:])
+            x = reshape_to_batch_event(x, self._x_shape[1:])
             log_prob_posterior_non_atomic = self._neural_net.log_prob(theta, x)
+            # squeeze to remove sample dimension, which is always one during the loss
+            # evaluation of `SNPE_C` (because we have one theta vector per x vector).
+            log_prob_posterior_non_atomic = log_prob_posterior_non_atomic.squeeze(dim=0)
             masks = masks.reshape(-1)
             log_prob_proposal_posterior = (
                 masks * log_prob_posterior_non_atomic + log_prob_proposal_posterior

--- a/sbi/neural_nets/categorial.py
+++ b/sbi/neural_nets/categorial.py
@@ -1,0 +1,34 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+from torch import Tensor, nn, unique
+
+from sbi.neural_nets.density_estimators import CategoricalMassEstimator, CategoricalNet
+
+
+def build_categoricalmassestimator(
+    input: Tensor,
+    condition: Tensor,
+    num_hidden: int = 20,
+    num_layers: int = 2,
+    embedding_net: Optional[nn.Module] = None,
+):
+    """Returns a density estimator for a categorical random variable."""
+    # Infer input and output dims.
+    if embedding_net is None:
+        dim_input = condition[0].numel()
+    else:
+        dim_input = embedding_net(condition[:1]).numel()
+    num_categories = unique(input).numel()
+
+    categorical_net = CategoricalNet(
+        num_input=dim_input,
+        num_categories=num_categories,
+        num_hidden=num_hidden,
+        num_layers=num_layers,
+        embedding_net=embedding_net,
+    )
+
+    return CategoricalMassEstimator(categorical_net)

--- a/sbi/neural_nets/density_estimators/categorical_net.py
+++ b/sbi/neural_nets/density_estimators/categorical_net.py
@@ -9,7 +9,7 @@ from sbi.neural_nets.density_estimators import DensityEstimator
 
 
 class CategoricalNet(nn.Module):
-    """Class to perform conditional density (mass) estimation for a categorical RV.
+    """Conditional density (mass) estimation for a categorical random variable.
 
     Takes as input parameters theta and learns the parameters p of a Categorical.
 
@@ -22,7 +22,7 @@ class CategoricalNet(nn.Module):
         num_categories: int = 2,
         num_hidden: int = 20,
         num_layers: int = 2,
-        embedding: Optional[nn.Module] = None,
+        embedding_net: Optional[nn.Module] = None,
     ):
         """Initialize the neural net.
 
@@ -31,7 +31,7 @@ class CategoricalNet(nn.Module):
             num_categories: number of output units, i.e., number of categories.
             num_hidden: number of hidden units per layer.
             num_layers: number of hidden layers.
-            embedding: emebedding net for parameters, e.g., a z-scoring transform.
+            embedding_net: emebedding net for parameters, e.g., a z-scoring transform.
         """
         super().__init__()
 
@@ -42,9 +42,9 @@ class CategoricalNet(nn.Module):
         self.num_categories = num_categories
 
         # Maybe add z-score embedding for parameters.
-        if embedding is not None:
+        if embedding_net is not None:
             self.input_layer = nn.Sequential(
-                embedding, nn.Linear(num_input, num_hidden)
+                embedding_net, nn.Linear(num_input, num_hidden)
             )
         else:
             self.input_layer = nn.Linear(num_input, num_hidden)
@@ -65,11 +65,6 @@ class CategoricalNet(nn.Module):
         Returns:
             Tensor: batch of predicted categorical probabilities.
         """
-        assert context.dim() == 2, "context needs to have a batch dimension."
-        assert (
-            context.shape[1] == self.num_input
-        ), f"context dimensions must match num_input {self.num_input}"
-
         # forward path
         context = self.activation(self.input_layer(context))
 
@@ -91,7 +86,9 @@ class CategoricalNet(nn.Module):
         """
         # Predict categorical ps and evaluate.
         ps = self.forward(context)
-        return Categorical(probs=ps).log_prob(input.squeeze())
+        # Squeeze dim=1 because `Categorical` has `event_shape=()` but our data usually
+        # has an event_shape of `(1,)`.
+        return Categorical(probs=ps).log_prob(input.squeeze(dim=1))
 
     def sample(self, sample_shape: torch.Size, context: Tensor) -> Tensor:
         """Returns samples from categorical random variable with probs predicted from
@@ -107,16 +104,13 @@ class CategoricalNet(nn.Module):
 
         # Predict Categorical ps and sample.
         ps = self.forward(context)
-        return (
-            Categorical(probs=ps)
-            .sample(sample_shape=sample_shape)
-            .reshape(sample_shape[0], -1)
-        )
+        return Categorical(probs=ps).sample(sample_shape=sample_shape)
 
 
 class CategoricalMassEstimator(DensityEstimator):
-    """Class to perform conditional density (mass) estimation
-    for a categorical RV.
+    """Conditional density (mass) estimation for a categorical random variable.
+
+    The event_shape of this class is `()`.
     """
 
     def __init__(self, net: CategoricalNet) -> None:
@@ -124,21 +118,65 @@ class CategoricalMassEstimator(DensityEstimator):
         self.net = net
         self.num_categories = net.num_categories
 
-    def log_prob(self, input: Tensor, context: Tensor, **kwargs) -> Tensor:
-        return self.net.log_prob(input, context, **kwargs)
+    def log_prob(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
+        """Return log-probability of samples.
 
-    def sample(self, sample_shape: torch.Size, context: Tensor, **kwargs) -> Tensor:
-        return self.net.sample(sample_shape, context, **kwargs)
+        Args:
+            input: Input datapoints of shape
+                `(sample_dim, batch_dim, *event_shape_input)`.Must be a discrete
+                indicator of class identity.
+            condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
-    def loss(self, input: Tensor, context: Tensor, **kwargs) -> Tensor:
+        Returns:
+            Log-probabilities of shape `(sample_dim, batch_dim)`.
+        """
+        input_sample_dim = input.shape[0]
+        input_batch_dim = input.shape[1]
+        condition_batch_dim = condition.shape[0]
+        condition_event_dims = len(condition.shape[1:])
+
+        assert condition_batch_dim == input_batch_dim, (
+            f"Batch shape of condition {condition_batch_dim} and input "
+            f"{input_batch_dim} do not match."
+        )
+
+        # `CategoricalNet` needs a single batch dimension for condition and input.
+        input = input.reshape((input_batch_dim * input_sample_dim, -1))
+
+        # Repeat the condition to match `input_batch_dim * input_sample_dim`.
+        ones_for_event_dims = (1,) * condition_event_dims  # Tuple of 1s, e.g. (1, 1, 1)
+        condition = condition.repeat(input_sample_dim, *ones_for_event_dims)
+
+        return self.net.log_prob(input, condition, **kwargs).reshape((
+            input_sample_dim,
+            input_batch_dim,
+        ))
+
+    def sample(self, sample_shape: torch.Size, condition: Tensor, **kwargs) -> Tensor:
+        """Return samples from the conditional categorical distribution.
+
+        Args:
+            sample_shape: Shape of samples.
+            condition: Conditions of shape
+                `(batch_dim_condition, *event_shape_condition)`.
+
+        Returns:
+            Samples of shape `(*sample_shape, batch_dim_condition)`. Note that the
+            `CategoricalMassEstimator` is defined to have `event_shape=()` and
+            therefore `.sample()` does not return a trailing dimension for
+            `event_shape`.
+        """
+        return self.net.sample(sample_shape, condition, **kwargs)
+
+    def loss(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
         r"""Return the loss for training the density estimator.
 
         Args:
-            input: Inputs to evaluate the loss on of shape (batch_size, input_size).
-            context: Conditions of shape (batch_size, *condition_shape).
+            input: Inputs of shape `(sample_dim, batch_dim, *input_event_shape)`.
+            condition: Conditions of shape `(batch_dim, *condition_event_shape)`.
 
         Returns:
-            Loss of shape (batch_size,)
+            Loss of shape `(batch_dim,)`
         """
 
-        return -self.log_prob(input, context)
+        return -self.log_prob(input, condition)

--- a/sbi/neural_nets/density_estimators/shape_handling.py
+++ b/sbi/neural_nets/density_estimators/shape_handling.py
@@ -2,10 +2,10 @@ import torch
 from torch import Tensor
 
 
-def reshape_to_iid_batch_event(
-    theta_or_x: Tensor, event_shape: torch.Size, leading_is_iid: bool
+def reshape_to_sample_batch_event(
+    theta_or_x: Tensor, event_shape: torch.Size, leading_is_sample: bool = False
 ) -> Tensor:
-    """Return theta or x s.t. its shape is `(iid_shape, batch_shape, event_shape)`.
+    """Return theta or x s.t. its shape is `(sample_dim, batch_dim, *event_shape)`.
 
     This follows the conventions used in pytorch distributions:
     https://bochang.me/blog/posts/pytorch-distributions/
@@ -14,16 +14,16 @@ def reshape_to_iid_batch_event(
         theta_or_x: The tensor to be reshaped. Can have any of the following shapes:
             - (event)
             - (batch, event)
-            - (iid, event)
-            - (iid, batch, event)
-        event_shape: The shape of a single datapoint (without batch dimension or iid
+            - (sample, event)
+            - (sample, batch, event)
+        event_shape: The shape of a single datapoint (without batch dimension or sample
             dimension).
-        leading_is_iid: Used only if `theta_or_x` has exactly one dimension beyond the
-            `event` dims. Defines whether the leading dimension is interpreted as batch
-            dimension or as iid dimension.
+        leading_is_sample: Used only if `theta_or_x` has exactly one dimension beyond
+            the `event` dims. Defines whether the leading dimension is interpreted as
+            batch dimension or as sample dimension.
 
     Returns:
-        A tensor of shape `(batch, iid, event)`.
+        A tensor of shape `(sample, batch, event)`.
     """
     # `2` for image data, `3` for video data, ...
     event_shape_dim = len(event_shape)
@@ -35,16 +35,51 @@ def reshape_to_iid_batch_event(
     ), "The trailing dimensions of `theta_or_x` do not match the `event_shape`."
 
     if len(leading_theta_or_x_shape) == 0:
-        # A single datapoint is passed. Add batch and iid dim artificially.
+        # A single datapoint is passed. Add batch and sample dim artificially.
         return theta_or_x.unsqueeze(0).unsqueeze(0)
     elif len(leading_theta_or_x_shape) == 1:
-        # Either a batch dimension or an iid dimension was passed.
-        return theta_or_x.unsqueeze(1) if leading_is_iid else theta_or_x.unsqueeze(0)
+        # Either a batch dimension or an sample dimension was passed.
+        return theta_or_x.unsqueeze(1) if leading_is_sample else theta_or_x.unsqueeze(0)
     elif len(leading_theta_or_x_shape) == 2:
-        # Batch dimension and iid dimension were passed.
-        return theta_or_x
+        # Batch dimension and sample dimension were passed.
+        return theta_or_x if leading_is_sample else theta_or_x.transpose(1, 0)
     else:
         raise ValueError(
             f"`len(leading_theta_or_x_shape) = {leading_theta_or_x_shape} > 2`. "
+            f"It is unclear how the additional entries should be interpreted"
+        )
+
+
+def reshape_to_batch_event(theta_or_x: Tensor, event_shape: torch.Size) -> Tensor:
+    """Return theta or x s.t. its shape is `(batch_dim, *event_shape)`.
+
+    Args:
+        theta_or_x: The tensor to be reshaped. Can have any of the following shapes:
+            - (event)
+            - (batch, event)
+        event_shape: The shape of a single datapoint (without batch dimension or sample
+            dimension).
+
+    Returns:
+        A tensor of shape `(batch, event)`.
+    """
+    # `2` for image data, `3` for video data, ...
+    event_shape_dim = len(event_shape)
+
+    trailing_theta_or_x_shape = theta_or_x.shape[-event_shape_dim:]
+    leading_theta_or_x_shape = theta_or_x.shape[:-event_shape_dim]
+    assert (
+        trailing_theta_or_x_shape == event_shape
+    ), "The trailing dimensions of `theta_or_x` do not match the `event_shape`."
+
+    if len(leading_theta_or_x_shape) == 0:
+        # A single datapoint is passed. Add batch artificially.
+        return theta_or_x.unsqueeze(0)
+    elif len(leading_theta_or_x_shape) == 1:
+        # A batch dimension was passed.
+        return theta_or_x
+    else:
+        raise ValueError(
+            f"`len(leading_theta_or_x_shape) = {leading_theta_or_x_shape} > 1`. "
             f"It is unclear how the additional entries should be interpreted"
         )

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, cast
 
 import torch
 from numpy import ndarray
-from pyknos.nflows import flows
 from scipy.stats._distn_infrastructure import rv_frozen
 from scipy.stats._multivariate import multi_rv_frozen
 from torch import Tensor, float32, nn
@@ -749,17 +748,19 @@ def validate_theta_and_x(
     return theta, x
 
 
-def test_posterior_net_for_multi_d_x(net: flows.Flow, theta: Tensor, x: Tensor) -> None:
+def test_posterior_net_for_multi_d_x(net, theta: Tensor, x: Tensor) -> None:
     """Test log prob method of the net.
 
     This is done to make sure the net can handle multidimensional inputs via an
     embedding net. If not, it usually fails with a RuntimeError. Here we catch the
     error, append a debug hint and raise it again.
-    """
 
+    Args:
+        net: A `DensityEstimator`.
+    """
     try:
         # torch.nn.functional needs at least two inputs here.
-        net.log_prob(theta[:2], x[:2])
+        net.log_prob(theta[:, :2], condition=x[:2])
     except RuntimeError as rte:
         ndims = x.ndim
         if ndims > 2:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -20,7 +20,7 @@ def test_infer():
         prior,
         method="SNPE_A",
         num_simulations=10,
-        init_kwargs={'num_components': 5},
+        init_kwargs={"num_components": 5},
         train_kwargs={"max_num_epochs": 2},
         build_posterior_kwargs={"prior": prior},
     )

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -10,7 +10,12 @@ import torch
 from torch import eye, zeros
 from torch.distributions import MultivariateNormal
 
-from sbi.neural_nets.density_estimators.shape_handling import reshape_to_iid_batch_event
+from sbi.neural_nets import build_mnle
+from sbi.neural_nets.categorial import build_categoricalmassestimator
+from sbi.neural_nets.density_estimators.shape_handling import (
+    reshape_to_sample_batch_event,
+)
+from sbi.neural_nets.embedding_nets import CNNEmbedding
 from sbi.neural_nets.flow import (
     build_maf,
     build_maf_rqs,
@@ -25,6 +30,7 @@ from sbi.neural_nets.flow import (
     build_zuko_sospf,
     build_zuko_unaf,
 )
+from sbi.neural_nets.mdn import build_mdn
 
 
 def get_batch_input(nsamples: int, input_dims: int) -> torch.Tensor:
@@ -61,215 +67,7 @@ def get_batch_context(nsamples: int, condition_shape: tuple[int, ...]) -> torch.
 
 
 @pytest.mark.parametrize(
-    "build_density_estimator",
-    (
-        build_maf,
-        build_maf_rqs,
-        build_nsf,
-        build_zuko_nice,
-        build_zuko_maf,
-        build_zuko_nsf,
-        build_zuko_ncsf,
-        build_zuko_sospf,
-        build_zuko_naf,
-        build_zuko_unaf,
-        build_zuko_gf,
-        build_zuko_bpf,
-    ),
-)
-@pytest.mark.parametrize("input_dims", (1, 2))
-@pytest.mark.parametrize(
-    "condition_shape", ((1,), (2,), (1, 1), (2, 2), (1, 1, 1), (2, 2, 2))
-)
-def test_api_density_estimator(build_density_estimator, input_dims, condition_shape):
-    r"""Checks whether we can evaluate and sample from density estimators correctly.
-
-    Args:
-        build_density_estimator: function that creates a DensityEstimator subclass.
-        input_dim: Dimensionality of the input.
-        context_shape: Dimensionality of the context.
-    """
-
-    nsamples = 10
-    nsamples_test = 5
-
-    batch_input = get_batch_input(nsamples, input_dims)
-    batch_context = get_batch_context(nsamples, condition_shape)
-
-    class EmbeddingNet(torch.nn.Module):
-        def forward(self, x):
-            for _ in range(len(condition_shape) - 1):
-                x = torch.sum(x, dim=-1)
-            return x
-
-    estimator = build_density_estimator(
-        batch_input,
-        batch_context,
-        hidden_features=10,
-        num_transforms=2,
-        embedding_net=EmbeddingNet(),
-    )
-
-    # Loss is only required to work for batched inputs and contexts
-    loss = estimator.loss(batch_input, batch_context)
-    assert loss.shape == (
-        nsamples,
-    ), f"Loss shape is not correct. It is of shape {loss.shape}, but should \
-        be {(nsamples,)}"
-
-    # Sample and log_prob should work for batched and unbatched contexts
-
-    # Unbatched context
-    samples = estimator.sample((nsamples_test,), batch_context[0])
-    assert samples.shape == (
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(nsamples_test, input_dims)}"
-    log_probs = estimator.log_prob(samples, batch_context[0])
-    assert log_probs.shape == (
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(nsamples_test,)}"
-
-    samples = estimator.sample((1, nsamples_test), batch_context[0])
-    assert samples.shape == (
-        1,
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(1, nsamples_test, input_dims)}"
-    log_probs = estimator.log_prob(samples, batch_context[0])
-    assert log_probs.shape == (
-        1,
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(1, nsamples_test)}"
-
-    samples = estimator.sample((2, nsamples_test), batch_context[0])
-    assert samples.shape == (
-        2,
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test, input_dims)}"
-    log_probs = estimator.log_prob(samples, batch_context[0])
-    assert log_probs.shape == (
-        2,
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test)}"
-
-    # Batched context
-    samples = estimator.sample((nsamples_test,), batch_context)
-    assert samples.shape == (
-        batch_context.shape[0],
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test, input_dims)}"
-    try:
-        log_probs = estimator.log_prob(samples, batch_context)
-    except RuntimeError:
-        # Shapes (10,) and (5,) are not broadcastable, so we expect a ValueError
-        pass
-    except Exception as err:
-        raise AssertionError(
-            f"Expected RuntimeError as shapes {batch_context.shape} \
-                             and {samples.shape} are not broadcastable, but got a \
-                             different/no error."
-        ) from err
-
-    samples = estimator.sample((nsamples_test,), batch_context[0].unsqueeze(0))
-    assert samples.shape == (
-        1,
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should be \
-        {(batch_context.shape[0], nsamples_test, input_dims)}"
-    log_probs = estimator.log_prob(samples, batch_context[0].unsqueeze(0))
-    assert log_probs.shape == (
-        1,
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test)}"
-
-    # Both batched
-    samples = estimator.sample((2, nsamples_test), batch_context.unsqueeze(0))
-    assert samples.shape == (
-        1,
-        batch_context.shape[0],
-        2,
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(1, batch_context.shape[0], 2, nsamples_test, input_dims)}"
-    try:
-        log_probs = estimator.log_prob(samples, batch_context.unsqueeze(0))
-    except RuntimeError:
-        # Shapes (10,) and (5,) are not broadcastable, so we expect a ValueError
-        pass
-    except Exception as err:
-        raise AssertionError(
-            f"Expected RuntimeError as shapes {batch_context.shape} \
-                            and {samples.shape} are not broadcastable, but got a \
-                            different/no error."
-        ) from err
-
-    # Sample and log_prob work for batched and unbatched contexts
-    samples, log_probs = estimator.sample_and_log_prob(
-        (nsamples_test,), batch_context[0]
-    )
-    assert samples.shape == (
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(nsamples_test, input_dims)}"
-    assert log_probs.shape == (
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(nsamples_test,)}"
-
-    samples, log_probs = estimator.sample_and_log_prob((nsamples_test,), batch_context)
-
-    assert samples.shape == (
-        batch_context.shape[0],
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test, input_dims)}"
-    assert log_probs.shape == (
-        batch_context.shape[0],
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(batch_context.shape[0], nsamples_test)}"
-
-    samples, log_probs = estimator.sample_and_log_prob(
-        (
-            2,
-            nsamples_test,
-        ),
-        batch_context.unsqueeze(0),
-    )
-    assert samples.shape == (
-        1,
-        batch_context.shape[0],
-        2,
-        nsamples_test,
-        input_dims,
-    ), f"Samples shape is not correct. It is of shape {samples.shape}, but should \
-        be {(1, batch_context.shape[0], 2, nsamples_test, input_dims)}"
-    assert log_probs.shape == (
-        1,
-        batch_context.shape[0],
-        2,
-        nsamples_test,
-    ), f"log_prob shape is not correct. It is of shape {log_probs.shape}, but should \
-        be {(1, batch_context.shape[0], 2, nsamples_test)}"
-
-
-@pytest.mark.parametrize(
-    "theta_or_x_shape, target_shape, event_shape, leading_is_iid",
+    "theta_or_x_shape, target_shape, event_shape, leading_is_sample",
     (
         ((3,), (1, 1, 3), (3,), False),
         ((3,), (1, 1, 3), (3,), True),
@@ -278,7 +76,7 @@ def test_api_density_estimator(build_density_estimator, input_dims, condition_sh
         ((2, 3), (1, 2, 3), (3,), False),
         ((2, 3), (2, 1, 3), (3,), True),
         ((1, 2, 3), (1, 2, 3), (3,), True),
-        ((1, 2, 3), (1, 2, 3), (3,), False),
+        ((1, 2, 3), (2, 1, 3), (3,), False),
         ((3, 5), (1, 1, 3, 5), (3, 5), False),
         ((3, 5), (1, 1, 3, 5), (3, 5), True),
         ((1, 3, 5), (1, 1, 3, 5), (3, 5), False),
@@ -286,7 +84,7 @@ def test_api_density_estimator(build_density_estimator, input_dims, condition_sh
         ((2, 3, 5), (1, 2, 3, 5), (3, 5), False),
         ((2, 3, 5), (2, 1, 3, 5), (3, 5), True),
         ((1, 2, 3, 5), (1, 2, 3, 5), (3, 5), True),
-        ((1, 2, 3, 5), (1, 2, 3, 5), (3, 5), False),
+        ((1, 2, 3, 5), (2, 1, 3, 5), (3, 5), False),
         pytest.param((1, 2, 3, 5), (1, 2, 3, 5), (5), False, marks=pytest.mark.xfail),
         pytest.param((1, 2, 3, 5), (1, 2, 3, 5), (3), False, marks=pytest.mark.xfail),
         pytest.param((1, 2, 3), (1, 2, 3), (1, 5), False, marks=pytest.mark.xfail),
@@ -299,14 +97,237 @@ def test_shape_handling_utility_for_density_estimator(
     theta_or_x_shape: Tuple,
     target_shape: Tuple,
     event_shape: Tuple,
-    leading_is_iid: bool,
+    leading_is_sample: bool,
 ):
-    """Test whether `reshape_to_batch_iid_event` results in expected outputs."""
+    """Test whether `reshape_to_batch_sample_event` results in expected outputs."""
     input = torch.randn(theta_or_x_shape)
-    output = reshape_to_iid_batch_event(
-        input, event_shape=event_shape, leading_is_iid=leading_is_iid
+    output = reshape_to_sample_batch_event(
+        input, event_shape=event_shape, leading_is_sample=leading_is_sample
     )
     assert output.shape == target_shape, (
         f"Shapes of Output ({output.shape}) and target shape ({target_shape}) do not "
         f"match."
     )
+
+
+@pytest.mark.parametrize(
+    "density_estimator_build_fn",
+    (
+        build_mdn,
+        build_maf,
+        build_maf_rqs,
+        build_nsf,
+        build_zuko_bpf,
+        build_zuko_gf,
+        build_zuko_maf,
+        build_zuko_naf,
+        build_zuko_ncsf,
+        build_zuko_nice,
+        build_zuko_nsf,
+        build_zuko_sospf,
+        build_zuko_unaf,
+        build_categoricalmassestimator,
+        build_mnle,
+    ),
+)
+@pytest.mark.parametrize("input_sample_dim", (1, 2))
+@pytest.mark.parametrize("input_event_shape", ((1,), (4,)))
+@pytest.mark.parametrize("condition_event_shape", ((1,), (7,)))
+@pytest.mark.parametrize("batch_dim", (1, 10))
+def test_density_estimator_loss_shapes(
+    density_estimator_build_fn,
+    input_sample_dim,
+    input_event_shape,
+    condition_event_shape,
+    batch_dim,
+):
+    """Test whether `loss` of DensityEstimators follow the shape convention."""
+    density_estimator, inputs, conditions = _build_density_estimator_and_tensors(
+        density_estimator_build_fn,
+        input_event_shape,
+        condition_event_shape,
+        batch_dim,
+        input_sample_dim,
+    )
+
+    losses = density_estimator.loss(inputs, condition=conditions)
+    assert losses.shape == (input_sample_dim, batch_dim)
+
+
+@pytest.mark.parametrize(
+    "density_estimator_build_fn",
+    (
+        build_mdn,
+        build_maf,
+        build_maf_rqs,
+        build_nsf,
+        build_zuko_bpf,
+        build_zuko_gf,
+        build_zuko_maf,
+        build_zuko_naf,
+        build_zuko_ncsf,
+        build_zuko_nice,
+        build_zuko_nsf,
+        build_zuko_sospf,
+        build_zuko_unaf,
+        build_categoricalmassestimator,
+    ),
+)
+@pytest.mark.parametrize("input_sample_dim", (1, 2))
+@pytest.mark.parametrize("input_event_shape", ((1,), (4,)))
+@pytest.mark.parametrize("condition_event_shape", ((1, 1), (1, 7), (7, 1), (7, 7)))
+@pytest.mark.parametrize("batch_dim", (1, 10))
+def test_density_estimator_log_prob_shapes_with_embedding(
+    density_estimator_build_fn,
+    input_sample_dim,
+    input_event_shape,
+    condition_event_shape,
+    batch_dim,
+):
+    """Test whether `loss` of DensityEstimators follow the shape convention."""
+    density_estimator, inputs, conditions = _build_density_estimator_and_tensors(
+        density_estimator_build_fn,
+        input_event_shape,
+        condition_event_shape,
+        batch_dim,
+        input_sample_dim,
+    )
+
+    losses = density_estimator.log_prob(inputs, condition=conditions)
+    assert losses.shape == (input_sample_dim, batch_dim)
+
+
+@pytest.mark.parametrize(
+    "density_estimator_build_fn",
+    (
+        build_mdn,
+        build_maf,
+        build_maf_rqs,
+        build_nsf,
+        build_zuko_bpf,
+        build_zuko_gf,
+        build_zuko_maf,
+        build_zuko_naf,
+        build_zuko_ncsf,
+        build_zuko_nice,
+        build_zuko_nsf,
+        build_zuko_sospf,
+        build_zuko_unaf,
+        build_categoricalmassestimator,
+        build_mnle,
+    ),
+)
+@pytest.mark.parametrize("sample_shape", ((), (1,), (2, 3)))
+@pytest.mark.parametrize("input_event_shape", ((1,), (4,)))
+@pytest.mark.parametrize("condition_event_shape", ((1,), (7,)))
+@pytest.mark.parametrize("batch_dim", (1, 10))
+def test_density_estimator_sample_shapes(
+    density_estimator_build_fn,
+    sample_shape,
+    input_event_shape,
+    condition_event_shape,
+    batch_dim,
+):
+    """Test whether `loss` of DensityEstimators follow the shape convention."""
+    density_estimator, _, conditions = _build_density_estimator_and_tensors(
+        density_estimator_build_fn, input_event_shape, condition_event_shape, batch_dim
+    )
+    samples = density_estimator.sample(sample_shape, condition=conditions)
+    if density_estimator_build_fn == build_categoricalmassestimator:
+        # Our categorical is always 1D and does not return `input_event_shape`.
+        input_event_shape = ()
+    elif density_estimator_build_fn == build_mnle:
+        input_event_shape = (input_event_shape[0] + 1,)
+    assert samples.shape == (*sample_shape, batch_dim, *input_event_shape)
+
+
+@pytest.mark.parametrize(
+    "density_estimator_build_fn",
+    (
+        build_mdn,
+        build_maf,
+        build_maf_rqs,
+        build_nsf,
+        build_zuko_bpf,
+        build_zuko_gf,
+        build_zuko_maf,
+        build_zuko_naf,
+        build_zuko_ncsf,
+        build_zuko_nice,
+        build_zuko_nsf,
+        build_zuko_sospf,
+        build_zuko_unaf,
+        build_categoricalmassestimator,
+        build_mnle,
+    ),
+)
+@pytest.mark.parametrize("input_event_shape", ((1,), (4,)))
+@pytest.mark.parametrize("condition_event_shape", ((1,), (7,)))
+@pytest.mark.parametrize("batch_dim", (1, 10))
+def test_correctness_of_density_estimator_loss(
+    density_estimator_build_fn,
+    input_event_shape,
+    condition_event_shape,
+    batch_dim,
+):
+    """Test whether identical inputs lead to identical loss values."""
+    input_sample_dim = 2
+    density_estimator, inputs, condition = _build_density_estimator_and_tensors(
+        density_estimator_build_fn,
+        input_event_shape,
+        condition_event_shape,
+        batch_dim,
+        input_sample_dim,
+    )
+    losses = density_estimator.loss(inputs, condition=condition)
+    assert torch.allclose(losses[0, :], losses[1, :])
+
+
+def _build_density_estimator_and_tensors(
+    density_estimator_build_fn: str,
+    input_event_shape: Tuple[int],
+    condition_event_shape: Tuple[int],
+    batch_dim: int,
+    input_sample_dim: int = 1,
+):
+    """Helper function for all tests that deal with shapes of density estimators."""
+    if density_estimator_build_fn == build_categoricalmassestimator:
+        input_event_shape = (1,)
+    elif density_estimator_build_fn == build_mnle:
+        input_event_shape = (
+            input_event_shape[0] + 1,
+        )  # 1 does not make sense for mixed.
+
+    # Use discrete thetas such that categorical density esitmators can also use them.
+    building_thetas = torch.randint(
+        0, 4, (1000, *input_event_shape), dtype=torch.float32
+    )
+    building_xs = torch.randn((1000, *condition_event_shape))
+    if len(condition_event_shape) > 1:
+        embedding_net = CNNEmbedding(condition_event_shape, kernel_size=1)
+    else:
+        embedding_net = torch.nn.Identity()
+
+    if density_estimator_build_fn == build_mnle:
+        building_thetas[:, :-1] += 5.0  # Make continuous dims positive for log-tf.
+        density_estimator = density_estimator_build_fn(
+            building_thetas, building_xs, embedding_net=embedding_net
+        )
+    elif density_estimator_build_fn == build_categoricalmassestimator:
+        density_estimator = density_estimator_build_fn(
+            building_thetas, building_xs, embedding_net=embedding_net
+        )
+    else:
+        density_estimator = density_estimator_build_fn(
+            torch.randn_like(building_thetas),
+            torch.randn_like(building_xs),
+            embedding_net=embedding_net,
+        )
+
+    inputs = building_thetas[:batch_dim]
+    condition = building_xs[:batch_dim]
+
+    inputs = inputs.unsqueeze(0)
+    inputs = inputs.expand(input_sample_dim, -1, -1)
+    condition = condition
+    return density_estimator, inputs, condition


### PR DESCRIPTION
## Shape conventions for the `DensityEstimator`

All density estimators now have a unified format of their input and output shapes. 
- `input` must have shape `(sample_dim: int, batch_dim: int, *event_shape: Tuple[int])`
- `condition` must have shape `(batch_dim: int, *event_shape: Tuple[int])`
- `batch_dim` of `input` and `condition` must be the same for `log_prob`.

### API
**`density_estimator.log_prob(input, condition)`**
```
input: (sample_input, batch_input, *event_shape_input)
condition: (batch_condition, *event_shape_condition)
returns: (sample_input, batch_input)
raises: batch_input != batch_condition
```

**`density_estimator.sample(sample_shape, condition)`**
```
sample_shape: (*sample_shape)
condition: (batch_condition, *event_shape_condition)
returns: (*sample_shape, batch_condition, *event_shape_input)
```

### Examples

**`density_estimator.log_prob(input, condition)`**
```
(1, 1, 3), (1, 6) -> (1, 1)
(1, 5, 3), (5, 6) -> (1, 5)
(10, 5, 3), (5, 6) -> (10, 5)
(1, 1, 3), (5, 6) -> Error, batch dims must match
```

**`density_estimator.sample(shape, condition)`**
```
(1,), (1, 6) -> (1, *event_shape_input)
(1,), (5, 6) -> (1, 5, *event_shape_input)
(10,), (5, 6) -> (10, 5, *event_shape_input)
(10, 3), (5, 6) -> (10, 3, 5, *event_shape_input)
```

### Issues to be opened

- `MixedDensityEstimator` cannot have `embedding_net`.
- `build_categoricalmassestimator` should have z-score option and perform z-scoring by itself.
- Only `DensityEstimator` should be carrying `condition_shape`. `posterior` and `inference` should not carry these attributes.
- `log_prob_iid` of MNLE not working


### Limitations

Not **all** `DensityEstimator`s can...
- ...handle `batch_shapes` (but only `batch_dims`, i.e. scalar values)
- ...evaluate one datapoint under multiple conditions with `log_prob` without adapting the `batch_dim` of the datapoint
- ...perform `log_prob` on data without `iid_dim_input`. I.e. `log_prob((50,3), (50,4))` might fail, but `log_prob((1,50,3), (50,4))` will work


### Does this close any currently open issues?

Fixes #1041 


### Additional (but orthogonal) contributions

- Make the naming of variables in `MixedDensityEstimator` independent of having to estimate the likelihood (it can, in principle, be used to estimate mixed posteriors)


### Checklist

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
