### PR TITLE
Refactor: Simplify posterior shrinkage tests with pytest marks

### DIFF
--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -195,43 +195,63 @@ def test_mmd_squared_distance(test, sigma):
         assert estimate > threshold, "Accepting 0-hypothesis even though q!=p."
 
 
-def test_posterior_shrinkage():
-    prior_samples = np.array([2])
-    post_samples = np.array([3])
-    assert torch.isnan(posterior_shrinkage(prior_samples, post_samples)[0])
+@pytest.mark.parametrize(
+    "prior_samples, post_samples, expected_shrinkage, raises_exception",
+    [
+        (np.array([2]), np.array([3]), None, False),
+        (
+            np.array([[1, 2], [2, 3]]),
+            np.array([[2, 3], [3, 4]]),
+            torch.tensor([0.0, 0.0]),
+            False,
+        ),
+        (
+            torch.tensor([[1.0, 2.0], [2.0, 3.0]]),
+            torch.tensor([[2.0, 3.0], [3.0, 4.0]]),
+            torch.tensor([0.0, 0.0]),
+            False,
+        ),
+        (np.array([]), np.array([]), None, True),
+    ],
+)
+def test_posterior_shrinkage(
+    prior_samples, post_samples, expected_shrinkage, raises_exception
+):
+    if raises_exception:
+        with pytest.raises(ValueError):
+            posterior_shrinkage(prior_samples, post_samples)
+    else:
+        if expected_shrinkage is not None:
+            assert torch.allclose(
+                posterior_shrinkage(prior_samples, post_samples), expected_shrinkage
+            )
+        else:
+            assert torch.isnan(posterior_shrinkage(prior_samples, post_samples)[0])
 
-    prior_samples = np.array([[1, 2], [2, 3]])
-    post_samples = np.array([[2, 3], [3, 4]])
-    expected_shrinkage = torch.tensor([0.0, 0.0])
-    assert torch.allclose(
-        posterior_shrinkage(prior_samples, post_samples), expected_shrinkage
-    )
 
-    prior_samples = torch.tensor([[1.0, 2.0], [2.0, 3.0]])
-    post_samples = torch.tensor([[2.0, 3.0], [3.0, 4.0]])
-    expected_shrinkage = torch.tensor([0.0, 0.0])
-    assert torch.allclose(
-        posterior_shrinkage(prior_samples, post_samples), expected_shrinkage
-    )
-
-    prior_samples = np.array([])
-    post_samples = np.array([])
-    with pytest.raises(ValueError):
-        posterior_shrinkage(prior_samples, post_samples)
-
-
-def test_posterior_zscore():
-    true_theta = np.array([2, 3])
-    post_samples = np.array([[1, 2], [2, 3], [3, 4]])
-    expected_zscore = torch.tensor([0.0, 0.0])
-    assert torch.allclose(posterior_zscore(true_theta, post_samples), expected_zscore)
-
-    true_theta = torch.tensor([2.0, 3.0])
-    post_samples = torch.tensor([[1.0, 2.0], [2.0, 3.0], [3.0, 4.0]])
-    expected_zscore = torch.tensor([0.0, 0.0])
-    assert torch.allclose(posterior_zscore(true_theta, post_samples), expected_zscore)
-
-    true_theta = np.array([])
-    post_samples = np.array([])
-    with pytest.raises(ValueError):
-        posterior_zscore(true_theta, post_samples)
+@pytest.mark.parametrize(
+    "true_theta, post_samples, expected_zscore, raises_exception",
+    [
+        (
+            np.array([2, 3]),
+            np.array([[1, 2], [2, 3], [3, 4]]),
+            torch.tensor([0.0, 0.0]),
+            False,
+        ),
+        (
+            torch.tensor([2.0, 3.0]),
+            torch.tensor([[1.0, 2.0], [2.0, 3.0], [3.0, 4.0]]),
+            torch.tensor([0.0, 0.0]),
+            False,
+        ),
+        (np.array([]), np.array([]), None, True),
+    ],
+)
+def test_posterior_zscore(true_theta, post_samples, expected_zscore, raises_exception):
+    if raises_exception:
+        with pytest.raises(ValueError):
+            posterior_zscore(true_theta, post_samples)
+    else:
+        assert torch.allclose(
+            posterior_zscore(true_theta, post_samples), expected_zscore
+        )


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Simplified the tests for posterior shrinkage and posterior zscore by using pytest marks to make the code cleaner and easier to manage.

## Does this close any currently open issues?

Fixes #1118 


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [X] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [X] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [X] New and existing unit tests pass locally with my changes
- [X] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [X] I rebased on `main` (or there are no conflicts with `main`)
- [ ] For reviewer: The continuous deployment (CD) workflow are passing.
