### PR TITLE
Wrap 1D PyTorch distributions

### DIFF
--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -17,6 +17,7 @@ from sbi.utils.torchutils import BoxUniform, atleast_2d
 from sbi.utils.user_input_checks_utils import (
     CustomPriorWrapper,
     MultipleIndependent,
+    OneDimPriorWrapper,
     PytorchReturnTypeWrapper,
 )
 
@@ -219,6 +220,11 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
 
     # This will fail for float64 priors.
     check_prior_return_type(prior)
+
+    # Potentially required wrapper if the prior returns an additional sample dimension
+    # for `.log_prob()`.
+    if prior.log_prob(prior.sample(torch.Size((10,)))).shape == torch.Size([10, 1]):
+        prior = OneDimPriorWrapper(prior, validate_args=False)
 
     theta_numel = prior.sample().numel()
 


### PR DESCRIPTION
Closes #1285 an #1284

1D pytorch distributions such as `torch.distributions.Exponential`, `.Uniform`, or `.Normal` do not, by default return __any__ sample or batch dimension. E.g.:
```python
dist = torch.distributions.Exponential(torch.tensor(3.0))
dist.sample((10,)).shape  # (10,)
```

`sbi` will raise an error that the sample dimension is missing. A simple solution is to add a batch dimension to `dist` as follows:
```python
dist = torch.distributions.Exponential(torch.tensor([3.0]))
dist.sample((10,)).shape  # (10, 1)
```

Unfortunately, this `dist` will return the batch dimension also for `.log_prob():
```python
dist = torch.distributions.Exponential(torch.tensor([3.0]))
samples = dist.sample((10,))
dist.log_prob(samples).shape  # (10, 1)
```

This will lead to unexpected errors in `sbi`. The point of this PR is to wrap those batched 1D distributions to get rid of their batch dimension in `.log_prob()`.