### PR TITLE
fix errors in pymc sampler implementaton

### DIFF
--- a/sbi/samplers/mcmc/pymc_wrapper.py
+++ b/sbi/samplers/mcmc/pymc_wrapper.py
@@ -138,16 +138,15 @@ class PyMCSampler:
         self._device = device
 
         # create PyMC model object
-        track_gradients = step in (pymc.NUTS, pymc.HamiltonianMC)
+        track_gradients = step in ("nuts", "hmc")
         self._model = pymc.Model()
         potential = PyMCPotential(
             potential_fn, track_gradients=track_gradients, device=device
         )
         with self._model:
-            params = pymc.Normal(
-                self.param_name, mu=initvals.mean(axis=0)
-            )  # dummy prior
-            pymc.Potential("likelihood", potential(params))  # type: ignore
+            pymc.DensityDist(
+                self.param_name, logp=potential, size=(initvals.shape[-1],)
+            )
 
     def run(self) -> np.ndarray:
         """Run MCMC with PyMC


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
Two errors in `PyMCSampler` fixed here:
* check for whether gradient tracking needed in line 141 of `sbi.samplers.mcmc.pymc_wrapper` looked for matching step class instead of the string value actually used and expected
* `pymc.Model()` incorrectly set up using a prior distribution and additional likelihood term which does not result in the desired distribution. Now using `pymc.DensityDist` which directly defines the distribution using given potential function
With these changes `test_c2st_pymc_sampler_on_Gaussian` passes locally for all sampling methods.

## Does this close any currently open issues?

Fixes #1127 

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
