### PR TITLE
Fix type annotation in class 'ConditionedPotential'.

### DIFF
--- a/sbi/analysis/conditional_density.py
+++ b/sbi/analysis/conditional_density.py
@@ -10,6 +10,7 @@ from pyknos.mdn.mdn import MultivariateGaussianMDN
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils.conditional_density_utils import (
     ConditionedPotential,
@@ -234,7 +235,7 @@ class ConditionedMDN:
 
 
 def conditonal_potential(
-    potential_fn: Callable,
+    potential_fn: BasePotential,
     theta_transform: TorchTransform,
     prior: Distribution,
     condition: Tensor,
@@ -257,7 +258,7 @@ def conditonal_potential(
 
 
 def conditional_potential(
-    potential_fn: Callable,
+    potential_fn: BasePotential,
     theta_transform: TorchTransform,
     prior: Distribution,
     condition: Tensor,

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -1,7 +1,8 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+from __future__ import annotations
 
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -23,7 +24,7 @@ def posterior_estimator_based_potential(
     prior: Distribution,
     x_o: Optional[Tensor],
     enable_transform: bool = True,
-) -> Tuple[Callable, TorchTransform]:
+) -> Tuple[PosteriorBasedPotential, TorchTransform]:
     r"""Returns the potential for posterior-based methods.
 
     It also returns a transformation that can be used to transform the potential into

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -11,6 +11,7 @@ from pyknos.nflows.flows import Flow
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.utils.torchutils import ensure_theta_batched
 from sbi.utils.user_input_checks import process_x
 
@@ -273,7 +274,7 @@ def condition_mog(
 class ConditionedPotential:
     def __init__(
         self,
-        potential_fn: Callable,
+        potential_fn: BasePotential,
         condition: Tensor,
         dims_to_sample: List[int],
     ):


### PR DESCRIPTION
Fix type annotation in class 'ConditionedPotential'. Correct return type

of the function 'posterior_estimator_based_potential'

## What does this implement/fix? Explain your changes

- The argument `potential_fn` of the class `ConditionedPotential` must be of type `BasePotential`

## Does this close any currently open issues?

Fixes #1055

## Any relevant code examples, logs, error output, etc?

...

## Any other comments?

...

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [x] ~I have commented my code, particularly in hard-to-understand areas~
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] ~I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.~
- [x] ~New and existing unit tests pass locally with my changes~
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
- [ ] For reviewer: The continuous deployment (CD) workflow are passing.
