### PR TITLE
Check if 'cnn_output_size' is zero in CNNembedding. 

### DIFF
--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -142,8 +142,8 @@ class CNNEmbedding(nn.Module):
             # Calculate change of output size of each CNN layer
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
 
-            assert (
-                all(cnn_output_size)
+            assert all(
+                cnn_output_size
             ), f"""CNN output size is zero at layer {ii + 1}. Either reduce
                  num_cnn_layers to {ii} or adjust the kernel_size
                  and pool_kernel_size accordingly."""

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -140,6 +140,10 @@ class CNNEmbedding(nn.Module):
             cnn_layers += [conv_layer, nn.ReLU(inplace=True), pool]
             # Calculate change of output size of each CNN layer
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
+            assert (
+            cnn_output_size > 0
+            ), f"""CNN output size is zero at layer {ii}. Either decrease num_cnn_layers
+                 or adjust the kernel_size and pool_kernel_size accordingly."""
 
         self.cnn_subnet = nn.Sequential(*cnn_layers)
 

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -141,9 +141,10 @@ class CNNEmbedding(nn.Module):
             # Calculate change of output size of each CNN layer
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
             assert (
-            cnn_output_size[0] > 0 and cnn_output_size[1] > 0
-            ), f"""CNN output size is zero at layer {ii+1}. Either reduce num_cnn_layers
-                 to {ii} or adjust the kernel_size and pool_kernel_size accordingly."""
+                cnn_output_size[0] > 0 and cnn_output_size[1] > 0
+            ), f"""CNN output size is zero at layer {ii + 1}. Either reduce
+                 num_cnn_layers to {ii} or adjust the kernel_size
+                 and pool_kernel_size accordingly."""
 
         self.cnn_subnet = nn.Sequential(*cnn_layers)
 

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -143,9 +143,7 @@ class CNNEmbedding(nn.Module):
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
 
             assert (
-                cnn_output_size[0] > 0 and cnn_output_size[1] > 0
-                if len(cnn_output_size) > 1
-                else True  # check for 2D conv
+                all(cnn_output_size)
             ), f"""CNN output size is zero at layer {ii + 1}. Either reduce
                  num_cnn_layers to {ii} or adjust the kernel_size
                  and pool_kernel_size accordingly."""

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -141,9 +141,9 @@ class CNNEmbedding(nn.Module):
             # Calculate change of output size of each CNN layer
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
             assert (
-            cnn_output_size > 0
-            ), f"""CNN output size is zero at layer {ii}. Either decrease num_cnn_layers
-                 or adjust the kernel_size and pool_kernel_size accordingly."""
+            cnn_output_size[0] > 0 and cnn_output_size[1] > 0
+            ), f"""CNN output size is zero at layer {ii+1}. Either reduce num_cnn_layers
+                 to {ii} or adjust the kernel_size and pool_kernel_size accordingly."""
 
         self.cnn_subnet = nn.Sequential(*cnn_layers)
 

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -127,6 +127,7 @@ class CNNEmbedding(nn.Module):
         cnn_output_size = input_shape
         stride = 1
         padding = 1
+
         for ii in range(num_conv_layers):
             # Defining another 2D convolution layer
             conv_layer = conv_module(
@@ -140,8 +141,11 @@ class CNNEmbedding(nn.Module):
             cnn_layers += [conv_layer, nn.ReLU(inplace=True), pool]
             # Calculate change of output size of each CNN layer
             cnn_output_size = get_new_cnn_output_size(cnn_output_size, conv_layer, pool)
+
             assert (
                 cnn_output_size[0] > 0 and cnn_output_size[1] > 0
+                if len(cnn_output_size) > 1
+                else True  # check for 2D conv
             ), f"""CNN output size is zero at layer {ii + 1}. Either reduce
                  num_cnn_layers to {ii} or adjust the kernel_size
                  and pool_kernel_size accordingly."""


### PR DESCRIPTION
When configuring the CNN-based embedding layer using `sbi.neural_nets.embedding_nets.CNNEmbedding`, setting the parameters for `num_cnn_layers`, `kernel_size`, and `pool_kernel_size` incorrectly may result in a vague error message, such as:

`RuntimeError: Given input size: (6x4x4). Calculated output size: (6x0x0). Output size is too small.`

**Proposed Solution**: 
Since the `cnn_output_size` is recalculated after each layer, a CNN setup with excessive depth results in an output size of zero. This could be leveraged to alert the user about appropriate layer size configurations or to adjust other parameters accordingly.