### PR TITLE
Fix pickle issues in MCMC posterior + test

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -1049,6 +1049,19 @@ class MCMCPosterior(NeuralPosterior):
 
         return inference_data
 
+    def __getstate__(self) -> Dict:
+        """Get state of MCMCPosterior.
+
+        Removes the posterior sampler from the state, as it may not be picklable.
+
+        Returns:
+            Dict: State of MCMCPosterior.
+        """
+        state = self.__dict__.copy()
+        state["_posterior_sampler"] = None
+
+        return state
+
 
 def _process_thin_default(thin: int) -> int:
     """

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -4,6 +4,7 @@
 import pickle
 
 import pytest
+from sbi.inference.posteriors.vi_posterior import VIPosterior
 import torch
 
 from sbi import utils as utils
@@ -33,6 +34,12 @@ def test_picklability(inference_method, sampling_method: str, tmp_path):
     posterior = inference.build_posterior(sample_with=sampling_method).set_default_x(
         x_o
     )
+
+    # After sample and log_prob, the posterior should still be picklable
+    if isinstance(posterior, VIPosterior):
+        posterior.train(max_num_iters=10)
+    _ = posterior.sample((1,))
+    _ = posterior.log_prob(torch.zeros(1, num_dim))
 
     with open(f"{tmp_path}/saved_posterior.pickle", "wb") as handle:
         pickle.dump(posterior, handle)

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -4,11 +4,11 @@
 import pickle
 
 import pytest
-from sbi.inference.posteriors.vi_posterior import VIPosterior
 import torch
 
 from sbi import utils as utils
 from sbi.inference import NLE, NPE, NRE
+from sbi.inference.posteriors.vi_posterior import VIPosterior
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR address the issue of the MCMCPosterior not being pickable after running sample.

## Does this close any currently open issues?

Fixes #1278  

## Any other comments?

Extended the save and load tests to be performed after calling sample and log_prob once.
