### PR TITLE
Clarify pbar annotation in sample_batched for DirectPosterior

### DIFF
--- a/sbi/samplers/rejection/rejection.py
+++ b/sbi/samplers/rejection/rejection.py
@@ -253,11 +253,6 @@ def accept_reject_sample(
 
     # Progress bar can be skipped, e.g. when sampling after each round just for
     # logging.
-    pbar = tqdm(
-        disable=not show_progress_bars,
-        total=num_samples,
-        desc=f"Drawing {num_samples} posterior samples",
-    )
     if proposal_sampling_kwargs is None:
         proposal_sampling_kwargs = {}
 
@@ -268,6 +263,12 @@ def accept_reject_sample(
     # But this would require giving the method the condition_shape explicitly...
     if "condition" in proposal_sampling_kwargs:
         num_xos = proposal_sampling_kwargs["condition"].shape[0]
+
+    pbar = tqdm(
+        disable=not show_progress_bars,
+        total=num_samples,
+        desc=f"Drawing {num_samples} posterior samples for {num_xos} observations",
+    )
 
     accepted = [[] for _ in range(num_xos)]
     acceptance_rate = torch.full((num_xos,), float("Nan"))


### PR DESCRIPTION
## This is a fix for the bug described in #1388

`sample_batch` of `DirectPosterior` uses `accept_reject_sample` to generate posterior samples for a batch of observations. Changed the description of the pbar in `accept_reject_sample` to clarify how many posterior samples for how many observations are generated.