### PR TITLE
Change xfail to skipif as outcome is not consistent

### DIFF
--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import sys
 from typing import Tuple, Union
 
+import pymc
 import pytest
 import torch
 import torch.distributions.transforms as torch_tf
@@ -76,10 +77,10 @@ pytestmark = pytest.mark.skipif(
             "nuts_pymc",
             marks=(
                 pytest.mark.mcmc,
-                pytest.mark.xfail(
-                    condition=sys.version_info >= (3, 10),
-                    reason="Fails with pymc>=5.20.1 and python>=3.10",
-                    raises=TypeError,
+                pytest.mark.skipif(
+                    condition=sys.version_info >= (3, 10)
+                    and pymc.__version__ >= "5.20.1",
+                    reason="Inconsistent behaviour with pymc>=5.20.1 and python>=3.10",
                 ),
             ),
         ),

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import sys
+
+import pymc
 import pytest
 import torch
 from torch import eye, ones, zeros
@@ -393,7 +396,18 @@ def test_c2st_multi_round_nle_on_linearGaussian_vi(num_trials: int):
         pytest.param("slice_np", "uniform", marks=pytest.mark.mcmc),
         pytest.param("slice_np_vectorized", "gaussian", marks=pytest.mark.mcmc),
         pytest.param("slice_np_vectorized", "uniform", marks=pytest.mark.mcmc),
-        pytest.param("nuts_pymc", "gaussian", marks=pytest.mark.mcmc),
+        pytest.param(
+            "nuts_pymc",
+            "gaussian",
+            marks=(
+                pytest.mark.mcmc,
+                pytest.mark.skipif(
+                    condition=sys.version_info >= (3, 10)
+                    and pymc.__version__ >= "5.20.1",
+                    reason="Inconsistent behaviour with pymc>=5.20.1 and python>=3.10",
+                ),
+            ),
+        ),
         pytest.param("nuts_pyro", "uniform", marks=pytest.mark.mcmc),
         pytest.param("hmc_pymc", "gaussian", marks=pytest.mark.mcmc),
         ("rejection", "uniform"),

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import sys
+
+import pymc
 import pytest
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
@@ -317,7 +320,18 @@ def test_c2st_multi_round_snr_on_linearGaussian_vi(
         pytest.param("slice_np", "uniform", marks=pytest.mark.mcmc),
         pytest.param("slice_np_vectorized", "gaussian", marks=pytest.mark.mcmc),
         pytest.param("slice_np_vectorized", "uniform", marks=pytest.mark.mcmc),
-        pytest.param("nuts_pymc", "gaussian", marks=pytest.mark.mcmc),
+        pytest.param(
+            "nuts_pymc",
+            "gaussian",
+            marks=(
+                pytest.mark.mcmc,
+                pytest.mark.skipif(
+                    condition=sys.version_info >= (3, 10)
+                    and pymc.__version__ >= "5.20.1",
+                    reason="Inconsistent behaviour with pymc>=5.20.1 and python>=3.10",
+                ),
+            ),
+        ),
         pytest.param("nuts_pyro", "uniform", marks=pytest.mark.mcmc),
         pytest.param("hmc_pyro", "gaussian", marks=pytest.mark.mcmc),
         ("rejection", "uniform"),

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import sys
 
 import numpy as np
+import pymc
 import pytest
 import torch
 from torch import eye, ones, zeros
@@ -187,11 +188,9 @@ def test_c2st_pymc_sampler_on_Gaussian(
         "hmc_pyro",
         pytest.param(
             "nuts_pymc",
-            marks=pytest.mark.xfail(
-                condition=sys.version_info >= (3, 10),
-                reason="Fails with pymc>=5.20.1 and python>=3.10",
-                strict=True,
-                raises=TypeError,
+            marks=pytest.mark.skipif(
+                condition=sys.version_info >= (3, 10) and pymc.__version__ >= "5.20.1",
+                reason="Inconsistent behaviour with pymc>=5.20.1 and python>=3.10",
             ),
         ),
         "hmc_pymc",

--- a/tests/posterior_sampler_test.py
+++ b/tests/posterior_sampler_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 
+import pymc
 import pytest
 from pyro.infer.mcmc import MCMC
 from torch import Tensor, eye, zeros
@@ -29,10 +30,9 @@ from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
         "hmc_pyro",
         pytest.param(
             "nuts_pymc",
-            marks=pytest.mark.xfail(
-                condition=sys.version_info >= (3, 10),
-                reason="Fails with pymc>=5.20.1 and python>=3.10",
-                raises=TypeError,
+            marks=pytest.mark.skipif(
+                condition=sys.version_info >= (3, 10) and pymc.__version__ >= "5.20.1",
+                reason="Inconsistent behaviour with pymc>=5.20.1 and python>=3.10",
             ),
         ),
         "hmc_pymc",


### PR DESCRIPTION
This addresses #1484 - we marked the `pymc` tests with `xfail` since the new pymc update - but it seems that the outcome of this test is stochastic as sometimes it works (and the xfail causes the test to Fail as a result). For now I propose a quick patch by changing `xfail` to `skipif` for the new version of pymc with python>=3.10, so that this is not a blocker during the hackathon. We can look into it further as a separate issue.