### PR TITLE
Give all DensityEstimators an input_shape

### DIFF
--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -142,7 +142,7 @@ class MCABC(ABCBASE):
         x = simulator(theta)
 
         # Infer shape of x to test and set x_o.
-        self.x_shape = x[0].unsqueeze(0).shape
+        self.x_shape = x[0].shape
         self.x_o = process_x(x_o, self.x_shape)
 
         distances = self.distance(self.x_o, x)

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -330,7 +330,7 @@ class SMCABC(ABCBASE):
         x = self._simulate_with_budget(theta)
 
         # Infer x shape to test and set x_o.
-        self.x_shape = x[0].unsqueeze(0).shape
+        self.x_shape = x[0].shape
         self.x_o = process_x(x_o, self.x_shape)
 
         distances = self.distance(self.x_o, x)

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -4,6 +4,7 @@
 import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional, Union
+from warnings import warn
 
 import torch
 import torch.distributions.transforms as torch_tf
@@ -42,8 +43,15 @@ class NeuralPosterior(ABC):
                 Allows to perform, e.g. MCMC in unconstrained space.
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
-            x_shape: Shape of the observed data.
+            x_shape: Deprecated, should not be passed.
         """
+        if x_shape is not None:
+            warn(
+                "x_shape is not None. However, passing x_shape to the `Posterior` is "
+                "deprecated and will be removed in a future release of `sbi`.",
+                stacklevel=2,
+            )
+
         if not isinstance(potential_fn, BasePotential):
             kwargs_of_callable = list(inspect.signature(potential_fn).parameters.keys())
             for key in ["theta", "x_o"]:
@@ -74,7 +82,6 @@ class NeuralPosterior(ABC):
 
         self._map = None
         self._purpose = ""
-        self._x_shape = x_shape
 
         # If the sampler interface (#573) is used, the user might have passed `x_o`
         # already to the potential function builder. If so, this `x_o` will be used
@@ -146,7 +153,7 @@ class NeuralPosterior(ABC):
             `NeuralPosterior` that will use a default `x` when not explicitly passed.
         """
         self._x = process_x(
-            x, x_shape=self._x_shape, allow_iid_x=self.potential_fn.allow_iid_x
+            x, x_event_shape=None, allow_iid_x=self.potential_fn.allow_iid_x
         ).to(self._device)
         self._map = None
         return self
@@ -156,7 +163,7 @@ class NeuralPosterior(ABC):
             # New x, reset posterior sampler.
             self._posterior_sampler = None
             return process_x(
-                x, x_shape=self._x_shape, allow_iid_x=self.potential_fn.allow_iid_x
+                x, x_event_shape=None, allow_iid_x=self.potential_fn.allow_iid_x
             )
         elif self.default_x is None:
             raise ValueError(

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -96,7 +96,7 @@ class EnsemblePosterior(NeuralPosterior):
             potential_fn=potential_fn,
             theta_transform=theta_transform,
             device=device,
-            x_shape=self.posteriors[0]._x_shape,
+            x_shape=None,
         )
 
     def ensure_same_device(self, posteriors: List) -> str:
