### PR TITLE
ci: drop python 3.8, update CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Cache dependency
       id: cache-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
-        torch-version: ['1.11', '2.2']
+        # test minimal and maximal supported python and torch versions
+        python-version: ['3.9', '3.12']
+        torch-version: ['1.8', '2.4']
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # test minimal and maximal supported python and torch versions
         python-version: ['3.9', '3.12']
-        torch-version: ['1.8', '2.4']
+        torch-version: ['1.11', '2.4']
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,14 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.torch-version }}$
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-${{ matrix.python-version }}
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -e .[dev]
 
     - name: Run the fast CPU tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # test minimal and maximal supported python and torch versions
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         # test minimal and maximal supported python and torch versions
         python-version: ['3.9', '3.12']
-        torch-version: ['1.11', '2.4']
 
     steps:
     - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files --show-diff-on-failure
@@ -40,14 +40,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Cache dependency
         id: cache-dependencies
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ubuntu-latest-pip-3.8
+          key: ubuntu-latest-pip-3.9
           restore-keys: |
             ubuntu-latest-pip-
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files --show-diff-on-failure
@@ -40,14 +40,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Cache dependency
         id: cache-dependencies
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ubuntu-latest-pip-3.9
+          key: ubuntu-latest-pip-3.12
           restore-keys: |
             ubuntu-latest-pip-
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@
 
 [Getting Started](https://sbi-dev.github.io/sbi/tutorial/00_getting_started/) | [Documentation](https://sbi-dev.github.io/sbi/)
 
-`sbi` is a PyTorch package for simulation-based inference. Simulation-based inference is
-the process of finding parameters of a simulator from observations.
+`sbi` is a PyTorch package for simulation-based inference. Simulation-based
+inference is the process of inferring the parameters of a simulator from
+observations.
 
-`sbi` takes a Bayesian approach and returns a full posterior distribution over the
-parameters of the simulator, conditional on the observations. The package implements a
-variety of inference algorithms, including _amortized_ and _sequential_ methods.
-Amortized methods return a posterior that can be applied to many different observations
-without retraining; sequential methods focus the inference on one particular observation
-to be more simulation-efficient. See below for an overview of implemented methods.
+`sbi` takes a Bayesian approach and returns the full posterior distribution over
+the parameters of the simulator, conditional on the observations. The package
+implements a variety of inference algorithms, including _amortized_ and
+_sequential_ methods. Amortized methods return a posterior that can be applied
+to many different observations without retraining; sequential methods focus the
+inference on one particular observation to be more simulation-efficient. See
+below for an overview of implemented methods.
 
 `sbi` offers a simple interface for posterior inference in a few lines of code
 
@@ -32,21 +34,27 @@ posterior = inference.build_posterior()
 
 ## Installation
 
-`sbi` requires Python 3.8 or higher. A GPU is not required, but can lead to speed-up in some cases. We recommend to use a [`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual
-environment ([Miniconda installation instructions](https://docs.conda.io/en/latest/miniconda.html)). If `conda` is installed on the system, an environment for installing `sbi` can be created as follows:
+`sbi` requires Python 3.9 or higher. A GPU is not required, but can lead to
+speed-up in some cases. We recommend using a
+[`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual environment
+([Miniconda installation
+instructions](https://docs.conda.io/en/latest/miniconda.html)). If `conda` is
+installed on the system, an environment for installing `sbi` can be created as
+follows:
 
 ```commandline
-# Create an environment for sbi (indicate Python 3.8 or higher); activate it
-$ conda create -n sbi_env python=3.10 && conda activate sbi_env
+# Create an environment for sbi (indicate Python 3.9 or higher); activate it
+$ conda create -n sbi_env python && conda activate sbi_env
 ```
 
-Independent of whether you are using `conda` or not, `sbi` can be installed using `pip`:
+Independent of whether you are using `conda` or not, `sbi` can be installed
+using `pip`:
 
 ```commandline
 pip install sbi
 ```
 
-To test the installation, drop into a python prompt and run
+To test the installation, drop into a Python prompt and run
 
 ```python
 from sbi.examples.minimal import simple
@@ -67,7 +75,9 @@ Jupyter notebooks.
 
 ## Inference Algorithms
 
-The following inference algorithms are currently available. You can find instructions on how to run each of these methods [here](https://sbi-dev.github.io/sbi/tutorial/16_implemented_methods/).
+The following inference algorithms are currently available. You can find
+instructions on how to run each of these methods
+[here](https://sbi-dev.github.io/sbi/tutorial/16_implemented_methods/).
 
 ### Neural Posterior Estimation: amortized (NPE) and sequential (SNPE)
 
@@ -105,23 +115,25 @@ The following inference algorithms are currently available. You can find instruc
 ## Feedback and Contributions
 
 We welcome any feedback on how `sbi` is working for your inference problems (see
-[Discussions](https://github.com/sbi-dev/sbi/discussions)) and are happy to receive bug
-reports, pull requests, and other feedback (see
-[contribute](http://sbi-dev.github.io/sbi/contribute/)). We wish to maintain a positive
-community; please read our [Code of Conduct](CODE_OF_CONDUCT.md).
+[Discussions](https://github.com/sbi-dev/sbi/discussions)) and are happy to
+receive bug reports, pull requests, and other feedback (see
+[contribute](http://sbi-dev.github.io/sbi/contribute/)). We wish to maintain a
+positive community; please read our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Acknowledgments
 
 `sbi` is the successor (using PyTorch) of the
-[`delfi`](https://github.com/mackelab/delfi) package. It started as a fork of Conor M.
-Durkan's `lfi`. `sbi` runs as a community project. See also
+[`delfi`](https://github.com/mackelab/delfi) package. It started as a fork of
+Conor M. Durkan's `lfi`. `sbi` runs as a community project. See also
 [credits](https://github.com/sbi-dev/sbi/blob/master/docs/docs/credits.md).
 
 ## Support
 
-`sbi` has been supported by the German Federal Ministry of Education and Research (BMBF)
-through project ADIMEM (FKZ 01IS18052 A-D), project SiMaLeSAM (FKZ 01IS21055A) and the
-Tübingen AI Center (FKZ 01IS18039A).
+`sbi` has been supported by the German Federal Ministry of Education and
+Research (BMBF) through project ADIMEM (FKZ 01IS18052 A-D), project SiMaLeSAM
+(FKZ 01IS21055A) and the Tübingen AI Center (FKZ 01IS18039A). Since 2024,
+@janfb's contributions to the package have been supported by the appliedAI
+Institute for Europe.
 
 ## License
 
@@ -129,7 +141,9 @@ Tübingen AI Center (FKZ 01IS18039A).
 
 ## Citation
 
-If you use `sbi` consider citing the [sbi software paper](https://doi.org/10.21105/joss.02505), in addition to the original research articles describing the specific sbi-algorithm(s) you are using.
+If you use `sbi` consider citing the [sbi software
+paper](https://doi.org/10.21105/joss.02505), in addition to the original
+research articles describing the specific sbi-algorithm(s) you are using.
 
 ```latex
 @article{tejero-cantero2020sbi,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![GitHub license](https://img.shields.io/github/license/sbi-dev/sbi)](https://github.com/sbi-dev/sbi/blob/master/LICENSE.txt)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.02505/status.svg)](https://doi.org/10.21105/joss.02505)
 
-## sbi: simulation-based inference
+
+# `sbi`: simulation-based inference
 
 [Getting Started](https://sbi-dev.github.io/sbi/tutorial/00_getting_started/) | [Documentation](https://sbi-dev.github.io/sbi/)
 
@@ -34,7 +35,7 @@ posterior = inference.build_posterior()
 
 ## Installation
 
-`sbi` requires Python 3.9 or higher. A GPU is not required, but can lead to
+`sbi` requires Python 3.10 or higher. A GPU is not required, but can lead to
 speed-up in some cases. We recommend using a
 [`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual environment
 ([Miniconda installation
@@ -43,7 +44,7 @@ installed on the system, an environment for installing `sbi` can be created as
 follows:
 
 ```commandline
-# Create an environment for sbi (indicate Python 3.9 or higher); activate it
+# Create an environment for sbi (indicate Python 3.10 or higher); activate it
 $ conda create -n sbi_env python && conda activate sbi_env
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 readme = "README.md"
 keywords = ["Bayesian inference", "simulation-based inference", "PyTorch"]
 dependencies = [
-    "arviz>=0.18.0",
+    "arviz",
     "joblib>=1.0.0",
     "matplotlib",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,9 @@ xfail_strict = true
 
 # Pyright configuration
 [tool.pyright]
-include = ["sbi", "tests"]
+include = ["sbi"]
 exclude = ["**/__pycache__", "**/__node_modules__", ".git", "docs", "examples", "tutorials", "tests"]
-python_version = "3.9"
+python_version = "3.12"
 reportUnsupportedDunderAll = false
 reportGeneralTypeIssues = false
 reportInvalidTypeForm = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,13 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 readme = "README.md"
 keywords = ["Bayesian inference", "simulation-based inference", "PyTorch"]
@@ -58,7 +62,7 @@ dev = [
     # Lint
     "pre-commit == 3.5.0",
     "pyyaml",
-    "pyright == 1.1.355",
+    "pyright",
     "ruff>=0.3.3",
     # Test
     "pytest",
@@ -130,7 +134,7 @@ xfail_strict = true
 [tool.pyright]
 include = ["sbi", "tests"]
 exclude = ["**/__pycache__", "**/__node_modules__", ".git", "docs", "examples", "tutorials", "tests"]
-python_version = "3.8"
+python_version = "3.9"
 reportUnsupportedDunderAll = false
 reportGeneralTypeIssues = false
 reportInvalidTypeForm = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 readme = "README.md"
 keywords = ["Bayesian inference", "simulation-based inference", "PyTorch"]
 dependencies = [
-    "arviz",
+    "arviz>=0.18.0",
     "joblib>=1.0.0",
     "matplotlib",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,18 +22,17 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 readme = "README.md"
 keywords = ["Bayesian inference", "simulation-based inference", "PyTorch"]
 dependencies = [
-    "arviz",
+    "arviz>=0.18.0",
     "joblib>=1.0.0",
     "matplotlib",
     "numpy",

--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -1562,7 +1562,7 @@ def _sbc_rank_plot(
     for idx, rank in enumerate(ranks_list):
         assert isinstance(rank, (Tensor, np.ndarray))
         if isinstance(rank, Tensor):
-            ranks_list[idx] = rank.numpy()
+            ranks_list[idx]: np.ndarray = rank.numpy()  # type: ignore
 
     plot_types = ["hist", "cdf"]
     assert (

--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -183,10 +183,10 @@ def plt_kde_2d(
     ax.imshow(
         Z,
         extent=(
-            limits_col[0],
-            limits_col[1],
-            limits_row[0],
-            limits_row[1],
+            limits_col[0].item(),
+            limits_col[1].item(),
+            limits_row[0].item(),
+            limits_row[1].item(),
         ),
         **offdiag_kwargs["mpl_kwargs"],
     )
@@ -388,6 +388,8 @@ def _format_subplot(
     ):
         ax.set_facecolor(fig_kwargs["fig_bg_colors"][current])
     # Limits
+    if isinstance(limits, torch.Tensor):
+        limits = limits.tolist()
     if current == "diag":
         eps = fig_kwargs["x_lim_add_eps"]
         ax.set_xlim((limits[col][0] - eps, limits[col][1] + eps))
@@ -398,6 +400,8 @@ def _format_subplot(
         ax.set_ylim((limits[row][0], limits[row][1]))
 
     # Ticks
+    if isinstance(ticks, torch.Tensor):
+        ticks = ticks.tolist()
     if ticks is not None:
         ax.set_xticks((ticks[col][0], ticks[col][1]))  # pyright: ignore[reportCallIssue]
         if current != "diag":
@@ -1996,7 +2000,7 @@ def marginal_plot_with_probs_intensity(
         weights = np.array([np.mean(w) for w in weights])
         # remove empty bins
         id = list(set(range(n_bins)) - set(probs_per_marginal["bins"]))
-        patches = np.delete(patches, id)
+        patches = np.delete(np.array(patches), id)
         bins = np.delete(bins, id)
 
         # normalize color intensity

--- a/sbi/analysis/sensitivity_analysis.py
+++ b/sbi/analysis/sensitivity_analysis.py
@@ -8,9 +8,10 @@ from warnings import warn
 
 import torch
 from pyknos.nflows.nn import nets
-from torch import Tensor, nn, optim, relu
+from torch import Tensor, nn, relu
 from torch.nn import MSELoss
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.adam import Adam
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 
@@ -286,7 +287,7 @@ class ActiveSubspace:
                 self._device
             )
 
-        optimizer = optim.Adam(
+        optimizer = Adam(
             list(self._regression_net.parameters()),
             lr=learning_rate,
         )

--- a/sbi/diagnostics/lc2st.py
+++ b/sbi/diagnostics/lc2st.py
@@ -670,15 +670,10 @@ def train_lc2st(
     Returns:
         Trained classifier.
     """
-    # cpu and numpy
-    theta_p = theta_p.cpu().numpy()
-    theta_q = theta_q.cpu().numpy()
-    x_p = x_p.cpu().numpy()
-    x_q = x_q.cpu().numpy()
 
     # concatenate to get joint data
-    joint_p = np.concatenate([theta_p, x_p], axis=1)
-    joint_q = np.concatenate([theta_q, x_q], axis=1)
+    joint_p = np.concatenate([theta_p.cpu().numpy(), x_p.cpu().numpy()], axis=1)
+    joint_q = np.concatenate([theta_q.cpu().numpy(), x_q.cpu().numpy()], axis=1)
 
     # prepare data
     data = np.concatenate((joint_p, joint_q))

--- a/sbi/diagnostics/tarp.py
+++ b/sbi/diagnostics/tarp.py
@@ -366,7 +366,7 @@ def check_tarp(
     midindex = nentries // 2
     atc = float((ecp[midindex:, ...] - alpha[midindex:, ...]).sum())
 
-    kstest_pvals = kstest(ecp.numpy(), alpha.numpy())[1]
+    kstest_pvals: float = kstest(ecp.numpy(), alpha.numpy())[1]  # type: ignore
 
     return atc, kstest_pvals
 

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -6,9 +6,10 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
-from torch import Tensor, optim
+from torch import Tensor
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.base import NeuralInference
@@ -182,7 +183,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         self._neural_net.to(self._device)
         if not resume_training:
-            self.optimizer = optim.Adam(
+            self.optimizer = Adam(
                 list(self._neural_net.parameters()),
                 lr=learning_rate,
             )

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -8,9 +8,10 @@ from typing import Any, Callable, Dict, Optional, Union
 from warnings import warn
 
 import torch
-from torch import Tensor, ones, optim
+from torch import Tensor, ones
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.base import NeuralInference, check_if_proposal_has_default_x
@@ -334,9 +335,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._neural_net.to(self._device)
 
         if not resume_training:
-            self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()), lr=learning_rate
-            )
+            self.optimizer = Adam(list(self._neural_net.parameters()), lr=learning_rate)
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
         while self.epoch <= max_num_epochs and not self._converged(

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -6,9 +6,10 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
-from torch import Tensor, eye, nn, ones, optim
+from torch import Tensor, eye, nn, ones
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.base import NeuralInference
@@ -207,7 +208,7 @@ class RatioEstimator(NeuralInference, ABC):
         self._neural_net.to(self._device)
 
         if not resume_training:
-            self.optimizer = optim.Adam(
+            self.optimizer = Adam(
                 list(self._neural_net.parameters()),
                 lr=learning_rate,
             )

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -8,7 +8,14 @@ import numpy as np
 import torch
 from torch import Tensor, nn
 from torch.distributions import Distribution
-from torch.optim import ASGD, SGD, Adadelta, Adagrad, Adam, AdamW, Adamax, RMSprop
+from torch.optim.adadelta import Adadelta
+from torch.optim.adagrad import Adagrad
+
+# TODO: import every optimizer directly from torch.optim
+from torch.optim.adam import Adam
+from torch.optim.adamax import Adamax
+from torch.optim.adamw import AdamW
+from torch.optim.asgd import ASGD
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     CosineAnnealingWarmRestarts,
@@ -17,6 +24,8 @@ from torch.optim.lr_scheduler import (
     LambdaLR,
     StepLR,
 )
+from torch.optim.rmsprop import RMSprop
+from torch.optim.sgd import SGD
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.samplers.vi.vi_utils import (

--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -168,13 +168,10 @@ def c2st_scores(
         X += noise_scale * torch.randn(X.shape)
         Y += noise_scale * torch.randn(Y.shape)
 
-    X = X.cpu().numpy()
-    Y = Y.cpu().numpy()
-
     clf = clf_class(random_state=seed, **clf_kwargs or {})
 
-    # prepare data
-    data = np.concatenate((X, Y))
+    # prepare data, convert to numpy
+    data = np.concatenate((X.cpu().numpy(), Y.cpu().numpy()))
     # labels
     target = np.concatenate((np.zeros((X.shape[0],)), np.ones((Y.shape[0],))))
 
@@ -183,7 +180,7 @@ def c2st_scores(
         clf, data, target, cv=shuffle, scoring=metric, verbose=verbosity
     )
 
-    return scores
+    return torch.from_numpy(scores).mean()
 
 
 def unbiased_mmd_squared(x: Tensor, y: Tensor, scale: Optional[float] = None):

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -8,9 +8,10 @@ from typing import Any, Callable, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 from pyknos.nflows.nn import nets
-from torch import Tensor, nn, optim, relu
+from torch import Tensor, nn, relu
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.adam import Adam
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler, WeightedRandomSampler
 
@@ -325,7 +326,7 @@ class RestrictionEstimator:
             self._first_round_validation_theta = theta[val_indices]
             self._first_round_validation_label = label[val_indices]
 
-        optimizer = optim.Adam(
+        optimizer = Adam(
             list(self._classifier.parameters()),
             lr=learning_rate,
         )


### PR DESCRIPTION
- Drop python 3.8: Python security support will end in October 2024
- Update CI test versions: we now test python 3.9 and 3.12, with torch version determined accordingly
- Update `pyright` settings: drop pin to `pyright==355`, use latest version and python 3.12 instead. Fix all errors. 

- update readme wording and python version
- update acknowledgments in readme.