### PR TITLE
fix: init file for score module, remove examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,7 +12,6 @@ recursive-include docs *.svg
 recursive-include docs *.yml
 recursive-include docs *.py
 
-recursive-include examples *.py
 recursive-include sbi *.md
 recursive-include tests *.md
 recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ ignore = [
 case-sensitive = true
 lines-between-types = 0  # like isort default.
 relative-imports-order = "furthest-to-closest"  # like isort default.
-known-first-party = ["sbi", "tests", "examples", "tutorials"]
+known-first-party = ["sbi", "tests", "tutorials"]
 
 [tool.ruff.format]
 exclude = ["*.ipynb"]


### PR DESCRIPTION
adds `__init__.py` to `score` to include it into the package. 