### PR TITLE
Unconditional LazyTransform workaround

### DIFF
--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -14,12 +14,12 @@ from pyknos.nflows.transforms.splines import (
     rational_quadratic,  # pyright: ignore[reportAttributeAccessIssue]
 )
 from torch import Tensor, nn, relu, tanh, tensor, uint8
-from zuko.flows import LazyTransform
 
 from sbi.neural_nets.density_estimators import NFlowsFlow, ZukoFlow
 from sbi.utils.sbiutils import (
     standardizing_net,
     standardizing_transform,
+    standardizing_transform_zuko,
     z_score_parser,
 )
 from sbi.utils.torchutils import create_alternating_binary_mask
@@ -501,15 +501,12 @@ def build_zuko_maf(
             residual=residual,
         )
 
-    transforms: Union[Sequence[LazyTransform], LazyTransform]
-    transforms = maf.transform.transforms  # pyright: ignore[reportAssignmentType]
+    transforms = maf.transform
     z_score_x_bool, structured_x = z_score_parser(z_score_x)
     if z_score_x_bool:
-        # transforms = transforms
         transforms = (
-            *transforms,
-            # Ideally `standardizing_transform` would return a `LazyTransform` instead of ` AffineTransform | Unconditional`, maybe all three are compatible
-            standardizing_transform(batch_x, structured_x, backend="zuko"),  # pyright: ignore[reportAssignmentType]
+            transforms,
+            standardizing_transform_zuko(batch_x, structured_x),
         )
 
     z_score_y_bool, structured_y = z_score_parser(z_score_y)

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -180,12 +180,10 @@ def standardizing_transform(
         return transforms.AffineTransform(shift=-t_mean / t_std, scale=1 / t_std)
     elif backend == "zuko":
         return UnconditionalLazyTransform(
-            zuko.flows.Unconditional(
-                zuko.transforms.MonotonicAffineTransform,
-                shift=-t_mean / t_std,
-                scale=1 / t_std,
-                buffer=True,
-            )
+            zuko.transforms.MonotonicAffineTransform,
+            shift=-t_mean / t_std,
+            scale=1 / t_std,
+            buffer=True,
         )
 
     else:

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -148,7 +148,7 @@ def standardizing_transform(
     structured_dims: bool = False,
     min_std: float = 1e-14,
 ) -> transforms.AffineTransform:
-    """Builds standardizing transform
+    """Builds standardizing transform for nflows
 
     Args:
         batch_t: Batched tensor from which mean and std deviation (across
@@ -172,7 +172,7 @@ def standardizing_transform_zuko(
     structured_dims: bool = False,
     min_std: float = 1e-14,
 ) -> zuko.flows.LazyTransform:
-    """Builds standardizing transform
+    """Builds standardizing transform for Zuko flows
 
     Args:
         batch_t: Batched tensor from which mean and std deviation (across
@@ -201,6 +201,21 @@ def z_standardization(
     structured_dims: bool = False,
     min_std: float = 1e-14,
 ) -> [Tensor, Tensor]:
+    """Computes mean and standard deviation for z-scoring
+
+    Args:
+        batch_t: Batched tensor from which mean and std deviation (across
+            first dimension) are computed.
+        structured_dim: Whether data dimensions are structured (e.g., time-series,
+            images), which requires computing mean and std per sample first before
+            aggregating over samples for a single standardization mean and std for the
+            batch, or independent (default), which z-scores dimensions independently.
+        min_std:  Minimum value of the standard deviation to use when z-scoring to
+            avoid division by zero.
+
+    Returns:
+        Mean and standard deviation for z-scoring
+    """
     is_valid_t, *_ = handle_invalid_x(batch_t, True)
 
     if structured_dims:
@@ -218,6 +233,7 @@ def z_standardization(
         t_std = torch.std(batch_t[is_valid_t], dim=0)
         t_std[t_std < min_std] = min_std
 
+    # Return mean and std for z-scoring.
     return t_mean, t_std
 
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -15,7 +15,13 @@ import zuko
 from pyro.distributions import Empirical
 from torch import Tensor, ones, optim, zeros
 from torch import nn as nn
-from torch.distributions import Distribution, Independent, biject_to, constraints
+from torch.distributions import (
+    AffineTransform,
+    Distribution,
+    Independent,
+    biject_to,
+    constraints,
+)
 
 from sbi import utils as utils
 from sbi.sbi_types import TorchTransform
@@ -183,8 +189,8 @@ def standardizing_transform_zuko(
     """
     t_mean, t_std = z_standardization(batch_t, structured_dims, min_std)
     return UnconditionalLazyTransform(
-        zuko.transforms.MonotonicAffineTransform,
-        shift=-t_mean / t_std,
+        AffineTransform,
+        loc=-t_mean / t_std,
         scale=1 / t_std,
         buffer=True,
     )

--- a/sbi/utils/zukoutils.py
+++ b/sbi/utils/zukoutils.py
@@ -1,0 +1,18 @@
+from torch import Tensor
+from zuko.flows import LazyTransform, Unconditional
+from zuko.transforms import Transform
+
+
+# This is a temporary wrapper for the Unconditional class in zuko.
+# Avoids pyright error of zuko Flows requiring a LazyTransform as input.
+class UnconditionalLazyTransform(LazyTransform):
+    def __init__(self, unconditional: Unconditional):
+        super().__init__()
+        self.unconditional = unconditional
+
+    def forward(self, c: Tensor) -> Transform:
+        return self.unconditional.meta(
+            *self.unconditional._parameters.values(),
+            *self.unconditional._buffers.values(),
+            **self.unconditional.kwargs,
+        )

--- a/sbi/utils/zukoutils.py
+++ b/sbi/utils/zukoutils.py
@@ -1,18 +1,7 @@
-from torch import Tensor
 from zuko.flows import LazyTransform, Unconditional
-from zuko.transforms import Transform
 
 
 # This is a temporary wrapper for the Unconditional class in zuko.
 # Avoids pyright error of zuko Flows requiring a LazyTransform as input.
-class UnconditionalLazyTransform(LazyTransform):
-    def __init__(self, unconditional: Unconditional):
-        super().__init__()
-        self.unconditional = unconditional
-
-    def forward(self, c: Tensor) -> Transform:
-        return self.unconditional.meta(
-            *self.unconditional._parameters.values(),
-            *self.unconditional._buffers.values(),
-            **self.unconditional.kwargs,
-        )
+class UnconditionalLazyTransform(Unconditional, LazyTransform):
+    pass


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Currently, the z-scoring layer for zuko transforms uses the `Unconditional` class from zuko, however this throws a pyright error when creating zuko flows, as `Unconditional` does not inherit from `LazyTransform`, which is expected to be the class of all transforms in a zuko `Flow` object. Here we create a temporary workaround, and will also start an issue in zuko for this.

## Does this close any currently open issues?

Fixes #1074 


## Checklist


- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
