### PR TITLE
Fix zuko kwargs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,3 +32,4 @@ your code.
 - [ ] I performed linting and formatting as described in the [contribution
   guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
 - [ ] I rebased on `main` (or there are no conflicts with `main`)
+- [ ] For reviewer: The continuous deployment (CD) workflow are passing.

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -25,6 +25,8 @@ from sbi.utils.sbiutils import (
 from sbi.utils.torchutils import create_alternating_binary_mask
 from sbi.utils.user_input_checks import check_data_device, check_embedding_net_device
 
+nflow_specific_kwargs = ["num_bins", "num_components"]
+
 
 def get_numel(batch_x: Tensor, batch_y: Tensor, embedding_net) -> Tuple[int, int]:
     """
@@ -1039,6 +1041,9 @@ def build_zuko_flow(
     """
 
     x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+
+    # keep only zuko kwargs
+    kwargs = {k: v for k, v in kwargs.items() if k not in nflow_specific_kwargs}
 
     if isinstance(hidden_features, int):
         hidden_features = [hidden_features] * num_transforms


### PR DESCRIPTION
The slow test `tests/linearGaussian_snle_test.py::test_c2st_and_map_snl_on_linearGaussian_different` is failing because we are passing `nflows` related kwargs to the `zuko` flow builder. 

Excluding those kwargs fixes the problem. 