### PR TITLE
Deprecate `prepare_for_sbi`

### DIFF
--- a/sbi/examples/minimal.py
+++ b/sbi/examples/minimal.py
@@ -1,7 +1,11 @@
 import torch
 
-from sbi.inference import SNPE, infer, prepare_for_sbi, simulate_for_sbi
+from sbi.inference import SNPE, infer, simulate_for_sbi
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
+from sbi.utils.user_input_checks import (
+    process_prior,
+    process_simulator,
+)
 
 
 def simple():
@@ -33,7 +37,9 @@ def flexible():
     prior = torch.distributions.MultivariateNormal(
         loc=prior_mean, covariance_matrix=prior_cov
     )
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+
     inference = SNPE(prior)
 
     theta, x = simulate_for_sbi(simulator, proposal=prior, num_simulations=500)

--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -25,7 +25,6 @@ from sbi.inference.snpe.snpe_a import SNPE_A
 from sbi.inference.snpe.snpe_b import SNPE_B
 from sbi.inference.snpe.snpe_c import SNPE_C  # noqa: F401
 from sbi.inference.snre import BNRE, SNRE, SNRE_A, SNRE_B, SNRE_C  # noqa: F401
-from sbi.utils.user_input_checks import prepare_for_sbi
 
 SNL = SNLE = SNLE_A
 _snle_family = ["SNL"]

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -29,7 +29,11 @@ from sbi.utils import (
 )
 from sbi.utils.sbiutils import get_simulations_since_round
 from sbi.utils.torchutils import check_if_prior_on_device, process_device
