### PR TITLE
refactor: remove simulate_for_sbi from tests.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -593,7 +593,9 @@ def simulate_for_sbi(
         simulator: A function that takes parameters $\theta$ and maps them to
             simulations, or observations, `x`, $\text{sim}(\theta)\to x$. Any
             regular Python callable (i.e. function or class with `__call__` method)
-            can be used.
+            can be used. Note that the simulator should be able to handle numpy
+            arrays for efficient parallelization. You can use
+            `process_simulator` to ensure this.
         proposal: Probability distribution that the parameters $\theta$ are sampled
             from.
         num_simulations: Number of simulations that are run.

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -249,6 +249,7 @@ def test_validate_theta_and_x_device(training_device: str, data_device: str) -> 
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize(
     "inference_method", [SNPE_A, SNPE_C, SNRE_A, SNRE_B, SNRE_C, SNLE]
 )

--- a/tests/linearGaussian_mdn_test.py
+++ b/tests/linearGaussian_mdn_test.py
@@ -14,13 +14,11 @@ from sbi.inference import (
     DirectPosterior,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    simulate_for_sbi,
 )
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import process_prior, process_simulator
 from tests.test_utils import check_c2st
 
 
@@ -50,9 +48,9 @@ def test_mdn_inference_with_different_methods(method, mcmc_params_accurate: dict
 
     inference = method(density_estimator="mdn")
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, num_simulations)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
+
     estimator = inference.append_simulations(theta, x).train()
     if method == SNPE:
         posterior = DirectPosterior(posterior_estimator=estimator, prior=prior)
@@ -84,6 +82,7 @@ def test_mdn_with_1D_uniform_prior():
     """
     num_dim = 1
     x_o = torch.tensor([[1.0]])
+    num_simulations = 100
     num_samples = 100
 
     # likelihood_mean will be likelihood_shift+theta
@@ -97,9 +96,9 @@ def test_mdn_with_1D_uniform_prior():
 
     inference = SNPE(density_estimator="mdn")
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, 100)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
+
     posterior_estimator = inference.append_simulations(theta, x).train()
     posterior = DirectPosterior(posterior_estimator=posterior_estimator, prior=prior)
     samples = posterior.sample((num_samples,), x=x_o)

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -29,7 +29,6 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import process_prior, process_simulator
 from tests.test_utils import (
     check_c2st,
     get_dkl_gaussian_prior,
@@ -54,17 +53,10 @@ def test_api_snre_multiple_trials_and_rounds_map(
     simulator = diagonal_linear_gaussian
     inference = snre_method(prior=prior, classifier="mlp", show_progress_bars=False)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-
     proposals = [prior]
     for _ in range(num_rounds):
-        theta, x = simulate_for_sbi(
-            simulator,
-            proposals[-1],
-            num_simulations,
-            simulation_batch_size=num_simulations,
-        )
+        theta = proposals[-1].sample((num_simulations,))
+        x = simulator(theta)
         inference.append_simulations(theta, x).train(
             training_batch_size=100, max_num_epochs=2
         )
@@ -113,12 +105,8 @@ def test_c2st_sre_on_linearGaussian(
 
     inference = snre_method(classifier="resnet", show_progress_bars=False)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-
-    theta, x = simulate_for_sbi(
-        simulator, prior, num_simulations, simulation_batch_size=100
-    )
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     ratio_estimator = inference.append_simulations(theta, x).train()
 
     x_o = zeros(1, x_dim)

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -13,7 +13,6 @@ from sbi.inference import (
     SNLE,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    simulate_for_sbi,
 )
 from sbi.neural_nets import likelihood_nn
 from sbi.samplers.mcmc.pymc_wrapper import PyMCSampler
@@ -26,7 +25,7 @@ from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils.user_input_checks import process_prior, process_simulator
+from sbi.utils.user_input_checks import process_prior
 from tests.test_utils import check_c2st
 
 
@@ -205,12 +204,9 @@ def test_getting_inference_diagnostics(method, mcmc_params_fast: dict):
     simulator = diagonal_linear_gaussian
     density_estimator = likelihood_nn("maf", num_transforms=3)
     inference = SNLE(density_estimator=density_estimator, show_progress_bars=False)
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-
-    theta, x = simulate_for_sbi(
-        simulator, prior, num_simulations, simulation_batch_size=num_simulations
-    )
+    prior, *_ = process_prior(prior)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     likelihood_estimator = inference.append_simulations(theta, x).train(
         training_batch_size=num_simulations, max_num_epochs=2
     )

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -10,9 +10,8 @@ from matplotlib.pyplot import close, subplots
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.analysis import pairplot, plot_summary, sbc_rank_plot
-from sbi.inference import SNLE, SNPE, SNRE, simulate_for_sbi
+from sbi.inference import SNLE, SNPE, SNRE
 from sbi.utils import BoxUniform
-from sbi.utils.user_input_checks import process_prior, process_simulator
 
 
 @pytest.mark.parametrize("samples", (torch.randn(100, 1),))
@@ -99,6 +98,7 @@ def test_pairplot_dep(
 def test_plot_summary(method, tmp_path):
     num_dim = 1
     prior = BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    num_simulations = 6
 
     summary_writer = SummaryWriter(tmp_path)
 
@@ -107,10 +107,9 @@ def test_plot_summary(method, tmp_path):
 
     inference = method(prior=prior, summary_writer=summary_writer)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
 
-    theta, x = simulate_for_sbi(simulator, proposal=prior, num_simulations=6)
     train_kwargs = (
         dict(max_num_epochs=5, validation_fraction=0.5, num_atoms=2)
         if method == SNRE

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -15,10 +15,8 @@ from sbi.inference import (
     SNRE_B,
     SNRE_C,
     DirectPosterior,
-    simulate_for_sbi,
 )
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
-from sbi.utils.user_input_checks import process_prior, process_simulator
 
 
 @pytest.mark.parametrize("snpe_method", [SNPE_A, SNPE_C])
@@ -32,14 +30,14 @@ from sbi.utils.user_input_checks import process_prior, process_simulator
 )
 def test_log_prob_with_different_x(snpe_method: type, x_o_batch_dim: bool):
     num_dim = 2
+    num_simulations = 1000
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
     simulator = diagonal_linear_gaussian
 
     inference = snpe_method(prior=prior)
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, 1000)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     posterior_estimator = inference.append_simulations(theta, x).train(max_num_epochs=3)
 
     if x_o_batch_dim == 0:
@@ -63,14 +61,14 @@ def test_log_prob_with_different_x(snpe_method: type, x_o_batch_dim: bool):
 )
 def test_importance_posterior_sample_log_prob(snplre_method: type):
     num_dim = 2
+    num_simulations = 1000
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
     simulator = diagonal_linear_gaussian
 
     inference = snplre_method(prior=prior)
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, 1000)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=3)
 
     posterior = inference.build_posterior(sample_with="importance")
@@ -93,14 +91,14 @@ def test_batched_sample_log_prob_with_different_x(
     snpe_method: type, x_o_batch_dim: bool
 ):
     num_dim = 2
+    num_simulations = 1000
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
     simulator = diagonal_linear_gaussian
 
     inference = snpe_method(prior=prior)
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, 1000)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     posterior_estimator = inference.append_simulations(theta, x).train(max_num_epochs=3)
 
     x_o = ones(num_dim) if x_o_batch_dim == 0 else ones(x_o_batch_dim, num_dim)
@@ -133,15 +131,15 @@ def test_batched_mcmc_sample_log_prob_with_different_x(
     snlre_method: type, x_o_batch_dim: bool, mcmc_params_fast: dict
 ):
     num_dim = 2
+    num_simulations = 1000
 
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
     simulator = diagonal_linear_gaussian
 
     inference = snlre_method(prior=prior)
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(simulator, prior, 1000)
-    _ = inference.append_simulations(theta, x).train(max_num_epochs=3)
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
+    inference.append_simulations(theta, x).train(max_num_epochs=3)
 
     x_o = ones(num_dim) if x_o_batch_dim == 0 else ones(x_o_batch_dim, num_dim)
 

--- a/tests/posterior_sampler_test.py
+++ b/tests/posterior_sampler_test.py
@@ -12,11 +12,9 @@ from sbi.inference import (
     SNL,
     MCMCPosterior,
     likelihood_estimator_based_potential,
-    simulate_for_sbi,
 )
 from sbi.samplers.mcmc import PyMCSampler, SliceSamplerSerial, SliceSamplerVectorized
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
-from sbi.utils.user_input_checks import process_prior, process_simulator
 
 
 @pytest.mark.mcmc
@@ -52,11 +50,8 @@ def test_api_posterior_sampler_set(
 
     inference = SNL(prior, show_progress_bars=False)
 
-    prior, _, prior_returns_numpy = process_prior(prior)
-    simulator = process_simulator(simulator, prior, prior_returns_numpy)
-    theta, x = simulate_for_sbi(
-        simulator, prior, num_simulations, simulation_batch_size=10
-    )
+    theta = prior.sample((num_simulations,))
+    x = simulator(theta)
     estimator = inference.append_simulations(theta, x).train(max_num_epochs=5)
     potential_fn, transform = likelihood_estimator_based_potential(
         estimator, prior, x_o


### PR DESCRIPTION
`simulate_for_sbi` is causing `main` to fail because it now requires the passed simulator to be able to handle `numpy` arrays. This works only if the simulator has been processed using `process_simulator` before. 

Along the way, I also removed all `simulate_for_sbi` calls from the tests because I believe that we don't need them there. Most priors and simulators we use during testing are torch distributions and simple linear Gaussian simulators. They can be sampled directly, i.e., just sampling the prior and passing the entire `theta` to the simulator. There is no need to use`process_simulator` or `simulate_for_sbi`. 

Of course, there are a couple of exceptions, e.g., when composing independent priors we need to process them. 