@@ -242,9 +242,7 @@ class EnsemblePosterior(NeuralPosterior):
             `EnsemblePosterior` that will use a default `x` when not explicitly
             passed.
         """
-        self._x = process_x(
-            x, x_shape=self._x_shape, allow_iid_x=self.potential_fn.allow_iid_x
-        ).to(self._device)
+        self._x = x.to(self._device)
 
         for posterior in self.posteriors:
             posterior.set_default_x(x)

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -52,8 +52,7 @@ class ImportanceSamplingPosterior(NeuralPosterior):
                 proposal at every iteration.
             device: Device on which to sample, e.g., "cpu", "cuda" or "cuda:0". If
                 None, `potential_fn.device` is used.
-            x_shape: Shape of a single simulator output. If passed, it is used to check
-                the shape of the observed data and give a descriptive error.
+            x_shape: Deprecated, should not be passed.
         """
         super().__init__(
             potential_fn,

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -98,8 +98,7 @@ class MCMCPosterior(NeuralPosterior):
                 (e.g. Linux and macOS, not Windows).
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
-            x_shape: Shape of a single simulator output. If passed, it is used to check
-                the shape of the observed data and give a descriptive error.
+            x_shape: Deprecated, should not be passed.
         """
         if method == "slice":
             warn(

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -49,8 +49,7 @@ class RejectionPosterior(NeuralPosterior):
             m: Multiplier to the `potential_fn / proposal` ratio.
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
-            x_shape: Shape of a single simulator output. If passed, it is used to check
-                the shape of the observed data and give a descriptive error.
+            x_shape: Deprecated, should not be passed.
         """
         super().__init__(
             potential_fn,

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -91,8 +91,7 @@ class VIPosterior(NeuralPosterior):
                 typically cover all modes (`fKL`, `IW`, `alpha` for alpha < 1).
             device: Training device, e.g., `cpu`, `cuda` or `cuda:0`. We will ensure
                 that all other objects are also on this device.
-            x_shape: Shape of a single simulator output. If passed, it is used to check
-                the shape of the observed data and give a descriptive error.
+            x_shape: Deprecated, should not be passed.
             parameters: List of parameters of the variational posterior. This is only
                 required for user-defined q i.e. if q does not have a `parameters`
                 attribute.

--- a/sbi/inference/snle/mnle.py
+++ b/sbi/inference/snle/mnle.py
@@ -171,7 +171,6 @@ class MNLE(LikelihoodEstimator):
                 proposal=prior,
                 method=mcmc_method,
                 device=device,
-                x_shape=self._x_shape,
                 **mcmc_parameters or {},
             )
         elif sample_with == "rejection":
@@ -179,7 +178,6 @@ class MNLE(LikelihoodEstimator):
                 potential_fn=potential_fn,
                 proposal=prior,
                 device=device,
-                x_shape=self._x_shape,
                 **rejection_sampling_parameters or {},
             )
         elif sample_with == "vi":
@@ -189,7 +187,6 @@ class MNLE(LikelihoodEstimator):
                 prior=prior,  # type: ignore
                 vi_method=vi_method,
                 device=device,
-                x_shape=self._x_shape,
                 **vi_parameters or {},
             )
         else:
@@ -209,6 +206,8 @@ class MNLE(LikelihoodEstimator):
         Returns:
             Negative log prob.
         """
-        theta = reshape_to_batch_event(theta, event_shape=theta.shape[1:])
-        x = reshape_to_sample_batch_event(x, event_shape=self._x_shape[1:])
+        theta = reshape_to_batch_event(
+            theta, event_shape=self._neural_net.condition_shape
+        )
+        x = reshape_to_sample_batch_event(x, event_shape=self._neural_net.input_shape)
         return -self._neural_net.log_prob(x, condition=theta)

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -399,7 +399,7 @@ class SNPE_A_MDN(DensityEstimator):
         """
         # Call nn.Module's constructor.
 
-        super().__init__(flow, flow._condition_shape)
+        super().__init__(flow, flow.input_shape, flow.condition_shape)
 
         self._neural_net = flow
         self._prior = prior
@@ -480,7 +480,7 @@ class SNPE_A_MDN(DensityEstimator):
             # \tilde{p} has already been observed. To analytically calculate the
             # log-prob of the Gaussian, we first need to compute the mixture components.
             num_samples = torch.Size(sample_shape).numel()
-            condition_ndim = len(self._condition_shape)
+            condition_ndim = len(self.condition_shape)
             batch_size = condition.shape[:-condition_ndim]
             batch_size = torch.Size(batch_size).numel()
             return self._sample_approx_posterior_mog(num_samples, condition, batch_size)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -355,7 +355,9 @@ class SNPE_C(PosteriorEstimator):
         atomic_theta = reshape_to_sample_batch_event(
             atomic_theta, atomic_theta.shape[1:]
         )
-        repeated_x = reshape_to_batch_event(repeated_x, self._x_shape[1:])
+        repeated_x = reshape_to_batch_event(
+            repeated_x, self._neural_net.condition_shape
+        )
         log_prob_posterior = self._neural_net.log_prob(atomic_theta, repeated_x)
         utils.assert_all_finite(log_prob_posterior, "posterior eval")
         log_prob_posterior = log_prob_posterior.reshape(batch_size, num_atoms)