-from sbi.utils.user_input_checks import prepare_for_sbi
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 
 def infer(
@@ -101,7 +105,9 @@ def infer(
     if init_kwargs is None:
         init_kwargs = {}
 
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
 
     inference = method_fun(prior=prior, **init_kwargs)
     theta, x = simulate_for_sbi(

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -610,7 +610,9 @@ def process_x(
 def prepare_for_sbi(simulator: Callable, prior) -> Tuple[Callable, Distribution]:
     """Prepare simulator and prior for usage in sbi.
 
-    NOTE: This is a wrapper around `process_prior` and `process_simulator` which can be
+    NOTE: This method is deprecated as of sbi version v0.23.0. and will be removed in a future release.
+    Please use `process_prior` and `process_simulator` in the future.
+    This is a wrapper around `process_prior` and `process_simulator` which can be
     used in isolation as well.
 
     Attempts to meet the following requirements by reshaping and type-casting:
@@ -629,6 +631,13 @@ def prepare_for_sbi(simulator: Callable, prior) -> Tuple[Callable, Distribution]
     Returns:
         Tuple (simulator, prior) checked and matching the requirements of sbi.
     """
+
+    warnings.warn(
+        "This method is deprecated as of sbi version v0.23.0. and will be removed in a future release."
+        "Please use `process_prior` and `process_simulator` in the future.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     # Check prior, return PyTorch prior.
     prior, _, prior_returns_numpy = process_prior(prior)

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -34,7 +34,9 @@ from sbi.simulators import diagonal_linear_gaussian, linear_gaussian
 from sbi.utils.torchutils import BoxUniform, gpu_available, process_device
 from sbi.utils.user_input_checks import (
     check_embedding_net_device,
-    prepare_for_sbi,
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
     validate_theta_and_x,
 )
 
@@ -283,7 +285,10 @@ def test_train_with_different_data_and_training_device(
     prior_ = BoxUniform(
         -torch.ones(num_dim), torch.ones(num_dim), device=training_device
     )
-    simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior_)
+
+    prior, _, prior_returns_numpy = process_prior(prior_)
+    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
 
     inference = inference_method(
         prior,
@@ -449,7 +454,9 @@ def test_nograd_after_inference_train(inference_method) -> None:
     """Test that no gradients are present after training."""
     num_dim = 2
     prior_ = BoxUniform(-torch.ones(num_dim), torch.ones(num_dim))
-    simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior_)
+    prior, _, prior_returns_numpy = process_prior(prior_)
+    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
 
     inference = inference_method(
         prior,

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -13,7 +13,6 @@ from sbi.inference import (
     SNPE_C,
     SRE,
     DirectPosterior,
-    prepare_for_sbi,
     simulate_for_sbi,
 )
 from sbi.simulators.linear_gaussian import (
@@ -22,6 +21,11 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils import RestrictionEstimator
 from sbi.utils.sbiutils import handle_invalid_x
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 from .test_utils import check_c2st
 
@@ -96,7 +100,9 @@ def test_inference_with_nan_simulator(method: type, percent_nans: float):
         prior=prior,
     )
 
-    simulator, prior = prepare_for_sbi(linear_gaussian_nan, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(linear_gaussian_nan, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = method(prior=prior)
 
     theta, x = simulate_for_sbi(simulator, prior, num_simulations)
@@ -137,7 +143,9 @@ def test_inference_with_restriction_estimator():
         prior=prior,
     )
 
-    simulator, prior = prepare_for_sbi(linear_gaussian_nan, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(linear_gaussian_nan, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     restriction_estimator = RestrictionEstimator(prior=prior)
     proposal = prior
     num_rounds = 2

--- a/tests/linearGaussian_mdn_test.py
+++ b/tests/linearGaussian_mdn_test.py
@@ -14,12 +14,16 @@ from sbi.inference import (
     DirectPosterior,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    prepare_for_sbi,
     simulate_for_sbi,
 )
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
+)
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
 )
 from tests.test_utils import check_c2st
 
@@ -54,7 +58,9 @@ def mdn_inference_with_different_methods(method):
     def simulator(theta: Tensor) -> Tensor:
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = method(density_estimator="mdn")
 
     theta, x = simulate_for_sbi(simulator, prior, num_simulations)
@@ -102,7 +108,9 @@ def test_mdn_with_1D_uniform_prior():
     def simulator(theta: Tensor) -> Tensor:
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = SNPE(density_estimator="mdn")
 
     theta, x = simulate_for_sbi(simulator, prior, 100)

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -15,7 +15,6 @@ from sbi.inference import (
     RejectionPosterior,
     VIPosterior,
     likelihood_estimator_based_potential,
-    prepare_for_sbi,
     simulate_for_sbi,
 )
 from sbi.neural_nets import likelihood_nn
@@ -26,7 +25,12 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils import BoxUniform, process_prior
+from sbi.utils import BoxUniform
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 from .test_utils import check_c2st, get_prob_outside_uniform_prior
 
@@ -54,7 +58,9 @@ def test_api_snle_multiple_trials_and_rounds_map(num_dim: int, prior_str: str):
     else:
         prior = BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = SNLE(prior=prior, density_estimator="mdn", show_progress_bars=False)
 
     proposals = [prior]
@@ -106,7 +112,8 @@ def test_c2st_snl_on_linear_gaussian_different_dims(model_str="maf"):
         num_discarded_dims=discard_dims,
         num_samples=num_samples,
     )
-    simulator, prior = prepare_for_sbi(
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(
         lambda theta: linear_gaussian(
             theta,
             likelihood_shift,
@@ -114,7 +121,10 @@ def test_c2st_snl_on_linear_gaussian_different_dims(model_str="maf"):
             num_discarded_dims=discard_dims,
         ),
         prior,
+        prior_returns_numpy,
     )
+    check_sbi_inputs(simulator, prior)
+
     density_estimator = likelihood_nn(model=model_str, num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
 
@@ -167,10 +177,14 @@ def test_c2st_and_map_snl_on_linearGaussian_different(
     else:
         prior = BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    simulator, prior = prepare_for_sbi(
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(
         lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
         prior,
+        prior_returns_numpy,
     )
+    check_sbi_inputs(simulator, prior)
+
     density_estimator = likelihood_nn(model_str, num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
 
@@ -292,10 +306,14 @@ def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int):
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    simulator, prior = prepare_for_sbi(
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(
         lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
         prior,
+        prior_returns_numpy,
     )
+    check_sbi_inputs(simulator, prior)
+
     inference = SNLE(show_progress_bars=False)
 
     theta, x = simulate_for_sbi(
@@ -357,10 +375,14 @@ def test_c2st_multi_round_snl_on_linearGaussian_vi(num_trials: int):
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    simulator, prior = prepare_for_sbi(
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(
         lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
         prior,
+        prior_returns_numpy,
     )
+    check_sbi_inputs(simulator, prior)
+
     inference = SNLE(show_progress_bars=False)
 
     theta, x = simulate_for_sbi(
@@ -465,7 +487,12 @@ def test_api_snl_sampling_methods(
     # Thus, we would not like to run, e.g., VI with all init_strategies, but only once
     # (namely with `init_strategy=proposal`).
     if sample_with == "mcmc" or init_strategy == "proposal":
-        simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
+        prior, _, prior_returns_numpy = process_prior(prior)
+        simulator = process_simulator(
+            diagonal_linear_gaussian, prior, prior_returns_numpy
+        )
+        check_sbi_inputs(simulator, prior)
+
         inference = SNLE(show_progress_bars=False)
 
         theta, x = simulate_for_sbi(

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -14,7 +14,6 @@ from sbi.inference import (
     SNLE,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    prepare_for_sbi,
     simulate_for_sbi,
 )
 from sbi.neural_nets import likelihood_nn
@@ -26,6 +25,11 @@ from sbi.samplers.mcmc.slice_numpy import (
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
+)
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
 )
 from tests.test_utils import check_c2st
 
@@ -148,7 +152,9 @@ def test_getting_inference_diagnostics(method):
         Uniform(low=-ones(1), high=ones(1)),
     ]
 
-    simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     density_estimator = likelihood_nn("maf", num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
 

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -10,8 +10,13 @@ from matplotlib.pyplot import subplots
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.analysis import pairplot, plot_summary, sbc_rank_plot
-from sbi.inference import SNLE, SNPE, SNRE, prepare_for_sbi, simulate_for_sbi
+from sbi.inference import SNLE, SNPE, SNRE, simulate_for_sbi
 from sbi.utils import BoxUniform
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 
 @pytest.mark.parametrize("samples", (torch.randn(100, 2), [torch.randn(100, 2)] * 2))
@@ -37,7 +42,9 @@ def test_plot_summary(method, tmp_path):
     def linear_gaussian(theta):
         return theta + 1.0 + torch.randn_like(theta) * 0.1
 
-    simulator, prior = prepare_for_sbi(linear_gaussian, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
 
     inference = method(prior=prior, summary_writer=summary_writer)
     theta, x = simulate_for_sbi(simulator, proposal=prior, num_simulations=6)

--- a/tests/posterior_sampler_test.py
+++ b/tests/posterior_sampler_test.py
@@ -13,11 +13,15 @@ from sbi.inference import (
     SNL,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    prepare_for_sbi,
     simulate_for_sbi,
 )
 from sbi.samplers.mcmc import SliceSamplerSerial, SliceSamplerVectorized
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 
 @pytest.mark.parametrize(
@@ -47,7 +51,9 @@ def test_api_posterior_sampler_set(sampling_method: str, set_seed):
     num_chains = 3 if sampling_method in "slice_np_vectorized" else 1
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
-    simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = SNL(prior, show_progress_bars=False)
 
     theta, x = simulate_for_sbi(

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -10,7 +10,11 @@ from torch import ones, zeros
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.utils.torchutils import BoxUniform
-from sbi.utils.user_input_checks import prepare_for_sbi
+from sbi.utils.user_input_checks import (
+    check_sbi_inputs,
+    process_prior,
+    process_simulator,
+)
 
 
 @pytest.mark.parametrize("num_sims", (0, 10))
@@ -28,7 +32,9 @@ def test_simulate_in_batches(
 ):
     """Test combinations of num_sims and simulation_batch_size."""
 
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     theta = prior.sample((num_sims,))
     # run twice to check seeding.
     x1 = simulate_in_batches(simulator, theta, batch_size, seed=seed)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -17,7 +17,7 @@ from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.utils import mcmc_transform, within_support
 from sbi.utils.torchutils import BoxUniform
 from sbi.utils.user_input_checks import (
-    prepare_for_sbi,
+    check_sbi_inputs,
     process_prior,
     process_simulator,
     process_x,
@@ -269,7 +269,9 @@ def test_prepare_sbi_problem(simulator: Callable, prior):
         x_shape: shape of data as defined by the user.
     """
 
-    simulator, prior = prepare_for_sbi(simulator, prior)
+    prior, _, prior_returns_numpy = process_prior(prior)
+    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
 
     # check batch sims and type
     n_batch = 5
@@ -315,7 +317,9 @@ def test_inference_with_user_sbi_problems(
     Test inference with combinations of user defined simulators, priors and x_os.
     """
 
-    simulator, prior = prepare_for_sbi(user_simulator, user_prior)
+    prior, _, prior_returns_numpy = process_prior(user_prior)
+    simulator = process_simulator(user_simulator, prior, prior_returns_numpy)
+    check_sbi_inputs(simulator, prior)
     inference = snpe_method(
         prior=prior,
         density_estimator="mdn_snpe_a" if snpe_method == SNPE_A else "maf",


### PR DESCRIPTION
Deprecates `prepare_for_sbi` and replaces it with `process_prior` and `process_simulator` in the rest of the codebase (already replaced in tutorial notebooks).

Fixes #1082

## Checklist

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
