### PR TITLE
MTN better split the linting process from the CI/CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,18 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre-commit:
-    name: ruff and hooks.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files --show-diff-on-failure
-
   cd:
     name: CD
     runs-on: ubuntu-latest
@@ -53,10 +41,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-
-    - name: Check types with pyright
-      run: |
-        pyright sbi
 
     - name: Run the fast and the slow CPU tests with coverage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre-commit:
-    name: ruff and hooks.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files --show-diff-on-failure
-
   ci:
     name: CI
     runs-on: ubuntu-latest
@@ -62,10 +50,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -e .[dev]
-
-    - name: Check types with pyright
-      run: |
-        pyright sbi
 
     - name: Run the fast CPU tests with coverage
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+name: Linting
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: ruff and hooks.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure
+
+  pyright:
+    name: Check types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Cache dependency
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ubuntu-latest-pip-3.8
+          restore-keys: |
+            ubuntu-latest-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -e .[dev]
+
+      - name: Check types with pyright
+        run: |
+          pyright sbi


### PR DESCRIPTION
- Separate workflow for the linting.
- Move pyright in dedicated process to avoid failing the test on type checks.