### PR TITLE
fix: gpu-handling for made and leakage correction

### DIFF
--- a/sbi/neural_nets/estimators/categorical_net.py
+++ b/sbi/neural_nets/estimators/categorical_net.py
@@ -61,6 +61,7 @@ class CategoricalMADE(MADE):
         self.mask = torch.zeros(self.num_variables, self.num_categories)
         for i, c in enumerate(num_categories):
             self.mask[i, :c] = 1
+        self.register_buffer("mask", self.mask)
 
         super().__init__(
             features=self.num_variables,

--- a/sbi/neural_nets/estimators/categorical_net.py
+++ b/sbi/neural_nets/estimators/categorical_net.py
@@ -58,10 +58,6 @@ class CategoricalMADE(MADE):
 
         self.num_variables = len(num_categories)
         self.num_categories = int(torch.max(num_categories))
-        self.mask = torch.zeros(self.num_variables, self.num_categories)
-        for i, c in enumerate(num_categories):
-            self.mask[i, :c] = 1
-        self.register_buffer("mask", self.mask)
 
         super().__init__(
             features=self.num_variables,
@@ -75,6 +71,10 @@ class CategoricalMADE(MADE):
             dropout_probability=dropout_probability,
             use_batch_norm=use_batch_norm,
         )
+        mask = torch.zeros(self.num_variables, self.num_categories)
+        for i, c in enumerate(num_categories):
+            mask[i, :c] = 1
+        self.register_buffer("mask", mask)
 
         self.embedding_net = embedding_net
         self.hidden_features = num_hidden_features

--- a/sbi/samplers/rejection/rejection.py
+++ b/sbi/samplers/rejection/rejection.py
@@ -364,4 +364,4 @@ def accept_reject_sample(
         "Number of accepted samples must match required samples."
     )
 
-    return samples, as_tensor(acceptance_rate)
+    return samples, as_tensor(acceptance_rate, device=samples.device)

--- a/sbi/utils/nn_utils.py
+++ b/sbi/utils/nn_utils.py
@@ -112,7 +112,7 @@ class MADEWrapper(made.MADE):
 
     def forward(self, inputs, context=None):
         # add dummy input to ensure all dims conditioned on context.
-        dummy_input = torch.zeros((inputs.shape[:-1] + (1,)))
+        dummy_input = torch.zeros((inputs.shape[:-1] + (1,)), device=inputs.device)
         concat_input = torch.cat((dummy_input, inputs), dim=-1)
         outputs = super().forward(concat_input, context)
         # the final layer of MADE produces self.output_multiplier outputs for each

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Tuple, Union
 
 import pytest
@@ -69,7 +70,19 @@ pytestmark = pytest.mark.skipif(
         pytest.param(NRE_B, "resnet", "slice_np", marks=pytest.mark.mcmc),
         (NRE_C, "resnet", "rejection"),
         (NRE_C, "resnet", "importance"),
-        pytest.param(NRE_C, "resnet", "nuts_pymc", marks=pytest.mark.mcmc),
+        pytest.param(
+            NRE_C,
+            "resnet",
+            "nuts_pymc",
+            marks=(
+                pytest.mark.mcmc,
+                pytest.mark.xfail(
+                    condition=sys.version_info >= (3, 10),
+                    reason="Fails with pymc>=5.20.1 and python>=3.10",
+                    raises=TypeError,
+                ),
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
during GPU tests a couple of bugs appeared, mostly for the new `CategoricalMADE`. 

I overloaded the `to` methods for the mixed density networks to avoid moving the `masks` to the device explicitly in every `forward` call. 