### PR TITLE
1350 leakage correction breaks consistency of log prob vs log prob batched

### DIFF
--- a/sbi/samplers/rejection/rejection.py
+++ b/sbi/samplers/rejection/rejection.py
@@ -362,6 +362,4 @@ def accept_reject_sample(
         samples.shape[0] == num_samples
     ), "Number of accepted samples must match required samples."
 
-    # NOTE: Restriction prior does currently require a float as return for the
-    # acceptance rate, which is why we for now also return the minimum acceptance rate.
-    return samples, as_tensor(min_acceptance_rate)
+    return samples, as_tensor(acceptance_rate)

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -692,6 +692,11 @@ class RestrictedPrior(Distribution):
                 max_sampling_batch_size=max_sampling_batch_size,
                 alternative_method="sample_with='sir'",
             )
+            # NOTE: This currently requires a float acceptance rate. As previous versions
+            # of accept_reject_sample returned a float. In favour to batched sampling
+            # it now returns a tensor.
+            acceptance_rate = acceptance_rate.min().item()
+
             if save_acceptance_rate:
                 self.acceptance_rate = torch.as_tensor(acceptance_rate)
             if print_rejected_frac:

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -692,7 +692,7 @@ class RestrictedPrior(Distribution):
                 max_sampling_batch_size=max_sampling_batch_size,
                 alternative_method="sample_with='sir'",
             )
-            # NOTE: This currently requires a float acceptance rate. As previous versions
+            # NOTE: This currently requires a float acceptance rate. A previous version
             # of accept_reject_sample returned a float. In favour to batched sampling
             # it now returns a tensor.
             acceptance_rate = acceptance_rate.min().item()

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -135,14 +135,17 @@ def test_batched_sample_log_prob_with_different_x(
     assert batched_log_probs.shape == (10, max(x_o_batch_dim, 1)), "logprob shape wrong"
 
     # Test consistency with non-batched log_prob
+    # NOTE: Leakage factor is a MC estimate, so we need to relax the tolerance here.
     if x_o_batch_dim == 0:
-        log_probs = posterior.log_prob(samples)
-        assert torch.allclose(log_probs, batched_log_probs[:, 0]), "Log probs wrong"
+        log_probs = posterior.log_prob(samples, x=x_o)
+        assert torch.allclose(
+            log_probs, batched_log_probs[:, 0], atol=1e-1, rtol=1e-1
+        ), "Log probs wrong"
     else:
         for idx in range(x_o_batch_dim):
-            log_probs = posterior.log_prob(samples, x_o[idx])
+            log_probs = posterior.log_prob(samples[:, idx], x=x_o[idx])
             assert torch.allclose(
-                log_probs, batched_log_probs[:, idx]
+                log_probs, batched_log_probs[:, idx], atol=1e-1, rtol=1e-1
             ), "Log probs wrong"
 
 

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -140,13 +140,13 @@ def test_batched_sample_log_prob_with_different_x(
         log_probs = posterior.log_prob(samples, x=x_o)
         assert torch.allclose(
             log_probs, batched_log_probs[:, 0], atol=1e-1, rtol=1e-1
-        ), "Log probs wrong"
+        ), "Batched log probs different from non-batched log probs"
     else:
         for idx in range(x_o_batch_dim):
             log_probs = posterior.log_prob(samples[:, idx], x=x_o[idx])
             assert torch.allclose(
                 log_probs, batched_log_probs[:, idx], atol=1e-1, rtol=1e-1
-            ), "Log probs wrong"
+            ), "Batched log probs different from non-batched log probs"
 
 
 @pytest.mark.mcmc


### PR DESCRIPTION
This should fix the issue #1350.

### Changes
- accept_reject_sample now returns a tensor of acceptance_rates.
- Only change was needed for the restriction estimator. Which now reduces this tensor to a float.
- Test added and extended to bounded priors to detect inconsistencies with leakage correction methods.