@@ -371,8 +373,8 @@ class SNPE_C(PosteriorEstimator):
 
         # XXX This evaluates the posterior on _all_ prior samples
         if self._use_combined_loss:
-            theta = reshape_to_sample_batch_event(theta, theta.shape[1:])
-            x = reshape_to_batch_event(x, self._x_shape[1:])
+            theta = reshape_to_sample_batch_event(theta, self._neural_net.input_shape)
+            x = reshape_to_batch_event(x, self._neural_net.condition_shape)
             log_prob_posterior_non_atomic = self._neural_net.log_prob(theta, x)
             # squeeze to remove sample dimension, which is always one during the loss
             # evaluation of `SNPE_C` (because we have one theta vector per x vector).

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -384,7 +384,6 @@ class RatioEstimator(NeuralInference, ABC):
                 proposal=prior,
                 method=mcmc_method,
                 device=device,
-                x_shape=self._x_shape,
                 **mcmc_parameters or {},
             )
         elif sample_with == "rejection":
@@ -392,7 +391,6 @@ class RatioEstimator(NeuralInference, ABC):
                 potential_fn=potential_fn,
                 proposal=prior,
                 device=device,
-                x_shape=self._x_shape,
                 **rejection_sampling_parameters or {},
             )
         elif sample_with == "vi":
@@ -402,7 +400,6 @@ class RatioEstimator(NeuralInference, ABC):
                 prior=prior,  # type: ignore
                 vi_method=vi_method,
                 device=device,
-                x_shape=self._x_shape,
                 **vi_parameters or {},
             )
         else:

