### PR TITLE
increase tutorial test timeout

### DIFF
--- a/tests/tutorials_test.py
+++ b/tests/tutorials_test.py
@@ -22,7 +22,7 @@ def test_tutorials(notebook_path):
     """Test that all notebooks in the tutorials directory can be executed."""
     with open(notebook_path) as f:
         nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        ep = ExecutePreprocessor(timeout=1200, kernel_name='python3')
         print(f"Executing notebook {notebook_path}")
         try:
             ep.preprocess(nb, {'metadata': {'path': os.path.dirname(notebook_path)}})


### PR DESCRIPTION
During the release, the GitHub action that executes and then strips all notebooks before building the docs failed because the decision making example notebook took longer than 10min to execute. Here, we increase to timeout to avoid this failure in the future. 