### PR TITLE
add details about zuko density estimators

### DIFF
--- a/tutorials/03_density_estimators.ipynb
+++ b/tutorials/03_density_estimators.ipynb
@@ -11,21 +11,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`sbi` allows to specify a custom density estimator for each of the implemented methods. For all options, check the API reference [here](https://sbi-dev.github.io/sbi/reference/models/).\n"
+    "`sbi` allows to specify a specific density estimator for each of the implemented methods.\n",
+    "We support a variety of density estimators, e.g., mixtures of Gaussians, normalizing\n",
+    "flows, and diffusion models. Some of the density estimators are implemented as part of\n",
+    "`sbi`, for others we rely on other packages like\n",
+    "[`nflows`](https://github.com/bayesiains/nflows/) (via `pyknos`) or [`zuko`](https://github.com/probabilists/zuko). \n",
+    "\n",
+    "For all options, check the API reference\n",
+    "[here](https://sbi-dev.github.io/sbi/reference/models/).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Changing the type of density estimator\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "One option is using one of the preconfigured density estimators by passing a string in the `density_estimator` keyword argument to the inference object (`NPE` or `NLE`), e.g., \"maf\" for a Masked Autoregressive Flow, of \"nsf\" for a Neural Spline Flow with default hyperparameters.\n"
+    "## Changing the type of density estimator\n",
+    "\n",
+    "One option is using one of the preconfigured density estimators by passing a string in\n",
+    "the `density_estimator` keyword argument to the inference object (`NPE` or `NLE`), e.g.,\n",
+    "\"maf\" for a Masked Autoregressive Flow, of \"nsf\" for a Neural Spline Flow with default\n",
+    "hyperparameters.\n",
+    "\n",
+    "**New with sbi 0.23:** Note that `\"maf\"` or `\"nsf\"` correspond to `nflows` density\n",
+    "estimators. Those have proven to work well, but the `nflows` package is not maintained\n",
+    "anymore. To use more recent and actively maintained density estimators, we tentatively\n",
+    "recommend using `zuko`, e.g., by passing `zuko_maf` or `zuko_nsf`. \n"
    ]
   },
   {
@@ -47,7 +57,7 @@
    "outputs": [],
    "source": [
     "prior = BoxUniform(torch.zeros(2), torch.ones(2))\n",
-    "inference = NPE(prior=prior, density_estimator=\"maf\")"
+    "inference = NPE(prior=prior, density_estimator=\"zuko_maf\")"
    ]
   },
   {
@@ -92,7 +102,7 @@
     "from sbi.neural_nets import posterior_nn\n",
     "\n",
     "density_estimator_build_fun = posterior_nn(\n",
-    "    model=\"nsf\", hidden_features=60, num_transforms=3\n",
+    "    model=\"zuko_nsf\", hidden_features=60, num_transforms=3\n",
     ")\n",
     "inference = NPE(prior=prior, density_estimator=density_estimator_build_fun)"
    ]


### PR DESCRIPTION
We did not have any details on how to use zuko density estimators. 

This adds details about `zuko` to the tutorial on density estimators (as requested in the JOSS review). 