### PR TITLE
Remove helpers from tests, skip GPU tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,16 @@ def set_seed():
 @pytest.fixture(scope="session", autouse=True)
 def set_default_tensor_type():
     torch.set_default_tensor_type("torch.FloatTensor")
+
+
+# Pytest hook to skip GPU tests if no devices are available.
+def pytest_collection_modifyitems(config, items):
+    """Skip GPU tests if no devices are available."""
+    gpu_device_available = (
+        torch.cuda.is_available() or torch.backends.mps.is_available()
+    )
+    if not gpu_device_available:
+        skip_gpu = pytest.mark.skip(reason="No devices available")
+        for item in items:
+            if "gpu" in item.keywords:
+                item.add_marker(skip_gpu)

--- a/tests/ensemble_test.py
+++ b/tests/ensemble_test.py
@@ -13,11 +13,6 @@ from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 from tests.test_utils import check_c2st, get_dkl_gaussian_prior
 
 
@@ -34,13 +29,8 @@ def test_import_before_deprecation():
         prior_cov = eye(2)
         prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
 
-        prior, _, prior_returns_numpy = process_prior(prior)
-        simulator = process_simulator(
-            lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-            prior,
-            prior_returns_numpy,
-        )
-        check_sbi_inputs(simulator, prior)
+        def simulator(theta):
+            return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
         theta = prior.sample((num_simulations,))
         x = simulator(theta)
@@ -87,13 +77,8 @@ def test_c2st_posterior_ensemble_on_linearGaussian(inference_method, num_trials)
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     # train ensemble components
     posteriors = []

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -23,7 +23,6 @@ from sbi.utils import RestrictionEstimator
 from sbi.utils.sbiutils import handle_invalid_x
 from sbi.utils.user_input_checks import (
     check_sbi_inputs,
-    process_prior,
     process_simulator,
 )
 
@@ -100,8 +99,7 @@ def test_inference_with_nan_simulator(method: type, percent_nans: float):
         prior=prior,
     )
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(linear_gaussian_nan, prior, prior_returns_numpy)
+    simulator = process_simulator(linear_gaussian_nan, prior, False)
     check_sbi_inputs(simulator, prior)
     inference = method(prior=prior)
 
@@ -143,8 +141,7 @@ def test_inference_with_restriction_estimator():
         prior=prior,
     )
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(linear_gaussian_nan, prior, prior_returns_numpy)
+    simulator = process_simulator(linear_gaussian_nan, prior, False)
     check_sbi_inputs(simulator, prior)
     restriction_estimator = RestrictionEstimator(prior=prior)
     proposal = prior

--- a/tests/linearGaussian_mdn_test.py
+++ b/tests/linearGaussian_mdn_test.py
@@ -20,11 +20,6 @@ from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 from tests.test_utils import check_c2st
 
 
@@ -58,9 +53,6 @@ def mdn_inference_with_different_methods(method):
     def simulator(theta: Tensor) -> Tensor:
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
     inference = method(density_estimator="mdn")
 
     theta, x = simulate_for_sbi(simulator, prior, num_simulations)
@@ -108,9 +100,6 @@ def test_mdn_with_1D_uniform_prior():
     def simulator(theta: Tensor) -> Tensor:
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
     inference = SNPE(density_estimator="mdn")
 
     theta, x = simulate_for_sbi(simulator, prior, 100)

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -27,9 +27,7 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils import BoxUniform
 from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
     process_prior,
-    process_simulator,
 )
 
 from .test_utils import check_c2st, get_prob_outside_uniform_prior
@@ -58,9 +56,7 @@ def test_api_snle_multiple_trials_and_rounds_map(num_dim: int, prior_str: str):
     else:
         prior = BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    simulator = diagonal_linear_gaussian
     inference = SNLE(prior=prior, density_estimator="mdn", show_progress_bars=False)
 
     proposals = [prior]
