### PR TITLE
reset tutorials to released sbi version

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,7 +24,6 @@ nav:
       - Analysis:
         - Conditional distributions: tutorial/07_conditional_distributions.md
         - Posterior sensitivity analysis: tutorial/09_sensitivity_analysis.md
-        - Pair and marginal plots: tutorial/19_plotting_functionality.md
       - Examples:
         - Hodgkin-Huxley example: examples/00_HH_simulator.md
         - Decision making model: examples/01_decision_making_model.md

--- a/tutorials/05_embedding_net.ipynb
+++ b/tutorials/05_embedding_net.ipynb
@@ -254,7 +254,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sbi.neural_nets import CNNEmbedding\n",
+    "from sbi.neural_nets.embedding_nets import CNNEmbedding\n",
     "\n",
     "embedding_net = CNNEmbedding(\n",
     "    input_shape=(32, 32),\n",
@@ -481,7 +481,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/13_diagnostics_simulation_based_calibration.ipynb
+++ b/tutorials/13_diagnostics_simulation_based_calibration.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0b29e299-a762-49ff-be34-94ec82652f0c",
    "metadata": {},
    "source": [
     "# Simulation-based Calibration in SBI\n",
@@ -14,7 +13,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ce235c3-9c70-4d10-845f-70add68576b5",
    "metadata": {},
    "source": [
     "## In a nutshell\n",
@@ -50,7 +48,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53f22ccc-e2bc-4a70-a422-e0cac6944648",
    "metadata": {},
    "source": [
     "## A healthy posterior\n",
@@ -63,7 +60,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b79cd0b8-8161-47b9-a008-510ea1b857ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,14 +68,13 @@
     "from torch.distributions import MultivariateNormal\n",
     "\n",
     "from sbi.analysis.plot import sbc_rank_plot\n",
-    "from sbi.diagnostics import check_sbc, run_sbc\n",
+    "from sbi.analysis import check_sbc, run_sbc\n",
     "from sbi.inference import SNPE, simulate_for_sbi"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae48dbd9-084c-4753-8feb-731a7f99075d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +90,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4efea93e-d93b-47ab-a1ef-487ee06ec2e0",
    "metadata": {},
    "source": [
     "## An ideal case\n",
@@ -106,7 +100,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8907ec4-8439-41aa-af69-c96c295748ea",
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +144,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73b47ac1-2588-44dd-ba45-9616dee3caab",
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +169,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3254e3d4-e5f1-4e1f-bb1c-fa9e9b3adcaf",
    "metadata": {},
    "outputs": [
     {
@@ -650,7 +641,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d6cf039-1dd8-44f8-bfed-3a3e027a84b4",
    "metadata": {},
    "outputs": [
     {
@@ -678,7 +668,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5e79734-08e8-4818-8402-798d5d01cbef",
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +699,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff831073-5d73-4301-8b50-6a853d0a3acd",
    "metadata": {},
    "source": [
     "The observation `x_o` falls into the support of the predicted posterior samples, i.e. it is within `simulator(posterior_samples)`. Given the simulator, this is indicative that our posterior estimates the data well.\n"
@@ -718,7 +706,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20763237-c51c-443f-9063-979c2b3e1a24",
    "metadata": {},
    "source": [
     "### Running SBC\n",
@@ -729,7 +716,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a81aee59-5cc8-497f-8a2c-5a7a0212df97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +727,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0de8cfe9-e7e9-445e-aced-346af8eac3cd",
    "metadata": {},
    "source": [
     "SBC is implemented in `sbi` for your use on any `sbi` posterior. To run it, we only need to call `run_sbc` with appropriate parameters.\n",
@@ -752,7 +737,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50930e69-f837-4bb6-8637-a1ef70cdef11",
    "metadata": {},
    "outputs": [
     {
@@ -780,7 +764,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95b19252-b39b-45d8-87e2-52d019bc974b",
    "metadata": {},
    "source": [
     "`sbi` establishes two methods to do simulation-based calibration:\n",
@@ -796,7 +779,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88b23176-28c5-4925-88f5-6c153d09e674",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +789,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe168784-354f-48aa-a24d-bd60abe9f863",
    "metadata": {},
    "source": [
     "The `check_stats` variable created contains a dictionary with 3 metrics that help to judge our posterior. The \"first\" two compare the ranks to a uniform distribution.\n"
@@ -815,7 +796,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cac382ac-ecf8-4ca3-b441-a8fcd904a14d",
    "metadata": {},
    "source": [
     "### Ranks versus Uniform distribution\n"
@@ -824,7 +804,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca62ad37-5004-43b0-b94c-02ec167e888e",
    "metadata": {},
    "outputs": [
     {
@@ -846,7 +825,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5eac9e63-3760-4f1f-a89e-c98d15a273fd",
    "metadata": {},
    "source": [
     "The Kolmogorov-Smirnov (KS test, see also [here](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test#Two-sample_Kolmogorov%E2%80%93Smirnov_test)) as used by `check_sbc` provides p-values `pvals` on the null hypothesis that the samples from `ranks` are drawn from a uniform distribution (in other words `H_0: PDF(ranks) == PDF(uniform)`). We are provided two values as our problem is two-dimensional - one p-value for each dimension.\n",
@@ -857,7 +835,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4967cb17-6728-44b7-bfb0-d71fee30e4d9",
    "metadata": {},
    "outputs": [
     {
@@ -877,7 +854,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "644ae333-f5d6-4118-99c1-f986e6a1a4d9",
    "metadata": {},
    "source": [
     "The second tier of metrics comparing `ranks` with a uniform distributions is a `c2st` test (see [here](http://arxiv.org/abs/1610.06545) for details). This is a nonparametric two sample test based on training a classifier to differentiate two ensembles. Here, these two ensembles are the observed `ranks` and samples from a uniform distribution. The values reported are the accuracies from n-fold cross-validation. If you see values around `0.5`, the classifier was unable to differentiate both ensembles, i.e. `ranks` are very uniform. If the values are high towards `1`, this matches the case where `ranks` is very unlike a uniform distribution.\n"
@@ -885,7 +861,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc0ad068-e9d1-4ec1-9667-44fb98ecbea6",
    "metadata": {},
    "source": [
     "### Data averaged posterior (DAP) versus prior\n"
@@ -894,7 +869,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4cb8611-763b-4318-a0ad-430266c46ac9",
    "metadata": {},
    "outputs": [
     {
@@ -911,7 +885,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4707dfa8-e8fd-44e1-bb4f-6bc6ed7744c5",
    "metadata": {},
    "source": [
     "The last metric reported is again based on `c2st` computed per dimension of `theta`. If you see values around `0.5`, the `c2st` classifier was unable to differentiate both ensembles for each dimension of `theta`, i.e. `dap` are much like (if not identical to) the prior. If the values are very high towards `1`, this represents the case where `dap` is very unlike the prior distribution.\n"
@@ -919,7 +892,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "229d6390-b05f-4b94-b016-6672f5b19069",
    "metadata": {},
    "source": [
     "### Visual Inspection\n"
@@ -928,7 +900,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bc29b66-1b11-494e-8b91-7e3a99d0adac",
    "metadata": {},
    "outputs": [
     {
@@ -953,7 +924,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53592f75-a204-4b5f-abc1-8bbdc8538297",
    "metadata": {},
    "source": [
     "The two plots visualize the distribution of `ranks` (here depicted in red) in each dimension. Highlighted in grey, you see the 99% confidence interval of a uniform distribution given the number of samples provided. In plain english: for a uniform distribution, we would expect 1 out of 100 (red) bars to lie outside the grey area.\n",
@@ -964,7 +934,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d76b5936-286f-468e-82ad-0a65194f9a43",
    "metadata": {},
    "outputs": [
     {
@@ -984,7 +953,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2b021c4-c1aa-433d-95c4-e09e926f172f",
    "metadata": {},
    "source": [
     "The above provides a visual representation of the cumulative density function (CDF) of `ranks` (blue and orange for each dimension of `theta`) with respect to the 95% confidence interval of a uniform distribution (grey).\n"
@@ -992,7 +960,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3f1a0cc-d83f-4f0c-b174-ca367aab7699",
    "metadata": {},
    "source": [
     "## multi dimensional SBC\n",
@@ -1003,7 +970,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c4de299-54a2-4ebd-beb0-344e90767c9f",
    "metadata": {},
    "outputs": [
     {
@@ -1043,7 +1009,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a283036-93e2-44ff-ac1d-fe42ceaaf6a0",
    "metadata": {},
    "source": [
     "In the code above, we depart from the default behavior of `run_sbc`. The standard behavior of `run_sbc` is to calculate the SBC ranks of parameters $\\theta$ by comparing the marginal values of the predicted parameter $\\theta_i$ to the reference value $\\theta_o$, i.e. we are ranking each parameter only within its marginal dimension `idx` which evaluates `theta_i[idx] < theta_o[idx]` to perform sbc ranking.  \n",
@@ -1055,7 +1020,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bd10e67-744f-4ea7-ab3c-08c14d9f9978",
    "metadata": {},
    "source": [
     "# When things go haywire\n",
@@ -1065,7 +1029,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46b9562d-9c7b-4adf-837e-e9e2ca5abdb6",
    "metadata": {},
    "source": [
     "## A shifted posterior mean\n",
@@ -1076,7 +1039,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b48d5404-ade1-45cb-97ee-9feab1da04ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,7 +1051,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1879b35-ebf5-4927-8200-9a3a6488213b",
    "metadata": {},
    "outputs": [
     {
@@ -1122,7 +1083,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fc2acca-03a0-42b1-a964-b0951b5c8f8d",
    "metadata": {},
    "source": [
     "We can see that the Kolmogorov-Smirnov p-values vanish (`'ks_pvals': tensor([0., 0.])`). Thus, we can reject the hypothesis that the `ranks` PDF is a uniform PDF. The `c2st` accuracies show values higher than `0.5`. This is supports as well that the `ranks` distribution is not a uniform PDF.\n"
@@ -1131,7 +1091,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ef7deb0-d73f-4c64-a6bb-71e388427036",
    "metadata": {},
    "outputs": [
     {
@@ -1151,7 +1110,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23ec9d31-d9fc-4469-9e7d-217d32bf70b9",
    "metadata": {},
    "source": [
     "Inspecting the histograms for both dimenions, the rank distribution is clearly tilted to low rank values for both dimensions. Because we have shifted the expected value of the posterior to higher values (by `0.1`), we see more entries at low rank values.\n"
@@ -1159,7 +1117,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34f95fb3-b195-44e1-b1bc-44d2dce1f6e7",
    "metadata": {},
    "source": [
     "Let's try to shift all posterior samples in the opposite direction. We shift the expectation value by `-0.1`:\n"
@@ -1168,7 +1125,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43a45b10-aaac-4e66-a502-440d2ac1a948",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1178,7 +1134,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98cbfd58-5bfc-414f-9fa3-ba766dad0638",
    "metadata": {},
    "outputs": [
     {
@@ -1222,7 +1177,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "794893d9-ec44-46fc-9234-9975327e62b7",
    "metadata": {},
    "source": [
     "A similar behavior is observed, but this time we see an upshot of ranks to higher values of posterior rank. Because we have shifted the expected value of the posterior to smaller values, we see an upshot in high rank counts.\n",
@@ -1239,7 +1193,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88bce62e-63b9-46b8-a3c5-a013e13e9cd0",
    "metadata": {},
    "source": [
     "## A dispersed posterior\n",
@@ -1250,7 +1203,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f12d3bde-920c-4811-997d-49b30202560c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1215,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20f63dba-afd6-4614-9f77-5b6a2dccf63d",
    "metadata": {},
    "outputs": [
     {
@@ -1307,7 +1258,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d21c7f4-477d-452f-951a-d78ae14912b2",
    "metadata": {},
    "source": [
     "The rank histograms now look more like a very wide gaussian distribution centered in the middle. The KS p-values again vanish unsurprisingly (we must reject the hypothesis that both distributions are from the same uniform PDF) and the c2st_ranks indicate that the rank histogram is not uniform too. As our posterior samples are distributed too broad now, we obtain more \"medium\" range ranks and hence produce the peak of ranks in the center of the histogram.\n"
@@ -1315,7 +1265,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b8127d6-0952-4684-800b-2e4b371c276d",
    "metadata": {},
    "source": [
     "We can repeat this exercise by making our posterior too thin, i.e. the variance of the posterior is too small. Let's cut it by half (`dispersion=0.5`).\n"
@@ -1324,7 +1273,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e893993d-b644-4da8-a0fe-5d4399683d1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,7 +1282,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11201c39-773a-4175-b301-ad5b6404e1c6",
    "metadata": {},
    "outputs": [
     {
@@ -1378,7 +1325,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31fb7dce-be10-4584-8cde-dc7a6ba0c292",
    "metadata": {},
    "source": [
     "The histogram of ranks now shoots above the allowed (greyed) area for a uniform distributed around the extrema. We made the posterior samples too thin, so we received more extreme counts of ranks. The KS p-values vanish again and the `c2st` metric of the ranks is also larger than `0.5` which underlines that our rank distribution is not uniformly distributed.\n"
@@ -1386,7 +1332,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66359a36-6a22-4b1b-8c5a-a9ce4d6425af",
    "metadata": {},
    "source": [
     "We again see, **the rank distribution is capable of identifying pathologies of the estimated posterior**:\n",
@@ -1399,7 +1344,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab0fc2e9-fdef-4f45-8c5c-147c0ad3910a",
    "metadata": {},
    "source": [
     "Simulation-based calibration offers a direct handle on which pathology an estimated posterior examines. Outside of this tutorial, you may very well encounter situations with mixtures of effects (a shifted mean and over-estimated variance). Moreover, uncovering a malignant posterior is only the first step to fix your analysis.\n"
@@ -1408,21 +1352,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "argv": [
-    "python",
-    "-m",
-    "ipykernel_launcher",
-    "-f",
-    "{connection_file}"
-   ],
-   "display_name": "python3",
-   "env": null,
-   "interrupt_mode": "signal",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "metadata": {
-    "debugger": true
-   },
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/14_iid_data_and_permutation_invariant_embeddings.ipynb
+++ b/tutorials/14_iid_data_and_permutation_invariant_embeddings.ipynb
@@ -490,11 +490,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sbi.neural_nets import FCEmbedding, PermutationInvariantEmbedding, posterior_nn\n",
+    "from sbi.neural_nets.embedding_nets import FCEmbedding, PermutationInvariantEmbedding\n",
+    "from sbi.utils import posterior_nn\n",
     "\n",
     "# embedding\n",
     "latent_dim = 10\n",
@@ -574,9 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -907,7 +906,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Our tutorials should be at the state of the released sbi version, not at the state of the github version. This PR fixes this. After being approved and merged I will redeploy.