### PR TITLE
fix: remove emb net device handling, refactor get_numel

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -321,7 +321,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         else:
             likelihood_estimator = density_estimator
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            device = str(next(density_estimator.parameters()).device)
 
         potential_fn, theta_transform = likelihood_estimator_based_potential(
             likelihood_estimator=likelihood_estimator,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -500,7 +500,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         else:
             posterior_estimator = density_estimator
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            device = str(next(density_estimator.parameters()).device)
 
         potential_fn, theta_transform = posterior_estimator_based_potential(
             posterior_estimator=posterior_estimator,

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -376,7 +376,7 @@ class RatioEstimator(NeuralInference, ABC):
         else:
             ratio_estimator = density_estimator
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            device = str(next(density_estimator.parameters()).device)
 
         potential_fn, theta_transform = ratio_estimator_based_potential(
             ratio_estimator=ratio_estimator,

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -9,6 +9,7 @@ from torch import Tensor, nn, relu
 
 from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import standardizing_net, z_score_parser
+from sbi.utils.user_input_checks import check_data_device
 
 
 class StandardizeInputs(nn.Module):
@@ -114,13 +115,11 @@ def build_linear_classifier(
     Returns:
         Neural network.
     """
-    # Infer the output dimensionalities of the embedding_net by making a forward pass.
-    x_numel, y_numel = get_numel(
-        batch_x,
-        batch_y,
-        embedding_net_x=embedding_net_x,
-        embedding_net_y=embedding_net_y,
-    )
+    # Infer the output dimensionalities of the embedding_net by making a forward
+    # pass.
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net_y)
 
     neural_net = nn.Linear(x_numel + y_numel, 1)
 
@@ -165,12 +164,9 @@ def build_mlp_classifier(
         Neural network.
     """
     # Infer the output dimensionalities of the embedding_net by making a forward pass.
-    x_numel, y_numel = get_numel(
-        batch_x,
-        batch_y,
-        embedding_net_x=embedding_net_x,
-        embedding_net_y=embedding_net_y,
-    )
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net_y)
 
     neural_net = nn.Sequential(
         nn.Linear(x_numel + y_numel, hidden_features),
@@ -225,12 +221,9 @@ def build_resnet_classifier(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(
-        batch_x,
-        batch_y,
-        embedding_net_x=embedding_net_x,
-        embedding_net_y=embedding_net_y,
-    )
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net_y)
 
     neural_net = nets.ResidualNet(
         in_features=x_numel + y_numel,

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -7,8 +7,8 @@ import torch
 from pyknos.nflows.nn import nets
 from torch import Tensor, nn, relu
 
+from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import standardizing_net, z_score_parser
-from sbi.utils.user_input_checks import check_data_device, check_embedding_net_device
 
 
 class StandardizeInputs(nn.Module):
@@ -114,13 +114,13 @@ def build_linear_classifier(
     Returns:
         Neural network.
     """
-    check_data_device(batch_x, batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_x, datum=batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_y, datum=batch_y)
-
     # Infer the output dimensionalities of the embedding_net by making a forward pass.
-    x_numel = embedding_net_x(batch_x[:1]).numel()
-    y_numel = embedding_net_y(batch_y[:1]).numel()
+    x_numel, y_numel = get_numel(
+        batch_x,
+        batch_y,
+        embedding_net_x=embedding_net_x,
+        embedding_net_y=embedding_net_y,
+    )
 
     neural_net = nn.Linear(x_numel + y_numel, 1)
 
@@ -164,13 +164,13 @@ def build_mlp_classifier(
     Returns:
         Neural network.
     """
-    check_data_device(batch_x, batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_x, datum=batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_y, datum=batch_y)
-
     # Infer the output dimensionalities of the embedding_net by making a forward pass.
-    x_numel = embedding_net_x(batch_x[:1]).numel()
-    y_numel = embedding_net_y(batch_y[:1]).numel()
+    x_numel, y_numel = get_numel(
+        batch_x,
+        batch_y,
+        embedding_net_x=embedding_net_x,
+        embedding_net_y=embedding_net_y,
+    )
 
     neural_net = nn.Sequential(
         nn.Linear(x_numel + y_numel, hidden_features),
@@ -225,13 +225,12 @@ def build_resnet_classifier(
     Returns:
         Neural network.
     """
-    check_data_device(batch_x, batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_x, datum=batch_y)
-    check_embedding_net_device(embedding_net=embedding_net_y, datum=batch_y)
-
-    # Infer the output dimensionalities of the embedding_net by making a forward pass.
-    x_numel = embedding_net_x(batch_x[:1]).numel()
-    y_numel = embedding_net_y(batch_y[:1]).numel()
+    x_numel, y_numel = get_numel(
+        batch_x,
+        batch_y,
+        embedding_net_x=embedding_net_x,
+        embedding_net_y=embedding_net_y,
+    )
 
     neural_net = nets.ResidualNet(
         in_features=x_numel + y_numel,

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -28,6 +28,7 @@ from sbi.neural_nets.flow import (
 )
 from sbi.neural_nets.mdn import build_mdn
 from sbi.neural_nets.mnle import build_mnle
+from sbi.utils.nn_utils import check_net_device
 
 model_builders = {
     "mdn": build_mdn,
@@ -98,8 +99,8 @@ def classifier_nn(
                 z_score_theta,
                 z_score_x,
                 hidden_features,
-                embedding_net_theta,
-                embedding_net_x,
+                check_net_device(embedding_net_theta, "cpu"),
+                check_net_device(embedding_net_x, "cpu"),
             ),
         ),
         **kwargs,
@@ -180,7 +181,7 @@ def likelihood_nn(
                 hidden_features,
                 num_transforms,
                 num_bins,
-                embedding_net,
+                check_net_device(embedding_net, "cpu"),
                 num_components,
             ),
         ),
@@ -256,7 +257,7 @@ def posterior_nn(
                 hidden_features,
                 num_transforms,
                 num_bins,
-                embedding_net,
+                check_net_device(embedding_net, "cpu"),
                 num_components,
             ),
         ),

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -48,6 +48,9 @@ model_builders = {
     "zuko_bpf": build_zuko_bpf,
 }
 
+embedding_net_warn_msg = """The passed embedding net will be moved to cpu for
+                        constructing the net building function."""
+
 
 def classifier_nn(
     model: str,
@@ -99,8 +102,8 @@ def classifier_nn(
                 z_score_theta,
                 z_score_x,
                 hidden_features,
-                check_net_device(embedding_net_theta, "cpu"),
-                check_net_device(embedding_net_x, "cpu"),
+                check_net_device(embedding_net_theta, "cpu", embedding_net_warn_msg),
+                check_net_device(embedding_net_x, "cpu", embedding_net_warn_msg),
             ),
         ),
         **kwargs,
@@ -181,7 +184,7 @@ def likelihood_nn(
                 hidden_features,
                 num_transforms,
                 num_bins,
-                check_net_device(embedding_net, "cpu"),
+                check_net_device(embedding_net, "cpu", embedding_net_warn_msg),
                 num_components,
             ),
         ),
@@ -257,7 +260,7 @@ def posterior_nn(
                 hidden_features,
                 num_transforms,
                 num_bins,
-                check_net_device(embedding_net, "cpu"),
+                check_net_device(embedding_net, "cpu", embedding_net_warn_msg),
                 num_components,
             ),
         ),

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -2,8 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from functools import partial
-from typing import List, Optional, Sequence, Tuple, Union
-from warnings import warn
+from typing import List, Optional, Sequence, Union
 
 import torch
 import zuko
@@ -16,6 +15,7 @@ from pyknos.nflows.transforms.splines import (
 from torch import Tensor, nn, relu, tanh, tensor, uint8
 
 from sbi.neural_nets.density_estimators import NFlowsFlow, ZukoFlow
+from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
     standardizing_net,
     standardizing_transform,
@@ -23,36 +23,8 @@ from sbi.utils.sbiutils import (
     z_score_parser,
 )
 from sbi.utils.torchutils import create_alternating_binary_mask
-from sbi.utils.user_input_checks import check_data_device, check_embedding_net_device
 
 nflow_specific_kwargs = ["num_bins", "num_components"]
-
-
-def get_numel(batch_x: Tensor, batch_y: Tensor, embedding_net) -> Tuple[int, int]:
-    """
-    Get the number of elements in the input and output space.
-
-    Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        embedding_net: Optional embedding network for y.
-
-    Returns:
-        Tuple of the number of elements in the input and output space.
-
-    """
-    x_numel = batch_x[0].numel()
-    # Infer the output dimensionality of the embedding_net by making a forward pass.
-    check_data_device(batch_x, batch_y)
-    check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
-    y_numel = embedding_net(batch_y[:1]).numel()
-    if x_numel == 1:
-        warn(
-            "In one-dimensional output space, this flow is limited to Gaussians",
-            stacklevel=2,
-        )
-
-    return x_numel, y_numel
 
 
 def build_made(
@@ -87,7 +59,7 @@ def build_made(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
 
     transform = transforms.IdentityTransform()
 
@@ -162,7 +134,9 @@ def build_maf(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+    x_numel, y_numel = get_numel(
+        batch_x, batch_y, embedding_net_y=embedding_net, warn_on_1d=True
+    )
 
     transform_list = []
     for _ in range(num_transforms):
@@ -262,7 +236,9 @@ def build_maf_rqs(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+    x_numel, y_numel = get_numel(
+        batch_x, batch_y, embedding_net_y=embedding_net, warn_on_1d=True
+    )
 
     transform_list = []
     for _ in range(num_transforms):
@@ -357,7 +333,7 @@ def build_nsf(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
 
     # Define mask function to alternate between predicted x-dimensions.
     def mask_in_layer(i):
@@ -1046,7 +1022,7 @@ def build_zuko_flow(
         ZukoFlow: The constructed Zuko normalizing flow model.
     """
 
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net)
+    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
 
     # keep only zuko kwargs
     kwargs = {k: v for k, v in kwargs.items() if k not in nflow_specific_kwargs}

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -23,6 +23,7 @@ from sbi.utils.sbiutils import (
     z_score_parser,
 )
 from sbi.utils.torchutils import create_alternating_binary_mask
+from sbi.utils.user_input_checks import check_data_device
 
 nflow_specific_kwargs = ["num_bins", "num_components"]
 
@@ -59,7 +60,9 @@ def build_made(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     transform = transforms.IdentityTransform()
 
@@ -134,9 +137,9 @@ def build_maf(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(
-        batch_x, batch_y, embedding_net_y=embedding_net, warn_on_1d=True
-    )
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net, warn_on_1d=True)
 
     transform_list = []
     for _ in range(num_transforms):
@@ -236,9 +239,9 @@ def build_maf_rqs(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(
-        batch_x, batch_y, embedding_net_y=embedding_net, warn_on_1d=True
-    )
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net, warn_on_1d=True)
 
     transform_list = []
     for _ in range(num_transforms):
@@ -333,7 +336,9 @@ def build_nsf(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     # Define mask function to alternate between predicted x-dimensions.
     def mask_in_layer(i):
@@ -1022,7 +1027,9 @@ def build_zuko_flow(
         ZukoFlow: The constructed Zuko normalizing flow model.
     """
 
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     # keep only zuko kwargs
     kwargs = {k: v for k, v in kwargs.items() if k not in nflow_specific_kwargs}

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -138,8 +138,12 @@ def build_maf(
         Neural network.
     """
     check_data_device(batch_x, batch_y)
-    x_numel = get_numel(batch_x, embedding_net=None)
-    y_numel = get_numel(batch_y, embedding_net=embedding_net, warn_on_1d=True)
+    x_numel = get_numel(
+        batch_x,
+        embedding_net=None,
+        warn_on_1d=True,  # warn if output space is 1D.
+    )
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     transform_list = []
     for _ in range(num_transforms):
@@ -240,8 +244,12 @@ def build_maf_rqs(
         Neural network.
     """
     check_data_device(batch_x, batch_y)
-    x_numel = get_numel(batch_x, embedding_net=None)
-    y_numel = get_numel(batch_y, embedding_net=embedding_net, warn_on_1d=True)
+    x_numel = get_numel(
+        batch_x,
+        embedding_net=None,
+        warn_on_1d=True,  # warn if output space is 1D.
+    )
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     transform_list = []
     for _ in range(num_transforms):

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -8,12 +8,12 @@ from pyknos.nflows import flows, transforms
 from torch import Tensor, nn
 
 from sbi.neural_nets.density_estimators import NFlowsFlow
+from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
     standardizing_net,
     standardizing_transform,
     z_score_parser,
 )
-from sbi.utils.user_input_checks import check_data_device, check_embedding_net_device
 
 
 def build_mdn(
@@ -48,12 +48,7 @@ def build_mdn(
     Returns:
         Neural network.
     """
-    x_numel = batch_x[0].numel()
-    # Infer the output dimensionality of the embedding_net by making a forward pass.
-    check_data_device(batch_x, batch_y)
-    check_embedding_net_device(embedding_net=embedding_net, datum=batch_y)
-    embedding_net.eval()
-    y_numel = embedding_net(batch_y[:1]).numel()
+    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
 
     transform = transforms.IdentityTransform()
 

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -14,6 +14,7 @@ from sbi.utils.sbiutils import (
     standardizing_transform,
     z_score_parser,
 )
+from sbi.utils.user_input_checks import check_data_device
 
 
 def build_mdn(
@@ -48,7 +49,9 @@ def build_mdn(
     Returns:
         Neural network.
     """
-    x_numel, y_numel = get_numel(batch_x, batch_y, embedding_net_y=embedding_net)
+    check_data_device(batch_x, batch_y)
+    x_numel = get_numel(batch_x, embedding_net=None)
+    y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     transform = transforms.IdentityTransform()
 

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 from sbi.utils.analysis_utils import get_1d_marginal_peaks_from_kde
-from sbi.utils.conditional_density_utils import extract_and_transform_mog
 from sbi.utils.io import get_data_root, get_log_root, get_project_root
 from sbi.utils.kde import KDEWrapper, get_kde
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential

--- a/sbi/utils/nn_utils.py
+++ b/sbi/utils/nn_utils.py
@@ -10,8 +10,8 @@ from sbi.utils.user_input_checks import check_data_device
 def get_numel(
     batch_x: Tensor,
     batch_y: Tensor,
-    embedding_net_x: Optional[nn.Module] | None = None,
-    embedding_net_y: Optional[nn.Module] | None = None,
+    embedding_net_x: Optional[nn.Module] = None,
+    embedding_net_y: Optional[nn.Module] = None,
     warn_on_1d: bool = False,
 ) -> Tuple[int, int]:
     """
@@ -45,3 +45,27 @@ def get_numel(
         )
 
     return x_numel, y_numel
+
+
+def check_net_device(net: nn.Module, device: str) -> nn.Module:
+    """
+    Check whether a net is on the desired device and move it there if not.
+
+    Args:
+        net: neural network.
+        device: desired device.
+
+    Returns:
+        Neural network on the desired device.
+    """
+
+    if isinstance(net, nn.Identity):
+        return net
+    if str(next(net.parameters()).device) != device:
+        warn(
+            f"Network is not on the correct device. Moving it to {device}.",
+            stacklevel=2,
+        )
+        return net.to(device)
+    else:
+        return net

--- a/sbi/utils/nn_utils.py
+++ b/sbi/utils/nn_utils.py
@@ -1,53 +1,46 @@
 # import all needed modules
-from typing import Optional, Tuple
+from typing import Optional
 from warnings import warn
 
 from torch import Tensor, nn
 
-from sbi.utils.user_input_checks import check_data_device
-
 
 def get_numel(
-    batch_x: Tensor,
-    batch_y: Tensor,
-    embedding_net_x: Optional[nn.Module] = None,
-    embedding_net_y: Optional[nn.Module] = None,
+    batch_input: Tensor,
+    embedding_net: Optional[nn.Module] = None,
     warn_on_1d: bool = False,
-) -> Tuple[int, int]:
+) -> int:
     """
-    Get the number of elements in the input and output space.
+    Return number of elements from an embedded batch of inputs.
+
+    Offers option to warn if the embedded input is one-dimensional.
 
     Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        embedding_net_x: Optional embedding network for x.
-        embedding_net_y: Optional embedding network for y.
+        batch_input: Batch of inputs.
+        embedding_net: Optional embedding network.
         warn_on_1d: Whether to warn if the output space is one-dimensional.
 
     Returns:
-        Tuple of the number of elements in the input and output space.
+        Number of elements after optional embedding.
 
     """
-    if embedding_net_x is None:
-        embedding_net_x = nn.Identity()
-    if embedding_net_y is None:
-        embedding_net_y = nn.Identity()
+    if embedding_net is None:
+        embedding_net = nn.Identity()
 
-    # Infer the output dimensionality of the embedding_net by making a forward pass.
-    check_data_device(batch_x, batch_y)
     # Make sure the embedding_net is on the same device as the data.
-    x_numel = embedding_net_x.to(batch_x.device)(batch_x[:1]).numel()
-    y_numel = embedding_net_y.to(batch_y.device)(batch_y[:1]).numel()
-    if x_numel == 1 and warn_on_1d:
+    numel = embedding_net.to(batch_input.device)(batch_input[:1]).numel()
+    if numel == 1 and warn_on_1d:
         warn(
             "In one-dimensional output space, this flow is limited to Gaussians",
             stacklevel=2,
         )
 
-    return x_numel, y_numel
+    return numel
 
 
-def check_net_device(net: nn.Module, device: str) -> nn.Module:
+def check_net_device(
+    net: nn.Module, device: str, message: Optional[str] = None
+) -> nn.Module:
     """
     Check whether a net is on the desired device and move it there if not.
 
@@ -63,7 +56,7 @@ def check_net_device(net: nn.Module, device: str) -> nn.Module:
         return net
     if str(next(net.parameters()).device) != device:
         warn(
-            f"Network is not on the correct device. Moving it to {device}.",
+            message or f"Network is not on the correct device. Moving it to {device}.",
             stacklevel=2,
         )
         return net.to(device)

--- a/sbi/utils/nn_utils.py
+++ b/sbi/utils/nn_utils.py
@@ -1,0 +1,47 @@
+# import all needed modules
+from typing import Optional, Tuple
+from warnings import warn
+
+from torch import Tensor, nn
+
+from sbi.utils.user_input_checks import check_data_device
+
+
+def get_numel(
+    batch_x: Tensor,
+    batch_y: Tensor,
+    embedding_net_x: Optional[nn.Module] | None = None,
+    embedding_net_y: Optional[nn.Module] | None = None,
+    warn_on_1d: bool = False,
+) -> Tuple[int, int]:
+    """
+    Get the number of elements in the input and output space.
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
+        embedding_net_x: Optional embedding network for x.
+        embedding_net_y: Optional embedding network for y.
+        warn_on_1d: Whether to warn if the output space is one-dimensional.
+
+    Returns:
+        Tuple of the number of elements in the input and output space.
+
+    """
+    if embedding_net_x is None:
+        embedding_net_x = nn.Identity()
+    if embedding_net_y is None:
+        embedding_net_y = nn.Identity()
+
+    # Infer the output dimensionality of the embedding_net by making a forward pass.
+    check_data_device(batch_x, batch_y)
+    # Make sure the embedding_net is on the same device as the data.
+    x_numel = embedding_net_x.to(batch_x.device)(batch_x[:1]).numel()
+    y_numel = embedding_net_y.to(batch_y.device)(batch_y[:1]).numel()
+    if x_numel == 1 and warn_on_1d:
+        warn(
+            "In one-dimensional output space, this flow is limited to Gaussians",
+            stacklevel=2,
+        )
+
+    return x_numel, y_numel

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -426,36 +426,6 @@ def check_prior_support(prior):
         ) from err
 
 
-def check_embedding_net_device(embedding_net: nn.Module, datum: torch.Tensor) -> None:
-    """Checks if the device for the `embedding_net`'s weights is the same as the device
-    for the fed `datum`. In case of discrepancy, warn the user and move the
-    embedding_net` to  the `datum`'s device.
-
-    Args:
-        embedding_net: torch `Module` embedding data
-        datum torch `Tensor` from the training device
-    """
-    datum_device = datum.device
-    embedding_net_devices = [p.device for p in embedding_net.parameters()]
-    if len(embedding_net_devices) > 0:
-        embedding_net_device = embedding_net_devices[0]
-        if embedding_net_device != datum_device:
-            warnings.warn(
-                "Mismatch between the device of the data fed "
-                "to the embedding_net and the device of the "
-                "embedding_net's weights. Fed data has device "
-                f"'{datum_device}' vs embedding_net weights have "
-                f"device '{embedding_net_device}'. "
-                "Automatically switching the embedding_net's device to "
-                f"'{datum_device}', which could otherwise be done manually "
-                f"""using the line `embedding_net.to('{datum_device}')`.""",
-                stacklevel=2,
-            )
-            embedding_net.to(datum_device)
-    else:
-        pass
-
-
 def check_data_device(datum_1: torch.Tensor, datum_2: torch.Tensor) -> None:
     """Checks if two tensors have the seme device. Fails if there is a device
     discrepancy

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from typing import Tuple
 
 import pytest
 import torch
 import torch.distributions.transforms as torch_tf
-import torch.nn as nn
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
@@ -32,7 +30,6 @@ from sbi.neural_nets import classifier_nn, likelihood_nn, posterior_nn
 from sbi.simulators import diagonal_linear_gaussian, linear_gaussian
 from sbi.utils.torchutils import BoxUniform, gpu_available, process_device
 from sbi.utils.user_input_checks import (
-    check_embedding_net_device,
     validate_theta_and_x,
 )
 
@@ -190,32 +187,6 @@ def test_training_and_mcmc_on_device(
     proposals[-1].potential(samples)
 
 
-@pytest.mark.gpu
-@pytest.mark.parametrize("device_datum", ["cpu", "gpu"])
-@pytest.mark.parametrize("device_embedding_net", ["cpu", "gpu"])
-def test_check_embedding_net_device(
-    device_datum: str, device_embedding_net: str
-) -> None:
-    device_datum = process_device(device_datum)
-    device_embedding_net = process_device(device_embedding_net)
-
-    datum = torch.zeros((1, 1)).to(device_datum)
-    embedding_net = nn.Linear(in_features=1, out_features=1).to(device_embedding_net)
-
-    if device_datum != device_embedding_net:
-        with pytest.warns(UserWarning):
-            check_embedding_net_device(datum=datum, embedding_net=embedding_net)
-    else:
-        check_embedding_net_device(datum=datum, embedding_net=embedding_net)
-
-    output_device_net = [p.device for p in embedding_net.parameters()][0]
-    assert datum.device == output_device_net, (
-        f"Failure when processing embedding_net: "
-        f"device should have been set to should have been '{datum.device}' but is "
-        f"still '{output_device_net}'"
-    )
-
-
 @pytest.mark.parametrize("shape_x", [(3, 1)])
 @pytest.mark.parametrize(
     "shape_theta", [(3, 2), pytest.param((2, 1), marks=pytest.mark.xfail)]
@@ -325,133 +296,6 @@ def test_train_with_different_data_and_training_device(
     assert posterior._device == str(
         weights_device
     ), "inferred posterior device not correct."
-
-
-@pytest.mark.gpu
-@pytest.mark.parametrize(
-    "inference_method", [SNPE_A, SNPE_C, SNRE_A, SNRE_B, SNRE_C, SNLE]
-)
-@pytest.mark.parametrize("prior_device", ("cpu", "gpu"))
-@pytest.mark.parametrize("embedding_net_device", ("cpu", "gpu"))
-@pytest.mark.parametrize("data_device", ("cpu", "gpu"))
-@pytest.mark.parametrize("training_device", ("cpu", "gpu"))
-def test_embedding_nets_integration_training_device(
-    inference_method,
-    prior_device: str,
-    embedding_net_device: str,
-    data_device: str,
-    training_device: str,
-    mcmc_params_fast: dict,
-) -> None:
-    """Test embedding nets integration with different devices, priors and methods."""
-    # add other methods
-
-    theta_dim = 2
-    x_dim = 3
-    # process all device strings
-    prior_device = process_device(prior_device)
-    embedding_net_device = process_device(embedding_net_device)
-    data_device = process_device(data_device)
-    training_device = process_device(training_device)
-
-    samples_per_round = 64
-    num_rounds = 2
-
-    x_o = torch.ones((1, x_dim))
-
-    prior = utils.BoxUniform(
-        low=-torch.ones((theta_dim,)),
-        high=torch.ones((theta_dim,)),
-        device=prior_device,
-    )
-
-    if inference_method in [SNRE_A, SNRE_B, SNRE_C]:
-        embedding_net_theta = nn.Linear(in_features=theta_dim, out_features=2).to(
-            embedding_net_device
-        )
-        embedding_net_x = nn.Linear(in_features=x_dim, out_features=2).to(
-            embedding_net_device
-        )
-        nn_kwargs = dict(
-            classifier=classifier_nn(
-                model="resnet",
-                embedding_net_x=embedding_net_x,
-                embedding_net_theta=embedding_net_theta,
-                hidden_features=4,
-            )
-        )
-        train_kwargs = dict()
-    elif inference_method == SNLE:
-        embedding_net = nn.Linear(in_features=theta_dim, out_features=2).to(
-            embedding_net_device
-        )
-        nn_kwargs = dict(
-            density_estimator=likelihood_nn(
-                model="mdn",
-                embedding_net=embedding_net,
-                hidden_features=4,
-                num_transforms=2,
-            )
-        )
-        train_kwargs = dict()
-    else:
-        embedding_net = nn.Linear(in_features=x_dim, out_features=2).to(
-            embedding_net_device
-        )
-        nn_kwargs = dict(
-            density_estimator=posterior_nn(
-                model="mdn_snpe_a" if inference_method == SNPE_A else "mdn",
-                embedding_net=embedding_net,
-                hidden_features=4,
-                num_transforms=2,
-            )
-        )
-        if inference_method == SNPE_A:
-            train_kwargs = dict()
-        else:
-            train_kwargs = dict(force_first_round_loss=True)
-
-    with pytest.raises(Exception) if prior_device != training_device else nullcontext():
-        inference = inference_method(prior=prior, **nn_kwargs, device=training_device)
-
-    if prior_device != training_device:
-        pytest.xfail("We do not correct the case of invalid prior device")
-
-    theta = prior.sample((samples_per_round,)).to(data_device)
-
-    proposal = prior
-    for _ in range(num_rounds):
-        # sample theta and x independently - quick way to get 3D simulation data.
-        theta = proposal.sample((samples_per_round,))
-        x = (
-            MultivariateNormal(torch.zeros((x_dim,)), torch.eye(x_dim))
-            .sample((samples_per_round,))
-            .to(data_device)
-        )
-
-        with (
-            pytest.warns(UserWarning)
-            if data_device != training_device
-            else nullcontext()
-        ):
-            density_estimator_append = inference.append_simulations(theta, x)
-
-        density_estimator_train = density_estimator_append.train(
-            max_num_epochs=2, **train_kwargs
-        )
-
-        posterior = inference.build_posterior(
-            density_estimator_train,
-            **(
-                {}
-                if inference_method == SNPE_A
-                else dict(
-                    mcmc_method="slice_np_vectorized",
-                    mcmc_parameters=mcmc_params_fast,
-                )
-            ),
-        )
-        proposal = posterior.set_default_x(x_o)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Context

The starting point for this PR is  #1161, the incorrect warning that embedding net and data device do not match.
On the way I realized that we are treating the `embedding_net` as separate net that can have its own device, different from the actual net. I think this does not make sense. 

In general, the device handling should be centralized, e.g., have a single entry point. At the moment, this entry point is the inference object, e.g., `SNPE(..., device=device)`. But are the different scenarios: 

1. user passes a model str to `SNPE`: all good, device handling is centralized via the `device`
2. user passes a custom net, which could be on a device already. Then this device must match the `device` passed to `SNPE`.
3. user uses e.g., `posterior_nn` to build a flow with an embedding net. `posterior_nn` normally returns a net on the cpu. but if the `embedding_net` passed by the user is on a different device, things might crash. 

## My suggestions

1. ✅ 
2. we assert that the device of a passed net matches the device passed to the inference object. 
EDIT: Does not make sense because in the standard case it will be in cpu and be moved to training device later, so there will be a mismatch. So we can either move the passed net to cpu entirely (bad), or, in those few cases where users pass large nets that have to be on the GPU, accept potential device mismatches. 
3. we assert in `posterior_nn` etc, that the passed embedding net is on the cpu, or we move it there. 
EDIT: I will add a function that checks the embedding net device and if it is not on cpu, it warns and moves it there. 

## What this PR does so far

- remove all the separate `embedding_net` device checking
- fix a small bug when inferring the device in `build_posterior` (and add test)
- unify `get_numel` to be used across the neural net factory. I had to put it into a separate utils file because putting it into  `sbiutils` or `torchutils` causes circular imports 😵 
- add 2. from above
- add 3. from above. 

fixes #1161 