### PR TITLE
DensityEstimator.loss does not take `sample_dim`

### DIFF
--- a/sbi/inference/snle/mnle.py
+++ b/sbi/inference/snle/mnle.py
@@ -5,16 +5,11 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
-from torch import Tensor
 from torch.distributions import Distribution
 
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import mixed_likelihood_estimator_based_potential
 from sbi.inference.snle.snle_base import LikelihoodEstimator
-from sbi.neural_nets.density_estimators.shape_handling import (
-    reshape_to_batch_event,
-    reshape_to_sample_batch_event,
-)
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
 from sbi.utils import check_prior, del_entries
@@ -196,18 +191,3 @@ class MNLE(LikelihoodEstimator):
         self._model_bank.append(deepcopy(self._posterior))
 
         return deepcopy(self._posterior)
-
-    # Temporary: need to rewrite mixed likelihood estimators as DensityEstimator
-    # objects.
-    # TODO: Fix and merge issue #968
-    def _loss(self, theta: Tensor, x: Tensor) -> Tensor:
-        r"""Return loss for SNLE, which is the likelihood of $-\log q(x_i | \theta_i)$.
-
-        Returns:
-            Negative log prob.
-        """
-        theta = reshape_to_batch_event(
-            theta, event_shape=self._neural_net.condition_shape
-        )
-        x = reshape_to_sample_batch_event(x, event_shape=self._neural_net.input_shape)
-        return -self._neural_net.log_prob(x, condition=theta)

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -18,7 +18,6 @@ from sbi.inference.potentials import likelihood_estimator_based_potential
 from sbi.neural_nets import DensityEstimator, likelihood_nn
 from sbi.neural_nets.density_estimators.shape_handling import (
     reshape_to_batch_event,
-    reshape_to_sample_batch_event,
 )
 from sbi.utils import check_estimator_arg, check_prior, x_shape_from_simulation
 
@@ -369,7 +368,5 @@ class LikelihoodEstimator(NeuralInference, ABC):
         theta = reshape_to_batch_event(
             theta, event_shape=self._neural_net.condition_shape
         )
-        x = reshape_to_sample_batch_event(
-            x, event_shape=self._neural_net.input_shape, leading_is_sample=False
-        )
+        x = reshape_to_batch_event(x, event_shape=self._neural_net.input_shape)
         return self._neural_net.loss(x, condition=theta)

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -578,7 +578,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                 distribution different from the prior.
         """
         if self._round == 0 or force_first_round_loss:
-            theta = reshape_to_sample_batch_event(
+            theta = reshape_to_batch_event(
                 theta, event_shape=self._neural_net.input_shape
             )
             x = reshape_to_batch_event(x, event_shape=self._neural_net.condition_shape)

--- a/sbi/neural_nets/density_estimators/base.py
+++ b/sbi/neural_nets/density_estimators/base.py
@@ -47,28 +47,15 @@ class DensityEstimator(nn.Module):
 
         Args:
             input: Inputs to evaluate the log probability on of shape
-                    (*batch_shape1, input_size).
-            condition: Conditions of shape (*batch_shape2, *condition_shape).
+                    `(sample_dim_input, batch_dim_input, *event_shape_input)`.
+            condition: Conditions of shape
+                `(batch_dim_condition, *event_shape_condition)`.
 
         Raises:
-            RuntimeError: If batch_shape1 and batch_shape2 are not broadcastable.
+            RuntimeError: If batch_dim_input and batch_dim_condition do not match.
 
         Returns:
             Sample-wise log probabilities.
-
-        Note:
-            This function should support PyTorch's automatic broadcasting. This means
-            the function should behave as follows for different input and condition
-            shapes:
-            - (input_size,) + (batch_size,*condition_shape) -> (batch_size,)
-            - (batch_size, input_size) + (*condition_shape) -> (batch_size,)
-            - (batch_size, input_size) + (batch_size, *condition_shape) -> (batch_size,)
-            - (batch_size1, input_size) + (batch_size2, *condition_shape)
-                                                  -> RuntimeError i.e. not broadcastable
-            - (batch_size1,1, input_size) + (batch_size2, *condition_shape)
-                                                  -> (batch_size1,batch_size2)
-            - (batch_size1, input_size) + (batch_size2,1, *condition_shape)
-                                                  -> (batch_size2,batch_size1)
         """
 
         raise NotImplementedError
@@ -77,11 +64,12 @@ class DensityEstimator(nn.Module):
         r"""Return the loss for training the density estimator.
 
         Args:
-            input: Inputs to evaluate the loss on of shape (batch_size, input_size).
-            condition: Conditions of shape (batch_size, *condition_shape).
+            input: Inputs to evaluate the loss on of shape
+                `(batch_dim, *input_event_shape)`.
+            condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
         Returns:
-            Loss of shape (batch_size,)
+            Loss of shape (batch_dim,)
         """
 
         raise NotImplementedError
