### PR TITLE
duplication of 'large number' in warning

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -452,11 +452,11 @@ class MCMCPosterior(NeuralPosterior):
         num_chains_extended = batch_size * num_chains
         if num_chains_extended > 100:
             warnings.warn(
-                "Note that for batched sampling, we use num_chains many chains for each"
-                " x in the batch. With the given settings, this results in a large "
-                f"number large number of chains ({num_chains_extended}), which can be "
-                "slow and memory-intensive for vectorized MCMC. Consider reducing the "
-                "number of chains.",
+                "Note that for batched sampling, we use num_chains many chains "
+                "for each x in the batch. With the given settings, this results "
+                f"in a large number of chains ({num_chains_extended}), which can "
+                "be slow and memory-intensive for vectorized MCMC. Consider "
+                "reducing the number of chains or batch size.",
                 stacklevel=2,
             )
         init_strategy_parameters["num_return_samples"] = num_chains_extended


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

The warning on the number of chains for batched sampling for a MCMC Posterior hat `larger number` twice in the string. 

Also, despite reducing the number of chains, reducing the batch size might be a suitable solution as well. 

## Does this close any currently open issues?

No.

## Any relevant code examples, logs, error output, etc?

No.

## Any other comments?

No.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.

- [x] I have read and understood the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have reported how long the new tests run and potentially marked them
  with `pytest.mark.slow`.~
- [ ] ~New and existing unit tests pass locally with my changes~
- [x] I performed linting and formatting as described in the [contribution
  guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] There are no conflicts with the `main` branch

For the reviewer:

- [x] I have reviewed every file
- [x] All comments have been addressed.
