### PR TITLE
ruff linting hook, fix line lengths.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
   rev: v0.3.3
   hooks:
     - id: ruff
-      args: [--diff]
     - id: ruff-format
       args: [--diff]
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
- ruff linting was not working during CI because of wrong `kwarg` `diff` (my bad). 
- too long line were pushed into `main` as a consequence. 

both fixed with this commit. 