### PR TITLE
Prevent notebook execution upon doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ myst_enable_extensions = [
     "colon_fence",
 ]
 nb_execution_timeout = 600
-nb_execution_mode = "cache"
+nb_execution_mode = "off"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Readthedocs does not build because it attempts to run the notebooks before converting them.