### PR TITLE
Minor fix for EnsemblePosterior weights.setter

### DIFF
--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -137,7 +137,7 @@ class EnsemblePosterior(NeuralPosterior):
             self._weights = torch.tensor([
                 1.0 / self.num_components for _ in range(self.num_components)
             ])
-        elif isinstance(weights, Tensor) or isinstance(weights, List):
+        elif isinstance(weights, (Tensor, List)):
             self._weights = torch.tensor(weights) / sum(weights)
         else:
             raise TypeError

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -137,7 +137,7 @@ class EnsemblePosterior(NeuralPosterior):
             self._weights = torch.tensor([
                 1.0 / self.num_components for _ in range(self.num_components)
             ])
-        elif weights is Tensor or weights is List:
+        elif isinstance(weights, Tensor) or isinstance(weights, List):
             self._weights = torch.tensor(weights) / sum(weights)
         else:
             raise TypeError


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

In sbi.inference.posteriors, the [EnsemblePosterior](https://github.com/sbi-dev/sbi/blob/main/sbi/inference/posteriors/ensemble_posterior.py) instantiation would return a **TypeError** when passing weights (torch.Tensor or List[float]).  The condition  `elif weights is Tensor or weights is List` would always return False, I changed the condition to` elif isinstance(weights, Tensor) or isinstance(weights, List)`, where Tensor is the torch class of the same name.

## Does this close any currently open issues?

No, to the best of my knowledge.

## Any relevant code examples, logs, error output, etc?

The only "fix" is intended to properly test the type of the weights attribute of [EnsemblePosterior](https://github.com/sbi-dev/sbi/blob/main/sbi/inference/posteriors/ensemble_posterior.py) in case it is not None.

## Any other comments?

I do not know whether I should have opened an new issue instead of doing a minor one-line PR. I will leave empty most of the Checklist items below.
...

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [ x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [ x] There are no conflicts with the `main` branch

For the reviewer:

- [x] I have reviewed every file
- [x] All comments have been addressed.
