### PR TITLE
fix: posterior potential iid handling

### DIFF
--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -89,11 +89,11 @@ class PosteriorBasedPotential(BasePotential):
         For posterior-based methods, `x_o` is not allowed to be iid, as we assume that
         iid `x` is handled by a Permutation Invariant embedding net.
         """
-        if x_is_iid:
+        if x_is_iid and x_o is not None and x_o.shape[0] > 1:
             raise NotImplementedError(
-                "For NPE, iid `x` must be handled by a Permutation Invariant embedding \
-                    net. Therefore, the iid dimension of `x` is added to the event\
-                        dimension of `x`. Please set `x_is_iid=False`."
+                "For NPE, iid `x` must be handled by a permutation invariant embedding "
+                "net. Therefore, the iid dimension of `x` is added to the event "
+                "dimension of `x`. Please set `x_is_iid=False`."
             )
         else:
             super().set_x(x_o, x_is_iid=False)

--- a/tests/linearGaussian_fmpe_test.py
+++ b/tests/linearGaussian_fmpe_test.py
@@ -287,8 +287,8 @@ def test_sample_conditional():
     # Evaluate the conditional density be drawing samples and smoothing with a Gaussian
     # kde.
     potential_fn, theta_transform = posterior_estimator_based_potential(
-        posterior_estimator, prior=prior, x_o=x_o
-    )
+        posterior_estimator, prior=prior
+    ).set_x(x_o, x_is_iid=False)
     (
         conditioned_potential_fn,
         restricted_tf,

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -558,8 +558,8 @@ def test_sample_conditional(mcmc_params_accurate: dict):
     # Evaluate the conditional density be drawing samples and smoothing with a Gaussian
     # kde.
     potential_fn, theta_transform = posterior_estimator_based_potential(
-        posterior_estimator, prior=prior, x_o=x_o
-    )
+        posterior_estimator, prior=prior
+    ).set_x(x_o, x_is_iid=False)
     (
         conditioned_potential_fn,
         restricted_tf,


### PR DESCRIPTION
Somehow the iid handling for NPE was failing because is was not checking for the shape > 1, but directly failing when `x_is_iid=True`. 