### PR TITLE
build: automatic nb stripping and pypi upload

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,6 @@ your code.
 
 - [ ] I have read and understood the [contribution
   guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
-- [ ] I agree with re-licensing my contribution from AGPLv3 to Apache-2.0.
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have reported how long the new tests run and potentially marked them
@@ -31,5 +30,9 @@ your code.
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I performed linting and formatting as described in the [contribution
   guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
-- [ ] I rebased on `main` (or there are no conflicts with `main`)
-- [ ] For reviewer: The continuous deployment (CD) workflow are passing.
+- [ ] There are no conflicts with the `main` branch
+
+For the reviewer:
+
+- [ ] I have reviewed every file
+- [ ] All comments have been addressed.

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -34,6 +34,10 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .[doc]
 
+    - name: strip output except plots and prints from tutorial notebooks
+      run: |
+        python tests/strip_notebook_outputs.py tutorials/
+
     - name: convert notebooks to markdown
       run: |
         cd docs

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,4 +1,4 @@
-name: "Build docs and deploy"
+name: "Build and deploy docs"
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,96 @@
+name: Build and publish 📦
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish to PyPI 🐍
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sbi
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign with Sigstore 🔐
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,18 +49,18 @@ dependencies = [
 [project.optional-dependencies]
 doc = [
     # Documentation
-    "jupyter_contrib_nbextensions",
-    "notebook <= 6.4.12",
-    "nbconvert",
-    "nbformat",
-    "traitlets <= 5.9.0",
     "ipython <= 8.9.0",
+    "jupyter_contrib_nbextensions",
+    "mike",
     "mkdocs",
-    "mkdocs-material",
     "markdown-include",
+    "mkdocs-material",
     "mkdocs-redirects",
     "mkdocstrings[python] >= 0.18",
-    "mike"
+    "nbconvert",
+    "nbformat",
+    "notebook <= 6.4.12",
+    "traitlets <= 5.9.0",
 ]
 dev = [
     "ffmpeg",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ doc = [
     # Documentation
     "jupyter_contrib_nbextensions",
     "notebook <= 6.4.12",
+    "nbconvert",
+    "nbformat",
     "traitlets <= 5.9.0",
     "ipython <= 8.9.0",
     "mkdocs",

--- a/tests/strip_notebook_outputs.py
+++ b/tests/strip_notebook_outputs.py
@@ -1,0 +1,80 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+# Script to strip outputs of Jupyter notebooks except for plots and prints so that there
+# are displayed nicely on the documentation website.
+
+import os
+
+import nbformat
+from nbconvert.preprocessors import Preprocessor
+
+
+class StripOutputExceptPlotsAndPrintsPreprocessor(Preprocessor):
+    """Subclass of nbconvert.preprocessors.Preprocessor to strip notebook outputs"""
+
+    def preprocess_cell(
+        self, cell: nbformat.NotebookNode, resources: dict, cell_index: int
+    ) -> tuple:
+        """Preprocess a cell
+
+        Note, this method will be called internall by the Preprocessor.preprocess
+        method and needs to have this specific signature.
+
+        Args:
+            cell: The cell to preprocess
+            resources: Additional resources used in the conversion process
+            cell_index: The index of the cell
+        """
+        if cell.cell_type == 'code':
+            # Retain outputs that contain either 'image/png' or 'stdout' (prints)
+            cell.outputs = [
+                output
+                for output in cell.outputs
+                if ('data' in output and 'image/png' in output['data'])
+                or (
+                    output.get('output_type') == 'stream'
+                    and output.get('name') == 'stdout'
+                )
+            ]
+        return cell, resources
+
+
+def strip_output_except_plots_and_prints(notebook_path):
+    """Strip the output from a Jupyter notebook, except for plots and prints"""
+
+    # Read the notebook
+    with open(notebook_path, 'r') as f:
+        nb = nbformat.read(f, as_version=4)
+
+    # Strip the output
+    preprocessor = StripOutputExceptPlotsAndPrintsPreprocessor()
+    nb, _ = preprocessor.preprocess(nb, {})
+
+    # Write the notebook back to disk
+    with open(notebook_path, 'w') as f:
+        nbformat.write(nb, f)
+
+
+def strip_notebooks_in_directory(directory):
+    """Strip output from all notebooks in a directory, except for plots and prints"""
+
+    # Walk through the directory
+    for root, _, files in os.walk(directory):
+        for file in files:
+            # Filter for Jupyter notebooks
+            if file.endswith(".ipynb"):
+                notebook_path = os.path.join(root, file)
+                strip_output_except_plots_and_prints(notebook_path)
+
+
+# Add main to run the script from the command line for GitHub Actions
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python strip_notebook_outputs.py <notebooks_directory>")
+        sys.exit(1)
+
+    notebooks_directory = sys.argv[1]
+    strip_notebooks_in_directory(notebooks_directory)


### PR DESCRIPTION
- [x] add script for stripping notebook output
- [x] add it to docs CI to automatically strip notebooks before building the docs
- [x] add workflow for the automatic upload to PyPI upon a new release. 
- [x] add trusted publisher to `sbi` PyPI project

## Relevant links
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/