### PR TITLE
Refactor gpu warnings

### DIFF
--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -4,7 +4,6 @@
 """Various PyTorch utility functions."""
 
 import os
-import warnings
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -28,14 +27,6 @@ def process_device(device: str) -> str:
     if device == "cpu":
         return "cpu"
     else:
-        warnings.warn(
-            "GPU was selected as a device for training the neural network. "
-            "Note that we expect no significant speed ups in training for the "
-            "default architectures we provide. Using the GPU will be effective "
-            "only for large neural networks with operations that are fast on the "
-            "GPU, e.g., for a CNN or RNN `embedding_net`.",
-            stacklevel=2,
-        )
         # If user just passes 'gpu', search for CUDA or MPS.
         if device == "gpu":
             # check whether either pytorch cuda or mps is available

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -736,8 +736,8 @@ def validate_theta_and_x(
 
     if str(x.device) != data_device:
         warnings.warn(
-            f"Data x has device '{x.device}'."
-            f"Moving x to the data_device '{data_device}'."
+            f"Data x has device '{x.device}'. "
+            f"Moving x to the data_device '{data_device}'. "
             f"Training will proceed on device '{training_device}'.",
             stacklevel=2,
         )
@@ -746,7 +746,7 @@ def validate_theta_and_x(
     if str(theta.device) != data_device:
         warnings.warn(
             f"Parameters theta has device '{theta.device}'. "
-            f"Moving theta to the data_device '{data_device}'."
+            f"Moving theta to the data_device '{data_device}'. "
             f"Training will proceed on device '{training_device}'.",
             stacklevel=2,
         )

--- a/tests/analysis_test.py
+++ b/tests/analysis_test.py
@@ -28,10 +28,10 @@ def test_analysis_modules(device: str) -> None:
         low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim), device=device
     )
 
-    def simulator(parameter_set):
-        return 1.0 + parameter_set + torch.randn(parameter_set.shape) * 0.1
+    def simulator(theta):
+        return 1.0 + theta + torch.randn(theta.shape, device=theta.device) * 0.1
 
-    theta = prior.sample((300,)).to("cpu")
+    theta = prior.sample((300,)).to(device)
     x = simulator(theta)
 
     inf = SNPE(prior=prior, device=device)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def set_seed():
 
 @pytest.fixture(scope="session", autouse=True)
 def set_default_tensor_type():
-    torch.set_default_tensor_type("torch.FloatTensor")
+    torch.set_default_dtype(torch.float32)
 
 
 # Pytest hook to skip GPU tests if no devices are available.


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Refactors warnings related to GPU usage. Fixes a warning about `torch.set_default_tensor_type()` being deprecated as of PyTorch 2.1. 

## Does this close any currently open issues?

Fixes #1168 

## Comment

Does is also fix #1167?