### PR TITLE
fix: type fix in VI subclasses. xfail pymc tests.

### DIFF
--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -513,6 +513,8 @@ class IWElboOptimizer(ElboOptimizer):
         self.loss_name = "iwelbo"
         self.eps = 1e-7
         self.dreg = dreg
+        if not hasattr(self, 'HYPER_PARAMETERS'):
+            self.HYPER_PARAMETERS = []
         self.HYPER_PARAMETERS += ["K", "dreg"]
         if dreg:
             self.stick_the_landing = True
@@ -675,6 +677,8 @@ class RenyiDivergenceOptimizer(ElboOptimizer):
         self.alpha = alpha
         self.unbiased = unbiased
         super().__init__(*args, **kwargs)
+        if not hasattr(self, 'HYPER_PARAMETERS'):
+            self.HYPER_PARAMETERS = []
         self.HYPER_PARAMETERS += ["alpha", "unbiased", "dreg"]
         self.eps = 1e-5
         self.dreg = dreg

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pytest
 import torch
@@ -183,7 +185,15 @@ def test_c2st_pymc_sampler_on_Gaussian(
     (
         "nuts_pyro",
         "hmc_pyro",
-        "nuts_pymc",
+        pytest.param(
+            "nuts_pymc",
+            marks=pytest.mark.xfail(
+                condition=sys.version_info >= (3, 12),
+                reason="Fails with pymc 5.20.1",
+                strict=True,
+                raises=TypeError,
+            ),
+        ),
         "hmc_pymc",
         "slice_pymc",
         "slice_np",


### PR DESCRIPTION
a new pyright version was detecting that `HYPER_PARAMETERS` might be uninitialized in the subclasses so that `+=` would not work.

This PR fixes it by initializing it with an empty list in that case. 