### PR TITLE
Fix npe iid handling

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -402,21 +402,6 @@ def nle_nre_apt_msg_on_invalid_x(
             )
 
 
-def warn_on_batched_x(batch_size):
-    """Warn if more than one x was passed."""
-
-    if batch_size > 1:
-        warnings.warn(
-            f"An x with a batch size of {batch_size} was passed. "
-            "Unless you are using `sample_batched` or `log_prob_batched`, this will "
-            "be interpreted as a batch of independent and identically distributed data"
-            " X={x_1, ..., x_n}, i.e., data generated based on the same underlying"
-            "(unknown) parameter. The resulting posterior will be with respect to"
-            " the entire batch, i.e,. p(theta | X).",
-            stacklevel=2,
-        )
-
-
 def check_warn_and_setstate(
     state_dict: Dict,
     key_name: str,

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -12,7 +12,7 @@ from torch import Tensor, float32, nn
 from torch.distributions import Distribution, Uniform
 
 from sbi.sbi_types import Array
-from sbi.utils.sbiutils import warn_on_batched_x, within_support
+from sbi.utils.sbiutils import within_support
 from sbi.utils.torchutils import BoxUniform, atleast_2d
 from sbi.utils.user_input_checks_utils import (
     CustomPriorWrapper,
@@ -582,7 +582,6 @@ def process_x(x: Array, x_event_shape: Optional[torch.Size] = None) -> Tensor:
         x = x.unsqueeze(0)
 
     input_x_shape = x.shape
-    warn_on_batched_x(batch_size=input_x_shape[0])
 
     if x_event_shape is not None:
         # Number of trials can change for every new x, but single trial x shape must

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -35,7 +35,7 @@ from tests.test_utils import check_c2st
         pytest.param(
             2,
             marks=pytest.mark.xfail(
-                raises=AssertionError,
+                raises=ValueError,
                 reason=".log_prob() supports only batch size 1 for x_o.",
             ),
         ),


### PR DESCRIPTION
fixes #1256 

Note: I removed `warn_on_batched_x` because it was shown whenever a batched `x` is passed, i.e., even when explicitly calling `sample_batched`. I think we do not need to issue the warning when calling the batched methods because users explicitly call those methods for the batched case.

For the iid case, in NPE, the user has to use a corresponding embedding net anyways, so this warning is also not helpful. 

For the iid base in likelihood-based methods, it is natural that we can sample iid data, so also no need to issue the warning. 