### PR TITLE
fixup for failing hmc test

### DIFF
--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -137,7 +137,7 @@ def test_c2st_pymc_sampler_on_Gaussian(
     step: str,
     num_chains: int,
     num_dim: int = 2,
-    num_samples: int = 1000,
+    num_samples: int = 1100,  # Had to change from 1000 to 1100 in #1247.
     warmup: int = 100,
 ):
     """Test PyMC on Gaussian, comparing to ground truth target via c2st."""


### PR DESCRIPTION
CD tests are failing on `main` right now `C2ST: 0.6028045112781955 <= (0.5 + 0.1)` for `test_c2st_pymc_sampler_on_Gaussian`. I cannot reproduce this failure locally (neither on python 3.9 nor on 3.12). However, to get github actions to run, I slightly increased the number of samples.