### PR TITLE
fix: removing circular imports

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -18,7 +18,7 @@ from matplotlib.patches import Rectangle
 from scipy.stats import binom, gaussian_kde, iqr
 from torch import Tensor
 
-from sbi.analysis import eval_conditional_density
+from sbi.analysis.conditional_density import eval_conditional_density
 from sbi.utils.analysis_utils import pp_vals
 
 try:

--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -1,29 +1,12 @@
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
-
-from sbi.inference.abc.mcabc import MCABC
-from sbi.inference.abc.smcabc import SMCABC
+from sbi.inference.abc import MCABC, SMCABC
 from sbi.inference.base import (
     NeuralInference,  # noqa: F401
     check_if_proposal_has_default_x,
     infer,
     simulate_for_sbi,
 )
-from sbi.inference.snle.mnle import MNLE
-from sbi.inference.snle.snle_a import SNLE_A
-from sbi.inference.snpe.snpe_a import SNPE_A
-from sbi.inference.snpe.snpe_b import SNPE_B
-from sbi.inference.snpe.snpe_c import SNPE_C  # noqa: F401
+from sbi.inference.snle import MNLE, SNLE_A
+from sbi.inference.snpe import SNPE_A, SNPE_B, SNPE_C  # noqa: F401
 from sbi.inference.snre import BNRE, SNRE, SNRE_A, SNRE_B, SNRE_C  # noqa: F401
 
 SNL = SNLE = SNLE_A
@@ -46,19 +29,17 @@ _abc_family = ["ABC", "MCABC", "SMC", "SMCABC"]
 
 __all__ = _snpe_family + _snre_family + _snle_family + _abc_family
 
