### PR TITLE
Fix issues pyright raises on newer Python versions

### DIFF
--- a/sbi/samplers/mcmc/slice_numpy.py
+++ b/sbi/samplers/mcmc/slice_numpy.py
@@ -10,6 +10,8 @@ import numpy as np
 import torch
 from joblib import Parallel, delayed
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import FigureBase
 from tqdm.auto import tqdm, trange
 
 from sbi.simulators.simutils import tqdm_joblib
@@ -134,8 +136,8 @@ class SliceSampler(MCMCSampler):
 
         # show trace plot
         if show_info:
-            fig: plt.FigureBase
-            ax: plt.Axes
+            fig: FigureBase
+            ax: Axes
             fig, ax = plt.subplots(1, 1)  # pyright: ignore[reportAssignmentType]
             ax.plot(L_trace)
             ax.set_ylabel("log probability")


### PR DESCRIPTION
Pyright raised errors in newer Python versions (e.g. 3.10) which it didn't do in our CI pipeline running on 3.8. First step towards #1102

## Checklist

- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.