### PR TITLE
update pickling FAQ

### DIFF
--- a/docs/docs/faq/question_05_pickling.md
+++ b/docs/docs/faq/question_05_pickling.md
@@ -13,7 +13,10 @@ with open("/path/to/my_posterior.pkl", "wb") as handle:
     pickle.dump(posterior, handle)
 ```
 
-Note: posterior objects that were saved under `sbi v0.17.2` or older can not be
+Note: posterior objects that were saved under `sbi v0.22.0` or older cannot be
+loaded under `sbi v0.23.0` or newer.
+
+Note: posterior objects that were saved under `sbi v0.17.2` or older cannot be
 loaded under `sbi v0.18.0` or newer.
 
 Note: if you try to load a posterior that was saved under `sbi v0.14.x` or


### PR DESCRIPTION
See #1254

Sampling of old posteriors under v0.23.1 leads to errors. I don't think that these errors have an easy fix, so I am adding this to the FAQ.

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[8], line 1
----> 1 posterior.sample((100,), x=torch.ones((1, 3)))

File [~/anaconda3/envs/sbidebug/lib/python3.12/site-packages/sbi/inference/posteriors/direct_posterior.py:111](http://localhost:8888/lab/workspaces/~/anaconda3/envs/sbidebug/lib/python3.12/site-packages/sbi/inference/posteriors/direct_posterior.py#line=110), in DirectPosterior.sample(self, sample_shape, x, max_sampling_batch_size, sample_with, show_progress_bars)
    108 num_samples = torch.Size(sample_shape).numel()
    109 x = self._x_else_default_x(x)
    110 x = reshape_to_batch_event(
--> 111     x, event_shape=self.posterior_estimator.condition_shape
    112 )
    114 max_sampling_batch_size = (
    115     self.max_sampling_batch_size
    116     if max_sampling_batch_size is None
    117     else max_sampling_batch_size
    118 )
    120 if sample_with is not None:

File [~/anaconda3/envs/sbidebug/lib/python3.12/site-packages/torch/nn/modules/module.py:1729](http://localhost:8888/lab/workspaces/~/anaconda3/envs/sbidebug/lib/python3.12/site-packages/torch/nn/modules/module.py#line=1728), in Module.__getattr__(self, name)
   1727     if name in modules:
   1728         return modules[name]
-> 1729 raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

AttributeError: 'Flow' object has no attribute 'condition_shape'
```