-from sbi.inference.posteriors.direct_posterior import DirectPosterior
-from sbi.inference.posteriors.ensemble_posterior import EnsemblePosterior
-from sbi.inference.posteriors.importance_posterior import ImportanceSamplingPosterior
-from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
-from sbi.inference.posteriors.rejection_posterior import RejectionPosterior
-from sbi.inference.posteriors.vi_posterior import VIPosterior
-from sbi.inference.potentials.likelihood_based_potential import (
+from sbi.inference.posteriors import (
+    DirectPosterior,
+    EnsemblePosterior,
+    ImportanceSamplingPosterior,
+    MCMCPosterior,
+    RejectionPosterior,
+    VIPosterior,
+)
+from sbi.inference.potentials import (
     likelihood_estimator_based_potential,
     mixed_likelihood_estimator_based_potential,
-)
-from sbi.inference.potentials.posterior_based_potential import (
     posterior_estimator_based_potential,
-)
-from sbi.inference.potentials.ratio_based_potential import (
     ratio_estimator_based_potential,
 )

--- a/sbi/inference/abc/__init__.py
+++ b/sbi/inference/abc/__init__.py
@@ -1,0 +1,2 @@
+from sbi.inference.abc.mcabc import MCABC
+from sbi.inference.abc.smcabc import SMCABC

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -10,7 +10,8 @@ from numpy import ndarray
 from torch import Tensor
 
 from sbi.inference.abc.abc_base import ABCBASE
-from sbi.utils import KDEWrapper, get_kde, process_x
+from sbi.utils.kde import KDEWrapper, get_kde
+from sbi.utils.user_input_checks import process_x
 
 
 class MCABC(ABCBASE):

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -14,7 +14,10 @@ from torch.distributions import Distribution, Multinomial, MultivariateNormal
 
 from sbi.inference.abc.abc_base import ABCBASE
 from sbi.sbi_types import Array
-from sbi.utils import BoxUniform, KDEWrapper, get_kde, process_x, within_support
+from sbi.utils.kde import KDEWrapper, get_kde
+from sbi.utils.sbiutils import within_support
+from sbi.utils.torchutils import BoxUniform
+from sbi.utils.user_input_checks import process_x
 
 
 class SMCABC(ABCBASE):

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -15,7 +15,6 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard.writer import SummaryWriter
 
-import sbi.inference
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.utils import (
@@ -79,6 +78,9 @@ def infer(
     """
 
     try:
+        # Moved here to avoid circular imports at initialization.
+        import sbi.inference  # noqa: R0401
+
         method_fun: Callable = getattr(sbi.inference, method.upper())
     except AttributeError as err:
         raise NameError(

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -15,7 +15,7 @@ from sbi.inference.potentials.base_potential import (
     CallablePotentialWrapper,
 )
 from sbi.sbi_types import Array, Shape, TorchTransform
-from sbi.utils import gradient_ascent
+from sbi.utils.sbiutils import gradient_ascent
 from sbi.utils.torchutils import ensure_theta_batched, process_device
 from sbi.utils.user_input_checks import process_x
 

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -18,8 +18,9 @@ from sbi.neural_nets.density_estimators.shape_handling import (
 )
 from sbi.samplers.rejection import rejection
 from sbi.sbi_types import Shape
-from sbi.utils import check_prior, within_support
+from sbi.utils.sbiutils import within_support
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks import check_prior
 
 
 class DirectPosterior(NeuralPosterior):

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -11,7 +11,7 @@ from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.inference.potentials.posterior_based_potential import PosteriorBasedPotential
 from sbi.sbi_types import Shape, TorchTransform
-from sbi.utils import gradient_ascent
+from sbi.utils.sbiutils import gradient_ascent
 from sbi.utils.torchutils import ensure_theta_batched
 from sbi.utils.user_input_checks import process_x
 

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Optional, Tuple, Union
 import torch
 from torch import Tensor
 
-from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.importance.importance_sampling import importance_sample

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -31,8 +31,8 @@ from sbi.samplers.mcmc import (
 )
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.simulators.simutils import tqdm_joblib
-from sbi.utils import pyro_potential_wrapper, tensor2numpy, transformed_potential
-from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
+from sbi.utils.torchutils import ensure_theta_batched, tensor2numpy
 
 
 class MCMCPosterior(NeuralPosterior):

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -8,7 +8,6 @@ from warnings import warn
 import torch
 from torch import Tensor
 
-from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.rejection.rejection import rejection_sample

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -29,7 +29,7 @@ from sbi.sbi_types import (
     TorchTensor,
     TorchTransform,
 )
-from sbi.utils import mcmc_transform
+from sbi.utils.sbiutils import mcmc_transform
 from sbi.utils.torchutils import atleast_2d_float32_tensor, ensure_theta_batched
 
 

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -15,7 +15,7 @@ from sbi.neural_nets.density_estimators.shape_handling import (
 )
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.sbi_types import TorchTransform
-from sbi.utils import mcmc_transform
+from sbi.utils.sbiutils import mcmc_transform
 
 
 def likelihood_estimator_based_potential(

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -14,8 +14,7 @@ from sbi.neural_nets.density_estimators.shape_handling import (
     reshape_to_sample_batch_event,
 )
 from sbi.sbi_types import TorchTransform
-from sbi.utils import mcmc_transform
-from sbi.utils.sbiutils import within_support
+from sbi.utils.sbiutils import mcmc_transform, within_support
 from sbi.utils.torchutils import ensure_theta_batched
 
 

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -9,8 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.sbi_types import TorchTransform
-from sbi.utils import mcmc_transform
-from sbi.utils.sbiutils import match_theta_and_x_batch_shapes
+from sbi.utils.sbiutils import match_theta_and_x_batch_shapes, mcmc_transform
 from sbi.utils.torchutils import atleast_2d
 
 

--- a/sbi/inference/snle/mnle.py
+++ b/sbi/inference/snle/mnle.py
@@ -11,7 +11,8 @@ from sbi.inference.potentials import mixed_likelihood_estimator_based_potential
 from sbi.inference.snle.snle_base import LikelihoodEstimator
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
-from sbi.utils import check_prior, del_entries
+from sbi.utils.sbiutils import del_entries
+from sbi.utils.user_input_checks import check_prior
 
 
 class MNLE(LikelihoodEstimator):

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -7,7 +7,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.snle.snle_base import LikelihoodEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class SNLE_A(LikelihoodEstimator):

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -11,7 +11,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.utils.tensorboard.writer import SummaryWriter
 
-from sbi.inference import NeuralInference
+from sbi.inference.base import NeuralInference
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
 from sbi.neural_nets import ConditionalDensityEstimator, likelihood_nn

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -10,7 +10,7 @@ from torch.distributions import Distribution
 import sbi.utils as utils
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class SNPE_B(PosteriorEstimator):

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -13,8 +13,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.utils.tensorboard.writer import SummaryWriter
 
-from sbi import utils as utils
-from sbi.inference import NeuralInference, check_if_proposal_has_default_x
+from sbi.inference.base import NeuralInference, check_if_proposal_has_default_x
 from sbi.inference.posteriors import (
     DirectPosterior,
     MCMCPosterior,
@@ -31,6 +30,7 @@ from sbi.neural_nets.density_estimators.shape_handling import (
 from sbi.utils import (
     RestrictedPrior,
     check_estimator_arg,
+    check_prior,
     handle_invalid_x,
     nle_nre_apt_msg_on_invalid_x,
     npe_msg_on_invalid_x,
@@ -483,7 +483,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             )
             prior = self._prior
         else:
-            utils.check_prior(prior)
+            check_prior(prior)
 
         if density_estimator is None:
             posterior_estimator = self._neural_net

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -9,7 +9,6 @@ from pyknos.nflows.transforms import CompositeTransform
 from torch import Tensor, eye, nn, ones
 from torch.distributions import Distribution, MultivariateNormal, Uniform
 
-from sbi import utils as utils
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
 from sbi.neural_nets.density_estimators.shape_handling import (
@@ -25,6 +24,8 @@ from sbi.utils import (
     del_entries,
     repeat_rows,
 )
+from sbi.utils.sbiutils import mog_log_prob
+from sbi.utils.torchutils import BoxUniform, assert_all_finite
 
 
 class SNPE_C(PosteriorEstimator):
@@ -251,7 +252,7 @@ class SNPE_C(PosteriorEstimator):
                 )
             else:
                 range_ = torch.sqrt(almost_one_std * 3.0)
-                self._maybe_z_scored_prior = utils.BoxUniform(
+                self._maybe_z_scored_prior = BoxUniform(
                     almost_zero_mean - range_, almost_zero_mean + range_
                 )
         else:
@@ -348,7 +349,7 @@ class SNPE_C(PosteriorEstimator):
         # Get (batch_size * num_atoms) log prob prior evals.
         log_prob_prior = self._prior.log_prob(atomic_theta)
         log_prob_prior = log_prob_prior.reshape(batch_size, num_atoms)
-        utils.assert_all_finite(log_prob_prior, "prior eval")
+        assert_all_finite(log_prob_prior, "prior eval")
 
         # Evaluate large batch giving (batch_size * num_atoms) log prob posterior evals.
         atomic_theta = reshape_to_sample_batch_event(
@@ -358,7 +359,7 @@ class SNPE_C(PosteriorEstimator):
             repeated_x, self._neural_net.condition_shape
         )
         log_prob_posterior = self._neural_net.log_prob(atomic_theta, repeated_x)
-        utils.assert_all_finite(log_prob_posterior, "posterior eval")
+        assert_all_finite(log_prob_posterior, "posterior eval")
         log_prob_posterior = log_prob_posterior.reshape(batch_size, num_atoms)
 
         # Compute unnormalized proposal posterior.
@@ -368,7 +369,7 @@ class SNPE_C(PosteriorEstimator):
         log_prob_proposal_posterior = unnormalized_log_prob[:, 0] - torch.logsumexp(
             unnormalized_log_prob, dim=-1
         )
-        utils.assert_all_finite(log_prob_proposal_posterior, "proposal posterior eval")
+        assert_all_finite(log_prob_proposal_posterior, "proposal posterior eval")
 
         # XXX This evaluates the posterior on _all_ prior samples
         if self._use_combined_loss:
@@ -444,10 +445,8 @@ class SNPE_C(PosteriorEstimator):
         )
 
         # Compute the log_prob of theta under the product.
-        log_prob_proposal_posterior = utils.mog_log_prob(
-            theta, logits_pp, m_pp, prec_pp
-        )
-        utils.assert_all_finite(
+        log_prob_proposal_posterior = mog_log_prob(theta, logits_pp, m_pp, prec_pp)
+        assert_all_finite(
             log_prob_proposal_posterior,
             """the evaluation of the MoG proposal posterior. This is likely due to a
             numerical instability in the training procedure. Please create an issue on

--- a/sbi/inference/snre/bnre.py
+++ b/sbi/inference/snre/bnre.py
@@ -9,7 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_a import SNRE_A
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class BNRE(SNRE_A):

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -9,7 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class SNRE_A(RatioEstimator):

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -9,7 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class SNRE_B(RatioEstimator):

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -11,7 +11,6 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.utils.tensorboard.writer import SummaryWriter
 
-from sbi import utils as utils
 from sbi.inference.base import NeuralInference
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import ratio_estimator_based_potential
@@ -22,6 +21,7 @@ from sbi.utils import (
     clamp_and_warn,
     x_shape_from_simulation,
 )
+from sbi.utils.torchutils import repeat_rows
 
 
 class RatioEstimator(NeuralInference, ABC):
@@ -293,7 +293,7 @@ class RatioEstimator(NeuralInference, ABC):
         The logits are obtained from atomic sets of (theta,x) pairs.
         """
         batch_size = theta.shape[0]
-        repeated_x = utils.repeat_rows(x, num_atoms)
+        repeated_x = repeat_rows(x, num_atoms)
 
         # Choose `1` or `num_atoms - 1` thetas from the rest of the batch for each x.
         probs = ones(batch_size, batch_size) * (1 - eye(batch_size)) / (batch_size - 1)

--- a/sbi/inference/snre/snre_c.py
+++ b/sbi/inference/snre/snre_c.py
@@ -9,7 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
-from sbi.utils import del_entries
+from sbi.utils.sbiutils import del_entries
 
 
 class SNRE_C(RatioEstimator):

--- a/sbi/neural_nets/density_estimators/categorical_net.py
+++ b/sbi/neural_nets/density_estimators/categorical_net.py
@@ -5,7 +5,7 @@ from torch import Tensor, nn
 from torch.distributions import Categorical
 from torch.nn import Sigmoid, Softmax
 
-from sbi.neural_nets.density_estimators import ConditionalDensityEstimator
+from sbi.neural_nets.density_estimators.base import ConditionalDensityEstimator
 
 
 class CategoricalNet(nn.Module):

--- a/sbi/neural_nets/density_estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/density_estimators/mixed_density_estimator.py
@@ -6,10 +6,8 @@ from typing import Tuple
 import torch
 from torch import Tensor
 
-from sbi.neural_nets.density_estimators import (
-    CategoricalMassEstimator,
-    ConditionalDensityEstimator,
-)
+from sbi.neural_nets.density_estimators.base import ConditionalDensityEstimator
+from sbi.neural_nets.density_estimators.categorical_net import CategoricalMassEstimator
 from sbi.neural_nets.density_estimators.nflows_flow import NFlowsFlow
 from sbi.utils.sbiutils import match_theta_and_x_batch_shapes
 from sbi.utils.torchutils import atleast_2d

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -7,8 +7,12 @@ from pyknos.mdn.mdn import MultivariateGaussianMDN
 from pyknos.nflows import flows, transforms
 from torch import Tensor, nn
 
-import sbi.utils as utils
 from sbi.neural_nets.density_estimators import NFlowsFlow
+from sbi.utils.sbiutils import (
+    standardizing_net,
+    standardizing_transform,
+    z_score_parser,
+)
 from sbi.utils.user_input_checks import check_data_device, check_embedding_net_device
 
 
@@ -53,15 +57,15 @@ def build_mdn(
 
     transform = transforms.IdentityTransform()
 
-    z_score_x_bool, structured_x = utils.z_score_parser(z_score_x)
+    z_score_x_bool, structured_x = z_score_parser(z_score_x)
     if z_score_x_bool:
-        transform_zx = utils.standardizing_transform(batch_x, structured_x)
+        transform_zx = standardizing_transform(batch_x, structured_x)
         transform = transforms.CompositeTransform([transform_zx, transform])
 
-    z_score_y_bool, structured_y = utils.z_score_parser(z_score_y)
+    z_score_y_bool, structured_y = z_score_parser(z_score_y)
     if z_score_y_bool:
         embedding_net = nn.Sequential(
-            utils.standardizing_net(batch_y, structured_y), embedding_net
+            standardizing_net(batch_y, structured_y), embedding_net
         )
 
     distribution = MultivariateGaussianMDN(

--- a/sbi/samplers/mcmc/pymc_wrapper.py
+++ b/sbi/samplers/mcmc/pymc_wrapper.py
@@ -6,7 +6,7 @@ import pytensor.tensor as pt
 import torch
 from arviz.data import InferenceData
 
-from sbi.utils import tensor2numpy
+from sbi.utils.torchutils import tensor2numpy
 
 
 class PyMCPotential(pt.Op):  # type: ignore

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -25,7 +25,7 @@ from sbi.samplers.vi.vi_utils import (
     move_all_tensor_to_device,
 )
 from sbi.sbi_types import Array, PyroTransformedDistribution
-from sbi.utils import check_prior
+from sbi.utils.user_input_checks import check_prior
 
 _VI_method = {}
 

--- a/sbi/simulators/linear_gaussian.py
+++ b/sbi/simulators/linear_gaussian.py
@@ -8,7 +8,7 @@ import torch
 from torch import Tensor
 from torch.distributions import Independent, MultivariateNormal, Uniform
 
-from sbi.utils import within_support
+from sbi.utils.sbiutils import within_support
 from sbi.utils.torchutils import atleast_2d
 
 

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -6,9 +6,9 @@ from warnings import warn
 
 from torch import nn
 
-from sbi.neural_nets import classifier_nn as classifier_nn_moved_to_neural_nets
-from sbi.neural_nets import likelihood_nn as likelihood_nn_moved_to_neural_nets
-from sbi.neural_nets import posterior_nn as posterior_nn_moved_to_neural_nets
+from sbi.neural_nets.factory import classifier_nn as classifier_nn_moved_to_neural_nets
+from sbi.neural_nets.factory import likelihood_nn as likelihood_nn_moved_to_neural_nets
+from sbi.neural_nets.factory import posterior_nn as posterior_nn_moved_to_neural_nets
 
 
 def classifier_nn(

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -23,7 +23,6 @@ from torch.distributions import (
     constraints,
 )
 
-from sbi import utils as utils
 from sbi.sbi_types import TorchTransform
 from sbi.utils.torchutils import atleast_2d
 from sbi.utils.zukoutils import UnconditionalLazyTransform
@@ -857,7 +856,7 @@ def mog_log_prob(
     constant = -(output_dim / 2.0) * torch.log(torch.tensor([2 * pi]))
     log_det = 0.5 * torch.log(torch.det(precisions_pp))
     theta_minus_mean = theta.expand_as(means_pp) - means_pp
-    exponent = -0.5 * utils.batched_mixture_vmv(precisions_pp, theta_minus_mean)
+    exponent = -0.5 * batched_mixture_vmv(precisions_pp, theta_minus_mean)
 
     return torch.logsumexp(weights + constant + log_det + exponent, dim=-1)
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -11,8 +11,8 @@ import torch
 from torch import Tensor, float32
 from torch.distributions import Independent, Uniform
 
-from sbi import utils as utils
 from sbi.sbi_types import Array, OneOrMore
+from sbi.utils.typechecks import is_nonnegative_int, is_positive_int
 
 
 def process_device(device: str) -> str:
@@ -103,7 +103,7 @@ def check_if_prior_on_device(
 
 
 def tile(x, n):
-    if not utils.is_positive_int(n):
+    if not is_positive_int(n):
         raise TypeError("Argument `n` must be a positive integer.")
     x_ = x.reshape(-1)
     x_ = x_.repeat(n)
@@ -115,7 +115,7 @@ def tile(x, n):
 
 def sum_except_batch(x, num_batch_dims=1):
     """Sums all elements of `x` except for the first `num_batch_dims` dimensions."""
-    if not utils.is_nonnegative_int(num_batch_dims):
+    if not is_nonnegative_int(num_batch_dims):
         raise TypeError("Number of batch dimensions must be a non-negative integer.")
     reduce_dims = list(range(num_batch_dims, x.ndimension()))
     return torch.sum(x, dim=reduce_dims)
@@ -130,7 +130,7 @@ def split_leading_dim(x, shape):
 def merge_leading_dims(x, num_dims):
     """Reshapes the tensor `x` such that the first `num_dims` dimensions are merged to
     one."""
-    if not utils.is_positive_int(num_dims):
+    if not is_positive_int(num_dims):
         raise TypeError("Number of leading dims must be a positive integer.")
     if num_dims > x.dim():
         raise ValueError(
@@ -142,7 +142,7 @@ def merge_leading_dims(x, num_dims):
 
 def repeat_rows(x, num_reps):
     """Each row of tensor `x` is repeated `num_reps` times along leading dimension."""
-    if not utils.is_positive_int(num_reps):
+    if not is_positive_int(num_reps):
         raise TypeError("Number of repetitions must be a positive integer.")
     shape = x.shape
     x = x.unsqueeze(1)

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -11,7 +11,7 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils import BoxUniform
+from sbi.utils.sbiutils import BoxUniform
 from tests.test_utils import check_c2st
 
 

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -11,7 +11,7 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.sbiutils import BoxUniform
+from sbi.utils.torchutils import BoxUniform
 from tests.test_utils import check_c2st
 
 

--- a/tests/circular_import_test.py
+++ b/tests/circular_import_test.py
@@ -1,0 +1,52 @@
+import importlib
+import inspect
+import pkgutil
+import random
+
+
+def import_first_function(module_name: str):
+    # This is a helper which emualtes
+    # from sbi.xxx import yyy
+    module = importlib.import_module(module_name)
+    functions = inspect.getmembers(module, inspect.isfunction)
+
+    if functions:
+        first_function_name, first_function = functions[0]
+        cmd = f"from {module_name} import {first_function_name}"
+        exec(cmd)
+        cmd_del = f"del {first_function_name}"
+        exec(cmd_del)
+    else:
+        pass
+
+
+def find_submodules(package_name):
+    # This is a helper which finds all modules from which we could import
+    submodules = []
+    package = __import__(package_name)
+
+    for _, name, _ in pkgutil.walk_packages(package.__path__):
+        full_name = package.__name__ + "." + name
+        submodules.append(full_name)
+
+    return submodules
+
+
+def test_circular_input():
+    modules = find_submodules("sbi")
+    # Permute the list of modules
+    random.shuffle(modules)
+
+    for module_name in modules:
+        # Try to import
+        if "sbi.examples" in module_name:
+            # This is not really a module :/ Hence skip it...
+            continue
+        try:
+            # Tests if we can: import module_name
+            module = importlib.import_module(module_name)
+            # Tests if we can: from module_name import xxx
+            import_first_function(module.__name__)
+            del module
+        except ImportError as e:
+            raise AssertionError(f"Cannot import {module_name}. Error: {e}") from e

--- a/tests/circular_import_test.py
+++ b/tests/circular_import_test.py
@@ -5,7 +5,7 @@ import random
 
 
 def import_first_function(module_name: str):
-    # This is a helper which emualtes
+    # This is a helper which emulates the following:
     # from sbi.xxx import yyy
     module = importlib.import_module(module_name)
     functions = inspect.getmembers(module, inspect.isfunction)
@@ -32,7 +32,7 @@ def find_submodules(package_name):
     return submodules
 
 
-def test_circular_input():
+def test_for_circular_imports():
     modules = find_submodules("sbi")
     # Permute the list of modules
     random.shuffle(modules)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
Currently, a lot of functions can not be directly imported due to circular imports e.g.

```
from sbi.neural_nets.factory import posterior_nn
from sbi.neural_nets.categorial import build_categoricalmassestimator
from sbi.neural_nets.mnle import MNLE
...
```

## Does this close any currently open issues?

Maybe #1158 


## Any relevant code examples, logs, error output, etc?

This is likely due to our current import hierarchy, which is quite chaotic and circular.
![packages](https://github.com/sbi-dev/sbi/assets/38903899/e81133da-6c96-43bd-a086-cd2d614359f5)