--- a/sbi/neural_nets/categorial.py
+++ b/sbi/neural_nets/categorial.py
@@ -9,8 +9,8 @@ from sbi.neural_nets.density_estimators import CategoricalMassEstimator, Categor
 
 
 def build_categoricalmassestimator(
-    input: Tensor,
-    condition: Tensor,
+    batch_x: Tensor,
+    batch_y: Tensor,
     num_hidden: int = 20,
     num_layers: int = 2,
     embedding_net: Optional[nn.Module] = None,
@@ -18,17 +18,19 @@ def build_categoricalmassestimator(
     """Returns a density estimator for a categorical random variable."""
     # Infer input and output dims.
     if embedding_net is None:
-        dim_input = condition[0].numel()
+        dim_condition = batch_y[0].numel()
     else:
-        dim_input = embedding_net(condition[:1]).numel()
-    num_categories = unique(input).numel()
+        dim_condition = embedding_net(batch_y[:1]).numel()
+    num_categories = unique(batch_x).numel()
 
     categorical_net = CategoricalNet(
-        num_input=dim_input,
+        num_input=dim_condition,
         num_categories=num_categories,
         num_hidden=num_hidden,
         num_layers=num_layers,
         embedding_net=embedding_net,
     )
 
-    return CategoricalMassEstimator(categorical_net)
+    return CategoricalMassEstimator(
+        categorical_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -19,17 +19,22 @@ class DensityEstimator(nn.Module):
 
     """
 
-    def __init__(self, net: nn.Module, condition_shape: torch.Size) -> None:
+    def __init__(
+        self, net: nn.Module, input_shape: torch.Size, condition_shape: torch.Size
+    ) -> None:
         r"""Base class for density estimators.
 
         Args:
             net: Neural network.
+            input_shape: Event shape of the input at which the density is being
+                evaluated (and which is also the event_shape of samples).
             condition_shape: Shape of the condition. If not provided, it will assume a
-                            1D input.
+                1D input.
         """
         super().__init__()
         self.net = net
-        self._condition_shape = condition_shape
+        self.input_shape = input_shape
+        self.condition_shape = condition_shape
 
     @property
     def embedding_net(self) -> Optional[nn.Module]:
@@ -136,17 +141,17 @@ class DensityEstimator(nn.Module):
             ValueError: If the shape of the condition does not match the expected
                         input dimensionality.
         """
-        if len(condition.shape) < len(self._condition_shape):
+        if len(condition.shape) < len(self.condition_shape):
             raise ValueError(
                 f"Dimensionality of condition is to small and does not match the\
-                expected input dimensionality {len(self._condition_shape)}, as provided\
+                expected input dimensionality {len(self.condition_shape)}, as provided\
                 by condition_shape."
             )
         else:
-            condition_shape = condition.shape[-len(self._condition_shape) :]
-            if tuple(condition_shape) != tuple(self._condition_shape):
+            condition_shape = condition.shape[-len(self.condition_shape) :]
+            if tuple(condition_shape) != tuple(self.condition_shape):
                 raise ValueError(
                     f"Shape of condition {tuple(condition_shape)} does not match the \
-                    expected input dimensionality {tuple(self._condition_shape)}, as \
+                    expected input dimensionality {tuple(self.condition_shape)}, as \
                     provided by condition_shape. Please reshape it accordingly."
                 )

--- a/sbi/neural_nets/density_estimators/categorical_net.py
+++ b/sbi/neural_nets/density_estimators/categorical_net.py
@@ -113,8 +113,12 @@ class CategoricalMassEstimator(DensityEstimator):
     The event_shape of this class is `()`.
     """
 
-    def __init__(self, net: CategoricalNet) -> None:
-        super().__init__(net=net, condition_shape=torch.Size([]))
+    def __init__(
+        self, net: CategoricalNet, input_shape: torch.Size, condition_shape: torch.Size
+    ) -> None:
+        super().__init__(
+            net=net, input_shape=input_shape, condition_shape=condition_shape
+        )
         self.net = net
         self.num_categories = net.num_categories
 

--- a/sbi/neural_nets/density_estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/density_estimators/mixed_density_estimator.py
@@ -26,6 +26,7 @@ class MixedDensityEstimator(DensityEstimator):
         self,
         discrete_net: CategoricalMassEstimator,
         continuous_net: NFlowsFlow,
+        input_shape: torch.Size,
         condition_shape: torch.Size,
         log_transform_input: bool = False,
     ):
@@ -34,12 +35,16 @@ class MixedDensityEstimator(DensityEstimator):
         Args:
             discrete_net: neural net to model discrete part of the data.
             continuous_net: neural net to model the continuous data.
+            input_shape: Event shape of the input at which the density is being
+                evaluated (and which is also the event_shape of samples).
+            condition_shape: Shape of the condition. If not provided, it will assume a
+                1D input.
             log_transform_input: whether to transform the continous part of the data
                 into logarithmic domain before training. This is helpful for bounded
                 data, e.g.,for reaction times.
         """
         super(MixedDensityEstimator, self).__init__(
-            net=continuous_net, condition_shape=condition_shape
+            net=continuous_net, input_shape=input_shape, condition_shape=condition_shape
         )
 
         self.discrete_net = discrete_net

--- a/sbi/neural_nets/density_estimators/zuko_flow.py
+++ b/sbi/neural_nets/density_estimators/zuko_flow.py
@@ -16,17 +16,25 @@ class ZukoFlow(DensityEstimator):
     """
 
     def __init__(
-        self, net: Flow, embedding_net: nn.Module, condition_shape: torch.Size
+        self,
+        net: Flow,
+        embedding_net: nn.Module,
+        input_shape: torch.Size,
+        condition_shape: torch.Size,
     ):
         r"""Initialize the density estimator.
 
         Args:
             flow: Flow object.
-            condition_shape: Shape of the condition.
+            input_shape: Event shape of the input at which the density is being
+                evaluated (and which is also the event_shape of samples).
+            condition_shape: Event shape of the condition.
         """
 
         # assert len(condition_shape) == 1, "Zuko Flows require 1D conditions."
-        super().__init__(net=net, condition_shape=condition_shape)
+        super().__init__(
+            net=net, input_shape=input_shape, condition_shape=condition_shape
+        )
         self._embedding_net = embedding_net
 
     @property
@@ -67,7 +75,7 @@ class ZukoFlow(DensityEstimator):
         """
 
         self._check_condition_shape(condition)
-        condition_dims = len(self._condition_shape)
+        condition_dims = len(self.condition_shape)
 
         # PyTorch's automatic broadcasting
         batch_shape_in = input.shape[:-1]

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -117,7 +117,9 @@ def build_made(
     )
 
     neural_net = flows.Flow(transform, distribution, embedding_net)
-    flow = NFlowsFlow(neural_net, condition_shape=batch_y[0].shape)
+    flow = NFlowsFlow(
+        neural_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )
 
     return flow
 
@@ -197,7 +199,9 @@ def build_maf(
 
     distribution = get_base_dist(x_numel, **kwargs)
     neural_net = flows.Flow(transform, distribution, embedding_net)
-    flow = NFlowsFlow(neural_net, condition_shape=batch_y[0].shape)
+    flow = NFlowsFlow(
+        neural_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )
 
     return flow
 
@@ -301,7 +305,9 @@ def build_maf_rqs(
 
     distribution = get_base_dist(x_numel, **kwargs)
     neural_net = flows.Flow(transform, distribution, embedding_net)
-    flow = NFlowsFlow(neural_net, condition_shape=batch_y[0].shape)
+    flow = NFlowsFlow(
+        neural_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )
 
     return flow
 
@@ -419,7 +425,9 @@ def build_nsf(
     # Combine transforms.
     transform = transforms.CompositeTransform(transform_list)
     neural_net = flows.Flow(transform, distribution, embedding_net)
-    flow = NFlowsFlow(neural_net, condition_shape=batch_y[0].shape)
+    flow = NFlowsFlow(
+        neural_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )
 
     return flow
 
@@ -1104,7 +1112,12 @@ def build_zuko_flow(
         # Combine transforms.
         neural_net = zuko.flows.Flow(transforms, flow_built.base)
 
-    flow = ZukoFlow(neural_net, embedding_net, condition_shape=batch_y[0].shape)
+    flow = ZukoFlow(
+        neural_net,
+        embedding_net,
+        input_shape=batch_x[0].shape,
+        condition_shape=batch_y[0].shape,
+    )
 
     return flow
 

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -82,6 +82,8 @@ def build_mdn(
     )
 
     neural_net = flows.Flow(transform, distribution, embedding_net)
-    flow = NFlowsFlow(neural_net, condition_shape=batch_y[0].shape)
+    flow = NFlowsFlow(
+        neural_net, input_shape=batch_x[0].shape, condition_shape=batch_y[0].shape
+    )
 
     return flow

--- a/sbi/neural_nets/mnle.py
+++ b/sbi/neural_nets/mnle.py
@@ -90,5 +90,6 @@ def build_mnle(
         discrete_net=disc_nle,
         continuous_net=cont_nle,
         log_transform_input=log_transform_x,
-        condition_shape=torch.Size([]),
+        input_shape=batch_x[0].shape,
+        condition_shape=batch_y[0].shape,
     )

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -183,13 +183,13 @@ def test_process_prior(prior):
 @pytest.mark.parametrize(
     "x, x_shape, allow_iid",
     (
-        (ones(3), torch.Size([1, 3]), False),
-        (ones(1, 3), torch.Size([1, 3]), False),
-        (ones(10, 3), torch.Size([1, 10, 3]), False),  # 2D data / iid SNPE
+        (ones(3), torch.Size([3]), False),
+        (ones(1, 3), torch.Size([3]), False),
+        (ones(10, 3), torch.Size([10, 3]), False),  # 2D data / iid SNPE
         pytest.param(
             ones(10, 3), None, False, marks=pytest.mark.xfail
         ),  # 2D data / iid SNPE without x_shape
-        (ones(10, 10), torch.Size([1, 10]), True),  # iid likelihood based
+        (ones(10, 10), torch.Size([10]), True),  # iid likelihood based
     ),
 )
 def test_process_x(x, x_shape, allow_iid):


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Closes #1135 

Does the following things:
- introduce `input_shape` to the `DensityEstimator`
- the `inference` classes uses the `input_shape` and `condition_shape` of the `DensityEstimator` to infer `._x_shape`. `inference._x_shape` no longer contains a batch dimension.
- the posterior no longer performs checks for `x_shape`. These checks should be fully handled by the `DensityEstimator`.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
- [ ] For reviewer: The continuous deployment (CD) workflow are passing.