@@ -112,18 +108,14 @@ def test_c2st_snl_on_linear_gaussian_different_dims(model_str="maf"):
         num_discarded_dims=discard_dims,
         num_samples=num_samples,
     )
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(
+
+    def simulator(theta):
+        return linear_gaussian(
             theta,
             likelihood_shift,
             likelihood_cov,
             num_discarded_dims=discard_dims,
-        ),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+        )
 
     density_estimator = likelihood_nn(model=model_str, num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
@@ -177,13 +169,8 @@ def test_c2st_and_map_snl_on_linearGaussian_different(
     else:
         prior = BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     density_estimator = likelihood_nn(model_str, num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
@@ -306,13 +293,8 @@ def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int):
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = SNLE(show_progress_bars=False)
 
@@ -375,13 +357,8 @@ def test_c2st_multi_round_snl_on_linearGaussian_vi(num_trials: int):
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = SNLE(show_progress_bars=False)
 
@@ -487,11 +464,7 @@ def test_api_snl_sampling_methods(
     # Thus, we would not like to run, e.g., VI with all init_strategies, but only once
     # (namely with `init_strategy=proposal`).
     if sample_with == "mcmc" or init_strategy == "proposal":
-        prior, _, prior_returns_numpy = process_prior(prior)
-        simulator = process_simulator(
-            diagonal_linear_gaussian, prior, prior_returns_numpy
-        )
-        check_sbi_inputs(simulator, prior)
+        simulator = diagonal_linear_gaussian
 
         inference = SNLE(show_progress_bars=False)
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -31,11 +31,6 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 from sbi.utils import RestrictedPrior, get_density_thresholder
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 
 from .sbiutils_test import conditional_of_mvn
 from .test_utils import (
@@ -80,13 +75,8 @@ def test_c2st_snpe_on_linearGaussian(snpe_method, num_dim: int, prior_str: str):
             num_samples=num_samples,
         )
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = snpe_method(prior, show_progress_bars=False)
 
@@ -181,13 +171,8 @@ def test_density_estimators_on_linearGaussian(density_estimator):
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = SNPE_C(prior, density_estimator=density_estimator)
 
@@ -234,18 +219,13 @@ def test_c2st_snpe_on_linearGaussian_different_dims(density_estimator="maf"):
         num_samples=num_samples,
     )
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(
+    def simulator(theta):
+        return linear_gaussian(
             theta,
             likelihood_shift,
             likelihood_cov,
             num_discarded_dims=discard_dims,
-        ),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+        )
 
     # Test whether prior can be `None`.
     inference = SNPE_C(
@@ -326,13 +306,8 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
     else:
         density_estimator = "maf"
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     creation_args = dict(
         prior=prior,
@@ -439,13 +414,8 @@ def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str):
     else:
         prior = utils.BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = SNPE_C(prior, show_progress_bars=False)
 
@@ -504,13 +474,8 @@ def test_api_force_first_round_loss(
     likelihood_cov = 0.3 * eye(num_dim)
     prior = utils.BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     inference = SNPE_C(prior, show_progress_bars=False)
 
@@ -562,10 +527,6 @@ def test_sample_conditional():
 
     # Test whether SNPE works properly with structured z-scoring.
     net = posterior_nn("maf", z_score_x="structured", hidden_features=20)
-
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
 
     inference = SNPE_C(prior, density_estimator=net, show_progress_bars=False)
 
@@ -693,9 +654,6 @@ def test_mdn_conditional_density(num_dim: int = 3, cond_dim: int = 1):
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
     inference = SNPE_C(density_estimator="mdn", show_progress_bars=False)
 
     theta, x = simulate_for_sbi(
@@ -732,13 +690,9 @@ def test_example_posterior(snpe_method: type):
 
     extra_kwargs = dict(final_round=True) if snpe_method == SNPE_A else dict()
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
     inference = snpe_method(prior, show_progress_bars=False)
 
     theta, x = simulate_for_sbi(

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -29,11 +29,6 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 from tests.test_utils import (
     check_c2st,
     get_dkl_gaussian_prior,
@@ -61,9 +56,7 @@ def test_api_snre_multiple_trials_and_rounds_map(
     num_simulations = 100
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    simulator = diagonal_linear_gaussian
     inference = snre_method(prior=prior, classifier="mlp", show_progress_bars=False)
 
     proposals = [prior]
@@ -112,15 +105,11 @@ def test_c2st_sre_on_linearGaussian(snre_method: RatioEstimator):
     prior_cov = eye(theta_dim)
     prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(
+    def simulator(theta):
+        return linear_gaussian(
             theta, likelihood_shift, likelihood_cov, num_discarded_dims=discard_dims
-        ),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+        )
+
     inference = snre_method(classifier="resnet", show_progress_bars=False)
 
     theta, x = simulate_for_sbi(
@@ -191,9 +180,6 @@ def test_c2st_snre_variants_on_linearGaussian_with_multiple_trials(
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
     kwargs = dict(
         classifier="resnet",
         show_progress_bars=False,
@@ -291,13 +277,9 @@ def test_c2st_multi_round_snr_on_linearGaussian_vi(
     )
     target_samples = gt_posterior.sample((num_samples,))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(
-        lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov),
-        prior,
-        prior_returns_numpy,
-    )
-    check_sbi_inputs(simulator, prior)
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
     inference = snre_method(show_progress_bars=False)
 
     theta, x = simulate_for_sbi(
@@ -393,9 +375,8 @@ def test_api_sre_sampling_methods(sampling_method: str, prior_str: str):
     else:
         prior = utils.BoxUniform(-ones(num_dim), ones(num_dim))
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    simulator = diagonal_linear_gaussian
+
     inference = SNRE_B(classifier="resnet", show_progress_bars=False)
 
     theta, x = simulate_for_sbi(

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -27,9 +27,7 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
     process_prior,
-    process_simulator,
 )
 from tests.test_utils import check_c2st
 
@@ -152,9 +150,8 @@ def test_getting_inference_diagnostics(method):
         Uniform(low=-ones(1), high=ones(1)),
     ]
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    prior, _, _ = process_prior(prior)
+    simulator = diagonal_linear_gaussian
     density_estimator = likelihood_nn("maf", num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
 

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -12,11 +12,6 @@ from torch.utils.tensorboard.writer import SummaryWriter
 from sbi.analysis import pairplot, plot_summary, sbc_rank_plot
 from sbi.inference import SNLE, SNPE, SNRE, simulate_for_sbi
 from sbi.utils import BoxUniform
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 
 
 @pytest.mark.parametrize("samples", (torch.randn(100, 2), [torch.randn(100, 2)] * 2))
@@ -39,12 +34,8 @@ def test_plot_summary(method, tmp_path):
 
     summary_writer = SummaryWriter(tmp_path)
 
-    def linear_gaussian(theta):
+    def simulator(theta):
         return theta + 1.0 + torch.randn_like(theta) * 0.1
-
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
 
     inference = method(prior=prior, summary_writer=summary_writer)
     theta, x = simulate_for_sbi(simulator, proposal=prior, num_simulations=6)

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -14,11 +14,6 @@ from sbi.inference import (
     simulate_for_sbi,
 )
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 
 
 @pytest.mark.parametrize("snpe_method", [SNPE_A, SNPE_C])
@@ -34,9 +29,7 @@ def test_log_prob_with_different_x(snpe_method: type, x_o_batch_dim: bool):
     num_dim = 2
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    simulator = diagonal_linear_gaussian
 
     inference = snpe_method(prior=prior)
     theta, x = simulate_for_sbi(simulator, prior, 1000)

--- a/tests/posterior_sampler_test.py
+++ b/tests/posterior_sampler_test.py
@@ -17,11 +17,6 @@ from sbi.inference import (
 )
 from sbi.samplers.mcmc import SliceSamplerSerial, SliceSamplerVectorized
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 
 
 @pytest.mark.parametrize(
@@ -51,9 +46,8 @@ def test_api_posterior_sampler_set(sampling_method: str, set_seed):
     num_chains = 3 if sampling_method in "slice_np_vectorized" else 1
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(diagonal_linear_gaussian, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
+    simulator = diagonal_linear_gaussian
+
     inference = SNL(prior, show_progress_bars=False)
 
     theta, x = simulate_for_sbi(

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -10,11 +10,6 @@ from torch import ones, zeros
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.utils.torchutils import BoxUniform
-from sbi.utils.user_input_checks import (
-    check_sbi_inputs,
-    process_prior,
-    process_simulator,
-)
 
 
 @pytest.mark.parametrize("num_sims", (0, 10))
@@ -32,9 +27,6 @@ def test_simulate_in_batches(
 ):
     """Test combinations of num_sims and simulation_batch_size."""
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    check_sbi_inputs(simulator, prior)
     theta = prior.sample((num_sims,))
     # run twice to check seeding.
     x1 = simulate_in_batches(simulator, theta, batch_size, seed=seed)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

- remove helper functions from tests when they are not needed
- add pytest hook to skip GPU tests when no devices are available: running `pytest tests/` locally without GPU will skip all `gpu` marked tests, i.e., act like `pytest -m "not gpu" tests/`

## Does this close any currently open issues?

Fixes #1093 #1098 