### PR TITLE
Docs: Markdown formatting compliant to Markdown Linter (solves #1434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@
 
 ## New Contributors 🎉
 
-* @emmanuel-ferdman made their first contribution in https://github.com/sbi-dev/sbi/pull/1297
-* @CompiledAtBirth made their first contribution in https://github.com/sbi-dev/sbi/pull/1299
-* @tvwenger made their first contribution in https://github.com/sbi-dev/sbi/pull/1302
-* @matthewfeickert made their first contribution in https://github.com/sbi-dev/sbi/pull/1340
-* @manuel-morales-a made their first contribution in https://github.com/sbi-dev/sbi/pull/1336
+* @emmanuel-ferdman made their first contribution in <https://github.com/sbi-dev/sbi/pull/1297>
+* @CompiledAtBirth made their first contribution in <https://github.com/sbi-dev/sbi/pull/1299>
+* @tvwenger made their first contribution in <https://github.com/sbi-dev/sbi/pull/1302>
+* @matthewfeickert made their first contribution in <https://github.com/sbi-dev/sbi/pull/1340>
+* @manuel-morales-a made their first contribution in <https://github.com/sbi-dev/sbi/pull/1336>
 
-**Full Changelog**: https://github.com/sbi-dev/sbi/compare/v0.23.2...v0.23.3
+**Full Changelog**: <https://github.com/sbi-dev/sbi/compare/v0.23.2...v0.23.3>
 
 # v0.23.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,30 @@
 
 ## Highlights 🤩
 
-* docs: Add conda-forge install instructions by @matthewfeickert in <https://github.com/sbi-dev/sbi/pull/1340>
-* feat: `NLE` with multiple iid conditions by @janfb in <https://github.com/sbi-dev/sbi/pull/1331>
+- docs: Add conda-forge install instructions by @matthewfeickert in <https://github.com/sbi-dev/sbi/pull/1340>
+- feat: `NLE` with multiple iid conditions by @janfb in <https://github.com/sbi-dev/sbi/pull/1331>
 
 ## What's Changed 🚧
 
-* fix: Correted typo in y-axis label by @turnmanh in <https://github.com/sbi-dev/sbi/pull/1296>
-* docs: update embedding networks notebook by @emmanuel-ferdman in <https://github.com/sbi-dev/sbi/pull/1297>
-* fix pickle issues in MCMC posterior + test by @manuelgloeckler in <https://github.com/sbi-dev/sbi/pull/1291>
-* Minor fix for EnsemblePosterior weights.setter by @CompiledAtBirth in <https://github.com/sbi-dev/sbi/pull/1299>
-* Remove deprecated neural_net access from `utils` by @tvwenger in <https://github.com/sbi-dev/sbi/pull/1302>
-* [test] add tests for ensemble posterior weights by @samadpls in <https://github.com/sbi-dev/sbi/pull/1307>
-* Clarify last round behavior of SNPE-A by @michaeldeistler in <https://github.com/sbi-dev/sbi/pull/1323>
-* expose batched sampling option; error handling by @janfb in <https://github.com/sbi-dev/sbi/pull/1321>
-* Fix #1316: remove sample_dim docstring for condition. by @janfb in <https://github.com/sbi-dev/sbi/pull/1338>
-* docs: fix tutorial typos by @janfb in <https://github.com/sbi-dev/sbi/pull/1341>
-* docs: run and seed SBC tutorial by @manuel-morales-a in <https://github.com/sbi-dev/sbi/pull/1336>
+- fix: Correted typo in y-axis label by @turnmanh in <https://github.com/sbi-dev/sbi/pull/1296>
+- docs: update embedding networks notebook by @emmanuel-ferdman in <https://github.com/sbi-dev/sbi/pull/1297>
+- fix pickle issues in MCMC posterior + test by @manuelgloeckler in <https://github.com/sbi-dev/sbi/pull/1291>
+- Minor fix for EnsemblePosterior weights.setter by @CompiledAtBirth in <https://github.com/sbi-dev/sbi/pull/1299>
+- Remove deprecated neural_net access from `utils` by @tvwenger in <https://github.com/sbi-dev/sbi/pull/1302>
+- [test] add tests for ensemble posterior weights by @samadpls in <https://github.com/sbi-dev/sbi/pull/1307>
+- Clarify last round behavior of SNPE-A by @michaeldeistler in <https://github.com/sbi-dev/sbi/pull/1323>
+- expose batched sampling option; error handling by @janfb in <https://github.com/sbi-dev/sbi/pull/1321>
+- Fix #1316: remove sample_dim docstring for condition. by @janfb in <https://github.com/sbi-dev/sbi/pull/1338>
+- docs: fix tutorial typos by @janfb in <https://github.com/sbi-dev/sbi/pull/1341>
+- docs: run and seed SBC tutorial by @manuel-morales-a in <https://github.com/sbi-dev/sbi/pull/1336>
 
 ## New Contributors 🎉
 
-* @emmanuel-ferdman made their first contribution in <https://github.com/sbi-dev/sbi/pull/1297>
-* @CompiledAtBirth made their first contribution in <https://github.com/sbi-dev/sbi/pull/1299>
-* @tvwenger made their first contribution in <https://github.com/sbi-dev/sbi/pull/1302>
-* @matthewfeickert made their first contribution in <https://github.com/sbi-dev/sbi/pull/1340>
-* @manuel-morales-a made their first contribution in <https://github.com/sbi-dev/sbi/pull/1336>
+- @emmanuel-ferdman made their first contribution in <https://github.com/sbi-dev/sbi/pull/1297>
+- @CompiledAtBirth made their first contribution in <https://github.com/sbi-dev/sbi/pull/1299>
+- @tvwenger made their first contribution in <https://github.com/sbi-dev/sbi/pull/1302>
+- @matthewfeickert made their first contribution in <https://github.com/sbi-dev/sbi/pull/1340>
+- @manuel-morales-a made their first contribution in <https://github.com/sbi-dev/sbi/pull/1336>
 
 **Full Changelog**: <https://github.com/sbi-dev/sbi/compare/v0.23.2...v0.23.3>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Highlights 🤩
 
-* docs: Add conda-forge install instructions by @matthewfeickert in https://github.com/sbi-dev/sbi/pull/1340
-* feat: `NLE` with multiple iid conditions by @janfb in https://github.com/sbi-dev/sbi/pull/1331
+* docs: Add conda-forge install instructions by @matthewfeickert in <https://github.com/sbi-dev/sbi/pull/1340>
+* feat: `NLE` with multiple iid conditions by @janfb in <https://github.com/sbi-dev/sbi/pull/1331>
 
 ## What's Changed 🚧
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,8 +145,8 @@
 - split linting process from the CI/CD workflow (#1164) (@tomMoral)
 - Switch to the newest `pyright` and fix all typing errors (#1045, #1108) (@Baschdl)
 - introduce two docs versions: `latest` pointing to latest release at
-  https://sbi-dev.github.io/sbi/latest/ and `dev` pointing to the latest version on
-  `main` https://sbi-dev.github.io/sbi/dev/
+  <https://sbi-dev.github.io/sbi/latest/> and `dev` pointing to the latest version on
+  `main` <https://sbi-dev.github.io/sbi/dev/>
 
 # v0.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@
 
 ## What's Changed 🚧
 
-* fix: Correted typo in y-axis label by @turnmanh in https://github.com/sbi-dev/sbi/pull/1296
-* docs: update embedding networks notebook by @emmanuel-ferdman in https://github.com/sbi-dev/sbi/pull/1297
-* fix pickle issues in MCMC posterior + test by @manuelgloeckler in https://github.com/sbi-dev/sbi/pull/1291
-* Minor fix for EnsemblePosterior weights.setter by @CompiledAtBirth in https://github.com/sbi-dev/sbi/pull/1299
-* Remove deprecated neural_net access from `utils` by @tvwenger in https://github.com/sbi-dev/sbi/pull/1302
-* [test] add tests for ensemble posterior weights by @samadpls in https://github.com/sbi-dev/sbi/pull/1307
-* Clarify last round behavior of SNPE-A by @michaeldeistler in https://github.com/sbi-dev/sbi/pull/1323
-* expose batched sampling option; error handling by @janfb in https://github.com/sbi-dev/sbi/pull/1321
-* Fix #1316: remove sample_dim docstring for condition. by @janfb in https://github.com/sbi-dev/sbi/pull/1338
-* docs: fix tutorial typos by @janfb in https://github.com/sbi-dev/sbi/pull/1341
-* docs: run and seed SBC tutorial by @manuel-morales-a in https://github.com/sbi-dev/sbi/pull/1336
+* fix: Correted typo in y-axis label by @turnmanh in <https://github.com/sbi-dev/sbi/pull/1296>
+* docs: update embedding networks notebook by @emmanuel-ferdman in <https://github.com/sbi-dev/sbi/pull/1297>
+* fix pickle issues in MCMC posterior + test by @manuelgloeckler in <https://github.com/sbi-dev/sbi/pull/1291>
+* Minor fix for EnsemblePosterior weights.setter by @CompiledAtBirth in <https://github.com/sbi-dev/sbi/pull/1299>
+* Remove deprecated neural_net access from `utils` by @tvwenger in <https://github.com/sbi-dev/sbi/pull/1302>
+* [test] add tests for ensemble posterior weights by @samadpls in <https://github.com/sbi-dev/sbi/pull/1307>
+* Clarify last round behavior of SNPE-A by @michaeldeistler in <https://github.com/sbi-dev/sbi/pull/1323>
+* expose batched sampling option; error handling by @janfb in <https://github.com/sbi-dev/sbi/pull/1321>
+* Fix #1316: remove sample_dim docstring for condition. by @janfb in <https://github.com/sbi-dev/sbi/pull/1338>
+* docs: fix tutorial typos by @janfb in <https://github.com/sbi-dev/sbi/pull/1341>
+* docs: run and seed SBC tutorial by @manuel-morales-a in <https://github.com/sbi-dev/sbi/pull/1336>
 
 ## New Contributors 🎉
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting `sbi` developer Jan Boelts via email
-(jan.boelts@mailbox.org) or anonymously via
+(<jan.boelts@mailbox.org>) or anonymously via
 [https://forms.gle/AEmwEznWAKdvrBQbA](https://forms.gle/AEmwEznWAKdvrBQbA). All
 complaints will be reviewed and investigated promptly and fairly.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ performance in some cases. We recommend using a virtual environment with
 
 If `conda` is installed on the system, an environment for installing `sbi` can be created as follows:
 
-```
+```bash
 conda create -n sbi_env python=3.10 && conda activate sbi_env
 ```
 
@@ -74,7 +74,7 @@ conda create -n sbi_env python=3.10 && conda activate sbi_env
 
 To install `sbi` from PyPI run
 
-```
+```bash
 python -m pip install sbi
 ```
 
@@ -82,13 +82,13 @@ python -m pip install sbi
 
 To install and add `sbi` to a project with [`pixi`](https://pixi.sh/), from the project directory run
 
-```
+```bash
 pixi add sbi
 ```
 
 and to install into a particular conda environment with [`conda`](https://docs.conda.io/projects/conda/), in the activated environment run
 
-```
+```bash
 conda install --channel conda-forge sbi
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ how to run each of these methods
   Simulation-Based Inference with Balanced Neural Ratio
   Estimation_](https://arxiv.org/abs/2208.13624) (NeurIPS 2022).
 
-
 ### Neural Variational Inference, amortized (NVI) and sequential (SNVI)
 
 - [`SNVI`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.posteriors.vi_posterior)

--- a/README.md
+++ b/README.md
@@ -120,54 +120,54 @@ how to run each of these methods
 
 ### Neural Posterior Estimation: amortized (NPE) and sequential (SNPE)
 
-* [`(S)NPE_A`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npe.npe_a.NPE_A)
+- [`(S)NPE_A`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npe.npe_a.NPE_A)
   (including amortized single-round `NPE`) from Papamakarios G and Murray I [_Fast
   ε-free Inference of Simulation Models with Bayesian Conditional Density
   Estimation_](https://proceedings.neurips.cc/paper/2016/hash/6aca97005c68f1206823815f66102863-Abstract.html)
   (NeurIPS 2016).
 
-* [`(S)NPE_C`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npe.npe_c.NPE_C)
+- [`(S)NPE_C`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npe.npe_c.NPE_C)
   or `APT` from Greenberg D, Nonnenmacher M, and Macke J [_Automatic Posterior
   Transformation for likelihood-free inference_](https://arxiv.org/abs/1905.07488) (ICML
   2019).
 
-* `TSNPE` from Deistler M, Goncalves P, and Macke J [_Truncated proposals for scalable
+- `TSNPE` from Deistler M, Goncalves P, and Macke J [_Truncated proposals for scalable
   and hassle-free simulation-based inference_](https://arxiv.org/abs/2210.04815)
   (NeurIPS 2022).
 
-* [`FMPE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.fmpe.fmpe.FMPE)
+- [`FMPE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.fmpe.fmpe.FMPE)
   from Wildberger, J., Dax, M., Buchholz, S., Green, S., Macke, J. H., & Schölkopf, B.
   [_Flow matching for scalable simulation-based
   inference_](https://proceedings.neurips.cc/paper_files/paper/2023/hash/3663ae53ec078860bb0b9c6606e092a0-Abstract-Conference.html).
   (NeurIPS 2023).
 
-* [`NPSE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npse.npse.NPSE) from
+- [`NPSE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.npse.npse.NPSE) from
   Geffner, T., Papamakarios, G., & Mnih, A. [_Compositional score modeling for
   simulation-based inference_](https://proceedings.mlr.press/v202/geffner23a.html).
   (ICML 2023)
 
 ### Neural Likelihood Estimation: amortized (NLE) and sequential (SNLE)
 
-* [`(S)NLE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nle.nle_a.NLE_A)
+- [`(S)NLE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nle.nle_a.NLE_A)
   or just `SNL` from Papamakarios G, Sterrat DC and Murray I [_Sequential Neural
   Likelihood_](https://arxiv.org/abs/1805.07226) (AISTATS 2019).
 
 ### Neural Ratio Estimation: amortized (NRE) and sequential (SNRE)
 
-* [`(S)NRE_A`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_a.NRE_A)
+- [`(S)NRE_A`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_a.NRE_A)
   or `AALR` from Hermans J, Begy V, and Louppe G. [_Likelihood-free Inference with
   Amortized Approximate Likelihood Ratios_](https://arxiv.org/abs/1903.04057) (ICML
   2020).
 
-* [`(S)NRE_B`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_b.NRE_B)
+- [`(S)NRE_B`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_b.NRE_B)
   or `SRE` from Durkan C, Murray I, and Papamakarios G. [_On Contrastive Learning for
   Likelihood-free Inference_](https://arxiv.org/abs/2002.03712) (ICML 2020).
 
-* [`(S)NRE_C`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_c.NRE_C)
+- [`(S)NRE_C`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.nre_c.NRE_C)
   or `NRE-C` from Miller BK, Weniger C, Forré P. [_Contrastive Neural Ratio
   Estimation_](https://arxiv.org/abs/2210.06170) (NeurIPS 2022).
 
-* [`BNRE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.bnre.BNRE) from
+- [`BNRE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nre.bnre.BNRE) from
   Delaunoy A, Hermans J, Rozet F, Wehenkel A, and Louppe G. [_Towards Reliable
   Simulation-Based Inference with Balanced Neural Ratio
   Estimation_](https://arxiv.org/abs/2208.13624) (NeurIPS 2022).
@@ -175,13 +175,13 @@ how to run each of these methods
 
 ### Neural Variational Inference, amortized (NVI) and sequential (SNVI)
 
-* [`SNVI`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.posteriors.vi_posterior)
+- [`SNVI`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.posteriors.vi_posterior)
   from Glöckler M, Deistler M, Macke J, [_Variational methods for simulation-based
   inference_](https://openreview.net/forum?id=kZ0UYdhqkNY) (ICLR 2022).
 
 ### Mixed Neural Likelihood Estimation (MNLE)
 
-* [`MNLE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nle.mnle.MNLE) from
+- [`MNLE`](https://sbi-dev.github.io/sbi/latest/reference/#sbi.inference.trainers.nle.mnle.MNLE) from
   Boelts J, Lueckmann JM, Gao R, Macke J, [_Flexible and efficient simulation-based
   inference for models of decision-making_](https://elifesciences.org/articles/77220)
   (eLife 2022).

--- a/docs/docs/contribute.md
+++ b/docs/docs/contribute.md
@@ -57,7 +57,8 @@ a repository [here](https://docs.github.com/en/pull-requests/collaborating-with-
 
 **Step 3**: Clone your fork of the `sbi` repo from your GitHub account to your
 local disk:
-```
+
+```bash
 git clone git@github.com:$USERNAME/sbi.git
 cd sbi
 ```
@@ -66,15 +67,18 @@ cd sbi
 for instance using [`miniforge`](https://github.com/conda-forge/miniforge). We
 strongly recommend you create a specific `conda` environment for doing
 development on `sbi` as per:
-```
+
+```bash
 conda create -n sbi_dev python=3.10
 conda activate sbi_dev
 ```
 
 **Step 5**: Install `sbi` in editable mode with
-```
+
+```bash
 pip install -e ".[dev]"
 ```
+
 This installs the `sbi` package into the current environment by creating a
 link to the source code directory (instead of copying the code to pip’s `site_packages`
 directory, which is what normally happens). This means that any edits you make
@@ -86,12 +90,15 @@ at least Python 3.8.
 **Step 6**: Add the upstream remote. This saves a reference to the main `sbi`
 repository, which you can use to keep your repository synchronized with the latest
 changes:
-```
+
+```bash
 git remote add upstream git@github.com:sbi-dev/sbi.git
 ```
+
 Check that the upstream and origin remote aliases are configured correctly by
 running `git remote -v` which should display:
-```
+
+```bash
 origin  git@github.com:$USERNAME/sbi.git (fetch)
 origin  git@github.com:$USERNAME/sbi.git (push)
 upstream        git@github.com:sbi-dev/sbi.git (fetch)
@@ -99,7 +106,8 @@ upstream        git@github.com:sbi-dev/sbi.git (push)
 ```
 
 **Step 7**: Install `pre-commit` to run code style checks before each commit:
-```
+
+```bash
 pip install pre-commit
 pre-commit install
 ```
@@ -110,16 +118,19 @@ process of modifying code and submitting a pull request:
 
 **Step 8**: Synchronize your main branch with the upstream/main branch. See more
 details on [GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork):
-```
+
+```bash
 git checkout main
 git fetch upstream
 git merge upstream/main
 ```
 
 **Step 9**: Create a feature branch to hold your development changes:
-```
+
+```bash
 git checkout -b my_feature
 ```
+
 and start making changes. Always use a feature branch! It’s good practice
 to never work on the main branch, as this allows you to easily get back to a
 working state of the code if needed (e.g., if you’re working on multiple
@@ -130,14 +141,18 @@ upstream’s main branch.
 **Step 10**: Develop your code on your feature branch on the computer, using
 Git to do the version control. When you’re done editing, add changed files
 using `git add` and then `git commit` to record your changes:
-```
+
+```bash
 git add modified_files
 git commit -m "description of your commit"
 ```
+
 Then push the changes to your GitHub account with:
-```
+
+```bash
 git push -u origin my_feature
 ```
+
 The `-u` flag ensures that your local branch will be automatically linked with
 the remote branch, so you can later use `git push` and `git pull` without any
 extra arguments.
@@ -164,13 +179,17 @@ For code linting and formating, we use [`ruff`](https://docs.astral.sh/ruff/),
 which is installed alongside `sbi`.
 
 You can exclude slow tests and those which require a GPU with
-```
+
+```bash
 pytest -m "not slow and not gpu"
 ```
+
 Additionally, we recommend to run tests with
-```
+
+```bash
 pytest -n auto -m "not slow and not gpu"
 ```
+
 in parallel. GPU tests should probably not be run this way. If you see unexpected
 behavior (tests fail if they shouldn't), try to run them without `-n auto` and
 see if it persists. When writing new tests and debugging things, it may make sense
@@ -222,20 +241,26 @@ are no errors) but output performance metrics that can be compared, e.g., to the
 performance metrics of the main branch or relative to each other. The user-facing API
 is available via `pytest` through custom flags. To run the mini-sbibm tests, you can use
 the following command:
+
 ```bash
     pytest --bm
 ```
+
 This will run all the mini-sbibm tests on all methods with default parameters and output
 the performance metrics nicely formatted to the console. If you have multiple CPU cores
 available, you can run the tests in parallel using the `-n auto` flag:
+
 ```bash
     pytest --bm -n auto
 ```
+
 What if you are currently working on a specific method and you want to run the
 mini-sbibm tests only for this class of methods? You can use the `--bm-mode` flag:
+
 ```bash
     pytest --bm --bm-mode nspe
 ```
+
 This will run the mini-sbibm tests only for methods of the `nspe` class, but with a
 few major hyperparameter choices, such as different base network architectures and
 different diffusion processes.

--- a/docs/docs/credits.md
+++ b/docs/docs/credits.md
@@ -13,9 +13,9 @@ direct contributions to the codebase have been instrumental in the development o
 
 > Copyright (C) 2020 Álvaro Tejero-Cantero, Jakob H. Macke, Jan-Matthis Lückmann,
 > Michael Deistler, Jan F. Bölts.
-
+>
 > Copyright (C) 2020 Conor M. Durkan.
-
+>
 > All contributors hold the copyright of their specific contributions.
 
 ## Support

--- a/docs/docs/credits.md
+++ b/docs/docs/credits.md
@@ -25,7 +25,7 @@ through project ADIMEM (FKZ 01IS18052 A-D), project SiMaLeSAM (FKZ 01IS21055A) a
 Tübingen AI Center (FKZ 01IS18039A). Since 2024, `sbi` has been supported by the
 appliedAI Institute for Europe gGmbH.
 
-![](static/logo_bmbf.svg)
+![German Federal Ministry of Education and Research Logo](static/logo_bmbf.svg)
 
 ## Important dependencies and prior art
 

--- a/docs/docs/faq/question_01_leakage.md
+++ b/docs/docs/faq/question_01_leakage.md
@@ -15,6 +15,7 @@ The reason for this issue is described in more detail
 [here](https://arxiv.org/abs/1905.07488). The following fixes are possible:
 
 - use truncated proposals for SNPE (TSNPE)
+
 ```python
 from sbi.inference import NPE
 from sbi.utils import RestrictedPrior, get_density_thresholder

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -93,7 +93,8 @@ these algorithms can be categorized as:
 Depending on the characteristics of the problem, e.g. the dimensionalities of the
 parameter space and the observation space, one of the methods will be more suitable.
 
-![](./static/goal.png)
+![Diagram showing simulation-based inference. It depicts a model, prior distribution, simulated data, neural density estimator, and posterior distribution. The process includes a feedback loop using posterion distribution to adaptively generate additional informative simulations. The diagram also illustrates consistent and inconsistent samples.
+](./static/goal.png)
 
 **Goal: Algorithmically identify mechanistic models that are consistent with data.**
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -93,7 +93,7 @@ these algorithms can be categorized as:
 Depending on the characteristics of the problem, e.g. the dimensionalities of the
 parameter space and the observation space, one of the methods will be more suitable.
 
-![Diagram showing simulation-based inference. It depicts a model, prior distribution, simulated data, neural density estimator, and posterior distribution. The process includes a feedback loop using posterion distribution to adaptively generate additional informative simulations. The diagram also illustrates consistent and inconsistent samples.
+![Conceptual diagram for simulation-based inference. It depicts a model, prior distribution, simulated data, neural density estimator, and posterior distribution. The process includes a feedback loop using the estimated posterior distribution to adaptively generate additional informative simulations. The diagram also illustrates consistent and inconsistent samples.
 ](./static/goal.png)
 
 **Goal: Algorithmically identify mechanistic models that are consistent with data.**

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -16,19 +16,19 @@ $ conda create -n sbi_env python=3.10 && conda activate sbi_env
 Independent of whether you are using `conda` or not, `sbi` can be installed
 using `pip`:
 
-```
+```bash
 python -m pip install sbi
 ```
 
 To install and add `sbi` to a project with [`pixi`](https://pixi.sh/), from the project directory run
 
-```
+```bash
 pixi add sbi
 ```
 
 and to install into a particular conda environment with [`conda`](https://docs.conda.io/projects/conda/), in the activated environment run
 
-```
+```bash
 conda install --channel conda-forge sbi
 ```
 

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -1,4 +1,4 @@
-# API Reference:
+# API Reference
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
Resolves https://github.com/sbi-dev/sbi/issues/1434

I modified minor details among various codebase's markdown files to make them compliant with [Markdown linter](https://github.com/DavidAnson/markdownlint/tree/v0.37.4), changes mainly involved:
- Providing a consistent unordered list marker in the same MD file (`*` or `-`, but not both in the same file)
- Providing extra void lines around code blocks where they were missing
-  Providing `bash` as language definition for code block where it was missing
- Added surrounding angular parenthesis (`<https:\\url>` and not `https:\\url`) for bare URLs
- Providing an alternative image textual description for a couple images around the docs, this will improve accessibility for users but also improve SEO as main search engines do not appreciate empty `alt=...` attribute in HTML (MkDocs simply convert the test inside square parenthesis in the `alt=...` attribute when converting to HTML)

All modifications are provided as many commits to provide a more clean, granular, description of changes made. Also, I already tested locally if MkDocs still works running a local instance of the webpage (following indications on your official [contribution guide](https://sbi-dev.github.io/sbi/latest/contribute/)) and everything seems ok.

***Note***: This PR do *not* solve all issues with the Markdown lint as sometimes such violations are needed if a certain graphical looking is desired (e.g. in the main README.md file markdown lints would prefer to find a 1-level heading `#` as first line, but there was rather HTML hard code of labels and buttons; also in various MD files HTML code is hard coded inside for making the docs to be more appealing as website), thus only modifications who did not drastically affect the final MkDocs results were made.