@@ -91,17 +79,10 @@ class DensityEstimator(nn.Module):
 
         Args:
             sample_shape: Shape of the samples to return.
-            condition: Conditions of shape (*batch_shape, *condition_shape).
+            condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
         Returns:
-            Samples of shape (*batch_shape, *sample_shape, input_size).
-
-        Note:
-            This function should support batched conditions and should admit the
-            following behavior for different condition shapes:
-            - (*condition_shape) -> (*sample_shape, input_size)
-            - (*batch_shape, *condition_shape)
-                                        -> (*batch_shape, *sample_shape, input_size)
+            Samples of shape (*sample_shape, batch_dim, *event_shape_input).
         """
 
         raise NotImplementedError
@@ -113,11 +94,10 @@ class DensityEstimator(nn.Module):
 
         Args:
             sample_shape: Shape of the samples to return.
-            condition: Conditions of shape (*batch_shape, *condition_shape).
+            condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
         Returns:
             Samples and associated log probabilities.
-
 
         Note:
             For some density estimators, computing log_probs for samples is
@@ -133,7 +113,7 @@ class DensityEstimator(nn.Module):
         r"""This method checks whether the condition has the correct shape.
 
         Args:
-            condition: Conditions of shape (*batch_shape, *condition_shape).
+            condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
         Raises:
             ValueError: If the condition has a dimensionality that does not match

