### PR TITLE
z_score correct order in Zuko

### DIFF
--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -1068,8 +1068,8 @@ def build_zuko_flow(
         z_score_x_bool, structured_x = z_score_parser(z_score_x)
         if z_score_x_bool:
             transform = (
-                transform,
                 standardizing_transform_zuko(batch_x, structured_x),
+                transform,
             )
 
         z_score_y_bool, structured_y = z_score_parser(z_score_y)
@@ -1087,8 +1087,8 @@ def build_zuko_flow(
         z_score_x_bool, structured_x = z_score_parser(z_score_x)
         if z_score_x_bool:
             transforms = (
-                *transforms,
                 standardizing_transform_zuko(batch_x, structured_x),
+                *transforms,
             )
 
         z_score_y_bool, structured_y = z_score_parser(z_score_y)


### PR DESCRIPTION
Bug resolved:

The order of the transformations and standardization has been changed: we first want to standardize the input and then perform a series of transformations.