### PR TITLE
docs: Add conda-forge install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![PyPI version](https://badge.fury.io/py/sbi.svg)](https://badge.fury.io/py/sbi)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/sbi.svg)](https://github.com/conda-forge/sbi-feedstock)
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/sbi-dev/sbi/blob/master/CONTRIBUTING.md)
 [![Tests](https://github.com/sbi-dev/sbi/actions/workflows/ci.yml/badge.svg)](https://github.com/sbi-dev/sbi/actions)
 [![codecov](https://codecov.io/gh/sbi-dev/sbi/branch/main/graph/badge.svg)](https://codecov.io/gh/sbi-dev/sbi)
@@ -62,22 +63,36 @@ posterior = inference.build_posterior()
 performance in some cases. We recommend using a virtual environment with
 [`conda`](https://docs.conda.io/en/latest/miniconda.html) for an easy setup.
 
-To install `sbi`, follow these steps:
+If `conda` is installed on the system, an environment for installing `sbi` can be created as follows:
 
-1. **Create a Conda Environment** (if using Conda):
+```
+conda create -n sbi_env python=3.9 && conda activate sbi_env
+```
 
-   ```bash
-   conda create -n sbi_env python=3.9 && conda activate sbi_env
-   ```
+### From PyPI
 
-2. **Install `sbi`**: Independent of whether you are using `conda` or not, `sbi` can be
-   installed using `pip`:
+To install `sbi` from PyPI run
 
-  ```commandline
-  pip install sbi
-  ```
+```
+python -m pip install sbi
+```
 
-3. **Test the installation**:
+### From conda-forge
+
+To install and add `sbi` to a project with [`pixi`](https://pixi.sh/), from the project directory run
+
+```
+pixi add sbi
+```
+
+and to install into a particular conda environment with [`conda`](https://docs.conda.io/projects/conda/), in the activated environment run
+
+```
+conda install --channel conda-forge sbi
+```
+
+### Test the installation
+
 Open a Python prompt and run
 
 ```python

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -39,7 +39,7 @@ samples = posterior.sample((1000,), x=x_o)
 **To get started, install the `sbi` package with:**
 
 ```commandline
-pip install sbi
+python -m pip install sbi
 ```
 
 for more advanced install options, see our [Install Guide](install.md).

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-`sbi` requires Python 3.8 or higher. A GPU is not required, but can lead to
+`sbi` requires Python 3.9 or higher. A GPU is not required, but can lead to
 speed-up in some cases. We recommend using a
 [`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual environment
 ([Miniconda installation
@@ -8,16 +8,28 @@ instructions](https://docs.conda.io/en/latest/miniconda.html)). If `conda` is
 installed on the system, an environment for installing `sbi` can be created as
 follows:
 
-```commandline
+```console
 # Create an environment for sbi (indicate Python 3.8 or higher); activate it
-$ conda create -n sbi_env python=3.10 && conda activate sbi_env
+$ conda create -n sbi_env python=3.12 && conda activate sbi_env
 ```
 
 Independent of whether you are using `conda` or not, `sbi` can be installed
 using `pip`:
 
-```commandline
-pip install sbi
+```
+python -m pip install sbi
+```
+
+To install and add `sbi` to a project with [`pixi`](https://pixi.sh/), from the project directory run
+
+```
+pixi add sbi
+```
+
+and to install into a particular conda environment with [`conda`](https://docs.conda.io/projects/conda/), in the activated environment run
+
+```
+conda install --channel conda-forge sbi
 ```
 
 To test the installation, drop into a Python prompt and run


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

* Add install instructions from conda-forge for pixi and conda to README.
   - c.f. https://github.com/conda-forge/sbi-feedstock
* Add conda-forge badge. [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sbi.svg)](https://github.com/conda-forge/sbi-feedstock)
* Add install instructions from conda-forge for pixi and conda to docs.
   - Correct minimum required Python to Python 3.9.
   - Update example python version in conda env creation to Python 3.12.

## Does this close any currently open issues?

Related to https://github.com/sbi-dev/sbi/issues/1322

## Any relevant code examples, logs, error output, etc?

N/A

## Any other comments?

With [`pixi`](https://pixi.sh/) you can now get a fully working CUDA environment very fast (under 30 seconds) with the following

```console
$ mkdir example && cd example
$ pixi init
```

Add in 

```toml
[system-requirements]
cuda = "11"
```

to `pixi.toml`

(here I'm using CUDA `v11`, but `v12` or whatever for your system works)

and add your dependencies (here with `time` to back up the claim at the top, though this is faster than maybe you'll get at first as there is system wide caching helping)

```console
$ time pixi add sbi
✔ Added sbi >=0.23.2,<0.24

real    0m19.885s
user	0m27.974s
sys	0m35.643s
```

That's it!

```console
$ pixi list | grep 'cuda\|pytorch\|sbi'
cuda-version                   11.8            h70ddcb2_3                 20.5 KiB   conda  cuda-version
cudatoolkit                    11.8.0          h4ba93d1_13                682.5 MiB  conda  cudatoolkit
libtorch                       2.5.1           cuda118_hb34f2e8_303       466.8 MiB  conda  libtorch
pytorch                        2.5.1           cuda118_py312h919e71f_303  35.3 MiB   conda  pytorch
sbi                            0.23.2          pyhd8ed1ab_0               213.6 KiB  conda  sbi
```

```console
$ pixi shell
(example) $ python
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:24:40) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sbi.examples.minimal import simple
/tmp/example/.pixi/envs/default/lib/python3.12/site-packages/pyro/ops/stats.py:514: SyntaxWarning: invalid escape sequence '\g'
  """
>>> posterior = simple()
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:00<00:00, 146715.54it/s]
Drawing 100 posterior samples: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 20748.47it/s]
>>> print(posterior)
Posterior p(θ|x) of type DirectPosterior. It samples the posterior network and rejects samples that
            lie outside of the prior bounds.
>>> 
```

(You also now have a fully reproducible hash level lock file `pixi.lock`)


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.
- [N/A] New and existing unit tests pass locally with my changes
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] There are no conflicts with the `main` branch

For the reviewer:

- [ ] I have reviewed every file
- [ ] All comments have been addressed.