--- a/sbi/neural_nets/density_estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/density_estimators/mixed_density_estimator.py
@@ -162,7 +162,16 @@ class MixedDensityEstimator(DensityEstimator):
         return log_probs_combined
 
     def loss(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
-        return self.log_prob(input, condition)
+        r"""Return the loss for training the density estimator.
+
+        Args:
+            input: Inputs of shape `(batch_dim, *input_event_shape)`.
+            condition: Conditions of shape `(batch_dim, *condition_event_shape)`.
+
+        Returns:
+            Loss of shape `(batch_dim,)`
+        """
+        return -self.log_prob(input.unsqueeze(0), condition)[0]
 
     def log_prob_iid(self, input: Tensor, condition: Tensor) -> Tensor:
         """Return logprob given a batch of iid input and a different batch of condition.

--- a/sbi/neural_nets/density_estimators/nflows_flow.py
+++ b/sbi/neural_nets/density_estimators/nflows_flow.py
@@ -52,20 +52,6 @@ class NFlowsFlow(DensityEstimator):
 
         Returns:
             noise: Transformed inputs.
-
-        Note:
-            This function should support PyTorch's automatic broadcasting. This means
-            the function should behave as follows for different input and condition
-            shapes:
-            - (input_size,) + (batch_size,*condition_shape) -> (batch_size,)
-            - (batch_size, input_size) + (*condition_shape) -> (batch_size,)
-            - (batch_size, input_size) + (batch_size, *condition_shape) -> (batch_size,)
-            - (batch_size1, input_size) + (batch_size2, *condition_shape)
-                                                  -> RuntimeError i.e. not broadcastable
-            - (batch_size1,1, input_size) + (batch_size2, *condition_shape)
-                                                  -> (batch_size1,batch_size2)
-            - (batch_size1, input_size) + (batch_size2,1, *condition_shape)
-                                                  -> (batch_size2,batch_size1)
         """
         self._check_condition_shape(condition)
         condition_dims = len(self.condition_shape)
@@ -121,17 +107,16 @@ class NFlowsFlow(DensityEstimator):
         return log_probs.reshape((input_sample_dim, input_batch_dim))
 
     def loss(self, input: Tensor, condition: Tensor) -> Tensor:
-        r"""Return the loss for training the density estimator.
+        r"""Return the negative log-probability for training the density estimator.
 
         Args:
-            input: Inputs to evaluate the loss on of shape
-                `(sample_dim, batch_dim, *event_shape)`.
-            condition: Conditions of shape `(sample_dim, batch_dim, *event_dim)`.
+            input: Inputs of shape `(batch_dim, *input_event_shape)`.
+            condition: Conditions of shape `(batch_dim, *condition_event_shape)`.
 
         Returns:
-            Negative log_probability of shape `(input_sample_dim, condition_batch_dim)`.
+            Negative log-probability of shape `(batch_dim,)`.
         """
-        return -self.log_prob(input, condition)
+        return -self.log_prob(input.unsqueeze(0), condition)[0]
 
     def sample(self, sample_shape: Shape, condition: Tensor) -> Tensor:
         r"""Return samples from the density estimator.

--- a/sbi/neural_nets/density_estimators/zuko_flow.py
+++ b/sbi/neural_nets/density_estimators/zuko_flow.py
@@ -121,18 +121,17 @@ class ZukoFlow(DensityEstimator):
         return log_probs
 
     def loss(self, input: Tensor, condition: Tensor) -> Tensor:
-        r"""Return the loss for training the density estimator.
+        r"""Return the negative log-probability for training the density estimator.
 
         Args:
-            input: Inputs to evaluate the loss on of shape
-                `(sample_dim, batch_dim, *event_shape)`.
-            condition: Conditions of shape `(sample_dim, batch_dim, *event_dim)`.
+            input: Inputs of shape `(batch_dim, *input_event_shape)`.
+            condition: Conditions of shape `(batch_dim, *condition_event_shape)`.
 
         Returns:
-            Negative log_probability of shape `(input_sample_dim, condition_batch_dim)`.
+            Negative log-probability of shape `(batch_dim,)`.
         """
 
-        return -self.log_prob(input, condition)
+        return -self.log_prob(input.unsqueeze(0), condition)[0]
 
     def sample(self, sample_shape: Shape, condition: Tensor) -> Tensor:
         r"""Return samples from the density estimator.

--- a/tests/density_estimator_test.py
+++ b/tests/density_estimator_test.py
@@ -150,8 +150,8 @@ def test_density_estimator_loss_shapes(
         input_sample_dim,
     )
 
-    losses = density_estimator.loss(inputs, condition=conditions)
-    assert losses.shape == (input_sample_dim, batch_dim)
+    losses = density_estimator.loss(inputs[0], condition=conditions)
+    assert losses.shape == (batch_dim,)
 
 
 @pytest.mark.parametrize(
@@ -193,8 +193,8 @@ def test_density_estimator_log_prob_shapes_with_embedding(
         input_sample_dim,
     )
 
-    losses = density_estimator.log_prob(inputs, condition=conditions)
-    assert losses.shape == (input_sample_dim, batch_dim)
+    log_probs = density_estimator.log_prob(inputs, condition=conditions)
+    assert log_probs.shape == (input_sample_dim, batch_dim)
 
 
 @pytest.mark.parametrize(
@@ -228,7 +228,7 @@ def test_density_estimator_sample_shapes(
     condition_event_shape,
     batch_dim,
 ):
-    """Test whether `loss` of DensityEstimators follow the shape convention."""
+    """Test whether `sample` of DensityEstimators follow the shape convention."""
     density_estimator, _, conditions = _build_density_estimator_and_tensors(
         density_estimator_build_fn, input_event_shape, condition_event_shape, batch_dim
     )
@@ -264,13 +264,13 @@ def test_density_estimator_sample_shapes(
 @pytest.mark.parametrize("input_event_shape", ((1,), (4,)))
 @pytest.mark.parametrize("condition_event_shape", ((1,), (7,)))
 @pytest.mark.parametrize("batch_dim", (1, 10))
-def test_correctness_of_density_estimator_loss(
+def test_correctness_of_density_estimator_log_prob(
     density_estimator_build_fn,
     input_event_shape,
     condition_event_shape,
     batch_dim,
 ):
-    """Test whether identical inputs lead to identical loss values."""
+    """Test whether identical inputs lead to identical log_prob values."""
     input_sample_dim = 2
     density_estimator, inputs, condition = _build_density_estimator_and_tensors(
         density_estimator_build_fn,
@@ -279,8 +279,8 @@ def test_correctness_of_density_estimator_loss(
         batch_dim,
         input_sample_dim,
     )
-    losses = density_estimator.loss(inputs, condition=condition)
-    assert torch.allclose(losses[0, :], losses[1, :])
+    log_probs = density_estimator.log_prob(inputs, condition=condition)
+    assert torch.allclose(log_probs[0, :], log_probs[1, :])
 
 
 def _build_density_estimator_and_tensors(


### PR DESCRIPTION
In #1066, we had defined that `log_prob` and `loss` have the same input and output shapes:
```
density_estimator.log_prob(input, condition)
```
```
input: (sample_input, batch_input, *event_shape_input)
condition: (batch_condition, *event_shape_condition)
returns: (sample_input, batch_input)
raises: batch_input != batch_condition
```

However, for `.loss`, we are now removing the `sample_dim`. Therefore, the `.loss` function now has the following signature:
```
input: (batch_input, *event_shape_input)
condition: (batch_condition, *event_shape_condition)
returns: (batch_input)
raises: batch_input != batch_condition
```

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
- [x] For reviewer: The continuous deployment (CD) workflow are passing.
