### PR TITLE
docs: add readme intro to docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 both researchers and practitioners. Whether you need fine-grained control or an
 easy-to-use interface, `sbi` has you covered.
 
-With `sbi`, you can perform simulation-based inference (SBI) using a Bayesian approach:
-Given a simulator that models a real-world process, SBI estimates the full posterior
+With `sbi`, you can perform parameter inference using Bayesian inference: Given a
+simulator that models a real-world process, SBI estimates the full posterior
 distribution over the simulator’s parameters based on observed data. This distribution
 indicates the most likely parameter values while additionally quantifying uncertainty
 and revealing potential interactions between parameters.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,5 +1,15 @@
 # `sbi`: simulation-based inference toolkit
 
+`sbi` is a Python package for simulation-based inference, designed to meet the needs of
+both researchers and practitioners. Whether you need fine-grained control or an
+easy-to-use interface, `sbi` has you covered.
+
+With `sbi`, you can perform parameter inference using Bayesian inference: Given a
+simulator that models a real-world process, SBI estimates the full posterior
+distribution over the simulator’s parameters based on observed data. This distribution
+indicates the most likely parameter values while additionally quantifying uncertainty
+and revealing potential interactions between parameters.
+
 `sbi` provides access to simulation-based inference methods via a user-friendly
 interface:
 


### PR DESCRIPTION
At the moment, the docs website landing page starts a bit abruptly directly with the code snippet. 

I think it is nice to have the same short intro text that we use in the updated readme as well. 

What do you think?

In the future it would be nice to show a plot there as well. 