### PR TITLE
Fix erroneous warnings about different devices

### DIFF
--- a/sbi/utils/nn_utils.py
+++ b/sbi/utils/nn_utils.py
@@ -54,7 +54,7 @@ def check_net_device(
 
     if isinstance(net, nn.Identity):
         return net
-    if str(next(net.parameters()).device) != device:
+    if str(next(net.parameters()).device) != str(device):
         warn(
             message or f"Network is not on the correct device. Moving it to {device}.",
             stacklevel=2,

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -715,7 +715,7 @@ def validate_theta_and_x(
     assert theta.dtype == float32, "Type of parameters must be float32."
     assert x.dtype == float32, "Type of simulator outputs must be float32."
 
-    if str(x.device) != data_device:
+    if str(x.device) != str(data_device):
         warnings.warn(
             f"Data x has device '{x.device}'. "
             f"Moving x to the data_device '{data_device}'. "
@@ -724,7 +724,7 @@ def validate_theta_and_x(
         )
         x = x.to(data_device)
 
-    if str(theta.device) != data_device:
+    if str(theta.device) != str(data_device):
         warnings.warn(
             f"Parameters theta has device '{theta.device}'. "
             f"Moving theta to the data_device '{data_device}'. "


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Fix for erroneous warnings saying tensors are on different devices when they are on the same device. 

This bug occurs when PyTorch `device` objects are used rather than their string representations. In the comparisons that check the tensors are on the right device one side is cast to a string but not the other. When `device` objects are used this leads to comparing an object to a string and hence them not being equal and a warning being raised, e.g.,
```text
UserWarning: Data x has device 'cuda:0'. Moving x to the data_device 'cuda:0'. Training will proceed on device 'cuda:0'.
  theta, x = validate_theta_and_x(
```

This bug is fixed by casting both sides of the comparison to strings. 

## Does this close any currently open issues?

None

## Any relevant code examples, logs, error output, etc?

Minimum working example to illustrate bug and replicate the warning shown above,

```python
"""MWE Example of erroneous warning in device comparison."""

import torch
from sbi.inference import SNPE
from sbi.utils.user_input_checks import process_prior, process_simulator

# Set device to GPU
device = torch.device("cuda:0")

# Define prior and simulator to be on the GPU
prior = torch.distributions.MultivariateNormal(
    torch.zeros(2, dtype=float, device=device), torch.eye(2, dtype=float, device=device)
)
simulator = lambda theta: theta

prior.sample()
prior, num_parameters, prior_returns_numpy = process_prior(prior)
simulator = process_simulator(simulator, prior, prior_returns_numpy)

# Also set the NPE to be on the same GPU
inference = SNPE(prior=prior, device=device)
theta = prior.sample((100,))
x = simulator(theta)
inference = inference.append_simulations(theta, x)

# This will raise a warning saying that the device of the density estimator is different from the 
# device of the prior even though they are both on the same GPU
density_estimator = inference.train(max_num_epochs=1)
```

## Any other comments?

None

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [x] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I rebased on `main` (or there are no conflicts with `main`)
- [x] For reviewer: The continuous deployment (CD) workflow are passing.
