### PR TITLE
Prior to(device)

### DIFF
--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -1068,8 +1068,8 @@ def build_zuko_flow(
         z_score_x_bool, structured_x = z_score_parser(z_score_x)
         if z_score_x_bool:
             transform = (
-                transform,
                 standardizing_transform_zuko(batch_x, structured_x),
+                transform,
             )
 
         z_score_y_bool, structured_y = z_score_parser(z_score_y)
@@ -1087,8 +1087,8 @@ def build_zuko_flow(
         z_score_x_bool, structured_x = z_score_parser(z_score_x)
         if z_score_x_bool:
             transforms = (
-                *transforms,
                 standardizing_transform_zuko(batch_x, structured_x),
+                *transforms,
             )
 
         z_score_y_bool, structured_y = z_score_parser(z_score_y)

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -61,7 +61,7 @@ def gpu_available() -> bool:
     return torch.cuda.is_available() or torch.backends.mps.is_available()
 
 
-def check_device(device: str) -> None:
+def check_device(device: Union[str, torch.device]) -> None:
     """Check whether the device is valid.
 
     Args:

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -332,21 +332,16 @@ class BoxUniform(Independent):
             reinterpreted_batch_ndims,
         )
 
-    def to(self, device: Union[str, torch.device]):
+    def to(self, device: Union[str, torch.device]) -> None:
         """
         Moves the distribution to the specified device **in place**.
 
         Args:
-            device (str): Target device (e.g., "cpu", "cuda", "mps").
-
-        Returns:
-            self (BoxUniform): The modified BoxUniform instance.
+            device: Target device (e.g., "cpu", "cuda", "mps").
         """
         # Update the device attribute
         self.device = device
-
-        if not isinstance(device, torch.device):
-            device = torch.device(device)
+        device = process_device(device)
 
         # Move tensors to the new device
         self.low = self.low.to(device=device)

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -274,8 +274,8 @@ def gaussian_kde_log_eval(samples, query):
 class BoxUniform(Independent):
     def __init__(
         self,
-        low: Tensor,
-        high: Tensor,
+        low: Union[Tensor, Array],
+        high: Union[Tensor, Array],
         reinterpreted_batch_ndims: int = 1,
         device: Optional[str] = None,
     ):

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -15,7 +15,7 @@ from sbi.sbi_types import Array, OneOrMore
 from sbi.utils.typechecks import is_nonnegative_int, is_positive_int
 
 
-def process_device(device: Union[str, torch.device]) -> Union[str, torch.device]:
+def process_device(device: Union[str, torch.device]) -> str:
     """Set and return the default device to cpu or gpu (cuda, mps).
 
     Args:
@@ -52,6 +52,8 @@ def process_device(device: Union[str, torch.device]) -> Union[str, torch.device]
         # Else, check whether the custom device is valid.
         else:
             check_device(device)
+            if isinstance(device, torch.device):
+                device = device.type
 
         return device
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -15,7 +15,7 @@ from sbi.sbi_types import Array, OneOrMore
 from sbi.utils.typechecks import is_nonnegative_int, is_positive_int
 
 
-def process_device(device: Union[str, torch.device]) -> str:
+def process_device(device: Union[str, torch.device]) -> Union[str, torch.device]:
     """Set and return the default device to cpu or gpu (cuda, mps).
 
     Args:

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -313,6 +313,11 @@ class BoxUniform(Independent):
         # Device handling
         device = low.device.type if device is None else device
         device = process_device(device)
+        self.device = device
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+        self.low = torch.as_tensor(low, dtype=torch.float32, device=device)
+        self.high = torch.as_tensor(high, dtype=torch.float32, device=device)
 
         super().__init__(
             Uniform(
@@ -325,6 +330,35 @@ class BoxUniform(Independent):
                 validate_args=False,
             ),
             reinterpreted_batch_ndims,
+        )
+
+    def to(self, device: Union[str, torch.device]):
+        """
+        Moves the distribution to the specified device **in place**.
+
+        Args:
+            device (str): Target device (e.g., "cpu", "cuda", "mps").
+
+        Returns:
+            self (BoxUniform): The modified BoxUniform instance.
+        """
+        # Update the device attribute
+        self.device = device
+
+        if not isinstance(device, torch.device):
+            device = torch.device(device)
+
+        # Move tensors to the new device
+        self.low = self.low.to(device=device)
+        self.high = self.high.to(device=device)
+
+        super().__init__(
+            Uniform(
+                low=self.low,
+                high=self.high,
+                validate_args=False,
+            ),
+            self.reinterpreted_batch_ndims,
         )
 
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -15,7 +15,7 @@ from sbi.sbi_types import Array, OneOrMore
 from sbi.utils.typechecks import is_nonnegative_int, is_positive_int
 
 
-def process_device(device: str) -> str:
+def process_device(device: Union[str, torch.device]) -> str:
     """Set and return the default device to cpu or gpu (cuda, mps).
 
     Args:

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -21,13 +21,13 @@ def get_distribution_parameters(
     # matrix from covariance, and stores it in the arg_constraints.
     # When reinstantiating, we must provide only one of them.
     if isinstance(dist, torch.distributions.MultivariateNormal):
-        params['precision_matrix'] = None
-        params['scale_tril'] = None
+        params["precision_matrix"] = None
+        params["scale_tril"] = None
     # torch.distributions.MultivariateNormal calculates logits
     # from probabilities, and stores it in the arg_constraints.
     # When reinstantiating, we must provide only one of them.
     elif isinstance(dist, torch.distributions.Binomial):
-        params['logits'] = None
+        params["logits"] = None
     return params
 
 

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -10,7 +10,7 @@ from torch.distributions import Distribution, constraints
 
 
 def get_distribution_parameters(
-    dist: torch.distributions, device: Union[str, torch.device]
+    dist: torch.distributions.Distribution, device: Union[str, torch.device]
 ) -> Dict:
     """Used to get the tensors of the parameters in torch distributions.
 

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -97,6 +97,12 @@ class CustomPriorWrapper(Distribution):
             )
 
     def to(self, device):
+        """
+        Move the distribution to the specified device. Not implemented for this class.
+
+        Raises:
+            NotImplementedError.
+        """
         raise NotImplementedError(
             "This class is not supported on the GPU. Use on cpu or use \
             any of `PytorchReturnTypeWrapper`, `BoxUniform`, or `MultipleIndependent`."
@@ -171,6 +177,16 @@ class PytorchReturnTypeWrapper(Distribution):
         return self.prior.support
 
     def to(self, device):
+        """
+        Move the distribution to the specified device.
+
+        It moves the distribution parameters to the specific device
+        because pytorch distribution does not have a `to` method.
+        It also updates the device attribute.
+
+        Args:
+            device: device to move the distribution to.
+        """
         params = get_distribution_parameters(self.prior, device)
         self.prior = type(self.prior)(**params)
         self.device = device
@@ -346,7 +362,14 @@ class MultipleIndependent(Distribution):
         )
 
     def to(self, device):
-        # Move the values of the arg_constraints dictionary to the specified device
+        """
+        Move the distribution to the specified device.
+        If the distribution has the `to` method, it is used. Otherwise, the
+        parameters of the distribution are moved to the specified device.
+
+        Args:
+            device: device to move the distribution to.
+        """
         for i in range(len(self.dists)):
             if hasattr(self.dists[i], "to"):
                 self.dists[i].to(device)

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -10,6 +10,9 @@ from torch.distributions import Distribution, constraints
 
 
 def get_distribution_parameters(dist, device):
+    '''Used to get the tensors of the parameters in torch distributions.
+    Returns the tensors relocated to device.
+    '''
     params = {param: getattr(dist, param).to(device) for param in dist.arg_constraints}
     if isinstance(dist, torch.distributions.MultivariateNormal):
         params['precision_matrix'] = None
@@ -92,6 +95,12 @@ class CustomPriorWrapper(Distribution):
                 UserWarning,
                 stacklevel=2,
             )
+
+    def to(self, device):
+        raise NotImplementedError(
+            "This class is not supported on the GPU. Use on cpu or use \
+            any of `PytorchReturnTypeWrapper`, `BoxUniform`, or `MultipleIndependent`."
+        )
 
     @property
     def mean(self):

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -189,9 +189,8 @@ class PytorchReturnTypeWrapper(Distribution):
         """
         Move the distribution to the specified device.
 
-        It moves the distribution parameters to the specific device
-        because pytorch distribution does not have a `to` method.
-        It also updates the device attribute.
+        Moves the distribution parameters to the specific device
+        and updates the device attribute.
 
         Args:
             device: device to move the distribution to.
@@ -380,6 +379,7 @@ class MultipleIndependent(Distribution):
             device: device to move the distribution to.
         """
         for i in range(len(self.dists)):
+            # ignoring because it is related to torch and not sbi
             if hasattr(self.dists[i], "to"):
                 self.dists[i].to(device)  # type: ignore
             else:

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -444,12 +444,15 @@ def test_vi_on_gpu(num_dim: int, q: str, vi_method: str, sampling_method: str):
         ("gpu", None),
         ("cpu", "cpu"),
         ("gpu", "gpu"),
+        (torch.device("cpu"), torch.device("cpu")),
         pytest.param("gpu", "cpu", marks=pytest.mark.xfail),
         pytest.param("cpu", "gpu", marks=pytest.mark.xfail),
     ],
 )
 def test_boxuniform_device_handling(arg_device, device):
-    """Test mismatch between device passed via low / high and device kwarg."""
+    """Test mismatch between device passed via low / high and device kwarg.
+
+    Also tests torch.device as argument of process_device."""
 
     arg_device = process_device(arg_device)
     device = process_device(device)

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -1,8 +1,12 @@
 import pytest
 import torch
+from torch.distributions import Beta, Gamma, Normal
 
 from sbi.utils.torchutils import BoxUniform, process_device
-from sbi.utils.user_input_checks_utils import PytorchReturnTypeWrapper
+from sbi.utils.user_input_checks_utils import (
+    MultipleIndependent,
+    PytorchReturnTypeWrapper,
+)
 
 
 @pytest.mark.gpu
@@ -29,5 +33,21 @@ def test_ReturnTypeWrapper(device: str):
     prior = torch.distributions.Normal(loc=0.0, scale=1.0)
     prior = PytorchReturnTypeWrapper(prior)
 
+    prior.to(device)
+    assert prior.device == device
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("device", ["mps"])
+def test_MultipleIndependent(device: str):
+    device = process_device(device)
+    dists = [
+        Gamma(torch.tensor([1.0]), torch.tensor([0.5])),
+        Beta(torch.tensor([2.0]), torch.tensor([2.0])),
+        BoxUniform(torch.zeros(1), torch.ones(1)),
+        Normal(torch.tensor([0.0]), torch.tensor([0.5])),
+    ]
+
+    prior = MultipleIndependent(dists)
     prior.to(device)
     assert prior.device == device

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -28,9 +28,9 @@ def test_BoxUniform(device: str):
 
 @pytest.mark.gpu
 @pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
-def test_ReturnTypeWrapper(device: str):
+def test_PytorchReturnTypeWrapper(device: str):
     device = process_device(device)
-    prior = torch.distributions.Normal(loc=0.0, scale=1.0)
+    prior = Normal(loc=0.0, scale=1.0)
     prior = PytorchReturnTypeWrapper(prior)
 
     prior.to(device)
@@ -38,7 +38,7 @@ def test_ReturnTypeWrapper(device: str):
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["mps"])
+@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
 def test_MultipleIndependent(device: str):
     device = process_device(device)
     dists = [

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -1,13 +1,14 @@
 import pytest
 import torch
 
-from sbi.utils.torchutils import BoxUniform
+from sbi.utils.torchutils import BoxUniform, process_device
 from sbi.utils.user_input_checks_utils import PytorchReturnTypeWrapper
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["cpu", "mps"])
+@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
 def test_BoxUniform(device: str):
+    device = process_device(device)
     low = torch.tensor([0.0])
     high = torch.tensor([1.0])
     prior = BoxUniform(low, high)
@@ -16,14 +17,15 @@ def test_BoxUniform(device: str):
 
     prior.to(device)
     assert prior.device == device
-    assert prior.low.device.type == device
-    assert prior.high.device.type == device
+    assert prior.low.device.type == device.strip(":0")
+    assert prior.high.device.type == device.strip(":0")
     prior.sample((1,))
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["cpu", "mps"])
+@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
 def test_ReturnTypeWrapper(device: str):
+    device = process_device(device)
     prior = torch.distributions.Normal(loc=0.0, scale=1.0)
     prior = PytorchReturnTypeWrapper(prior)
 

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+from sbi.utils.torchutils import BoxUniform
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_BoxUniform(device: str):
+    low = torch.tensor([0.0])
+    high = torch.tensor([1.0])
+    prior = BoxUniform(low, high)
+    prior.sample((1,))
+    assert prior.device == "cpu"
+
+    prior.to(device)
+    assert prior.device == device
+    assert prior.low.device.type == device
+    assert prior.high.device.type == device
+    prior.sample((1,))

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from torch.distributions import Beta, Gamma, Normal
+from torch.distributions import Beta, Binomial, Gamma, MultivariateNormal, Normal
 
 from sbi.utils.torchutils import BoxUniform, process_device
 from sbi.utils.user_input_checks_utils import (
@@ -10,35 +10,54 @@ from sbi.utils.user_input_checks_utils import (
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
+@pytest.mark.parametrize("device", ["cpu", "gpu"])
 def test_BoxUniform(device: str):
     device = process_device(device)
     low = torch.tensor([0.0])
     high = torch.tensor([1.0])
     prior = BoxUniform(low, high)
-    prior.sample((1,))
+    sample = prior.sample((1,))
     assert prior.device == "cpu"
+    assert sample.device.type == "cpu"
+    log_probs = prior.log_prob(sample)
+    assert log_probs.device.type == "cpu"
 
     prior.to(device)
     assert prior.device == device
     assert prior.low.device.type == device.strip(":0")
     assert prior.high.device.type == device.strip(":0")
-    prior.sample((1,))
+
+    sample_device = prior.sample((100,))
+    assert sample_device.device.type == device.strip(":0")
+    log_probs = prior.log_prob(sample_device)
+    assert log_probs.device.type == device.strip(":0")
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
-def test_PytorchReturnTypeWrapper(device: str):
+@pytest.mark.parametrize("device", ["cpu", "gpu"])
+@pytest.mark.parametrize(
+    "prior",
+    [
+        Normal(loc=0.0, scale=1.0),
+        Binomial(total_count=10, probs=torch.tensor([0.5])),
+        MultivariateNormal(torch.tensor([0.1, 0.0]), covariance_matrix=torch.eye(2)),
+    ],
+)
+def test_PytorchReturnTypeWrapper(device: str, prior: torch.distributions):
     device = process_device(device)
-    prior = Normal(loc=0.0, scale=1.0)
     prior = PytorchReturnTypeWrapper(prior)
 
     prior.to(device)
     assert prior.device == device
 
+    sample_device = prior.sample((100,))
+    assert sample_device.device.type == device.strip(":0")
+    log_probs = prior.log_prob(sample_device)
+    assert log_probs.device.type == device.strip(":0")
+
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("device", ["cpu", "mps", "gpu"])
+@pytest.mark.parametrize("device", ["cpu", "gpu"])
 def test_MultipleIndependent(device: str):
     device = process_device(device)
     dists = [
@@ -46,8 +65,14 @@ def test_MultipleIndependent(device: str):
         Beta(torch.tensor([2.0]), torch.tensor([2.0])),
         BoxUniform(torch.zeros(1), torch.ones(1)),
         Normal(torch.tensor([0.0]), torch.tensor([0.5])),
+        Binomial(torch.tensor([10]), torch.tensor([0.5])),
     ]
 
     prior = MultipleIndependent(dists)
     prior.to(device)
     assert prior.device == device
+
+    sample_device = prior.sample((100,))
+    assert sample_device.device.type == device.strip(":0")
+    log_probs = prior.log_prob(sample_device)
+    assert log_probs.device.type == device.strip(":0")

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -12,6 +12,7 @@ from sbi.utils.user_input_checks_utils import (
 @pytest.mark.gpu
 @pytest.mark.parametrize("device", ["cpu", "gpu"])
 def test_BoxUniform(device: str):
+    """Test moving BoxUniform prior between devices."""
     device = process_device(device)
     low = torch.tensor([0.0])
     high = torch.tensor([1.0])
@@ -52,6 +53,10 @@ def test_BoxUniform(device: str):
     ],
 )
 def test_PytorchReturnTypeWrapper(device: str, prior: torch.distributions):
+    """Test moving PytorchReturnTypeWrapper objects between devices.
+
+    Asserts that samples, prior, and log_probs are in device.
+    """
     device = process_device(device)
     prior = PytorchReturnTypeWrapper(prior)
 
@@ -71,6 +76,12 @@ def test_PytorchReturnTypeWrapper(device: str, prior: torch.distributions):
 @pytest.mark.gpu
 @pytest.mark.parametrize("device", ["cpu", "gpu"])
 def test_MultipleIndependent(device: str):
+    """Test moving MultipleIndependent objects between devices.
+
+    Asserts that samples, prior, and log_probs are in device.
+    Uses Gamma, Beta, Normal and Binomial, from
+    torch.distributions and BoxUniform form sbi.
+    """
     device = process_device(device)
     dists = [
         Gamma(torch.tensor([1.0]), torch.tensor([0.5])),

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -17,20 +17,28 @@ def test_BoxUniform(device: str):
     high = torch.tensor([1.0])
     prior = BoxUniform(low, high)
     sample = prior.sample((1,))
-    assert prior.device == "cpu"
-    assert sample.device.type == "cpu"
+    assert prior.device == "cpu", "Prior is not initially in cpu."
+    assert sample.device.type == "cpu", "sample is not initially in cpu."
     log_probs = prior.log_prob(sample)
-    assert log_probs.device.type == "cpu"
+    assert log_probs.device.type == "cpu", "Log probs are not initially in cpu."
 
     prior.to(device)
-    assert prior.device == device
-    assert prior.low.device.type == device.strip(":0")
-    assert prior.high.device.type == device.strip(":0")
+    assert prior.device == device, f"Prior was not moved to {device}."
+    assert prior.low.device.type == device.strip(":0"), (
+        f"BoxUniform low tensor is not in {device}."
+    )
+    assert prior.high.device.type == device.strip(":0"), (
+        f"BoxUniform high tensor is not in {device}."
+    )
 
     sample_device = prior.sample((100,))
-    assert sample_device.device.type == device.strip(":0")
+    assert sample_device.device.type == device.strip(":0"), (
+        f"sample tensor is not in {device}."
+    )
     log_probs = prior.log_prob(sample_device)
-    assert log_probs.device.type == device.strip(":0")
+    assert log_probs.device.type == device.strip(":0"), (
+        f"log_prob tensor is not in {device}."
+    )
 
 
 @pytest.mark.gpu
@@ -48,12 +56,16 @@ def test_PytorchReturnTypeWrapper(device: str, prior: torch.distributions):
     prior = PytorchReturnTypeWrapper(prior)
 
     prior.to(device)
-    assert prior.device == device
+    assert prior.device == device, f"Prior was not correctly moved to {device}."
 
     sample_device = prior.sample((100,))
-    assert sample_device.device.type == device.strip(":0")
+    assert sample_device.device.type == device.strip(":0"), (
+        f"sample was not correctly moved to {device}."
+    )
     log_probs = prior.log_prob(sample_device)
-    assert log_probs.device.type == device.strip(":0")
+    assert log_probs.device.type == device.strip(":0"), (
+        f"log_prob was not correctly moved to {device}."
+    )
 
 
 @pytest.mark.gpu
@@ -69,10 +81,15 @@ def test_MultipleIndependent(device: str):
     ]
 
     prior = MultipleIndependent(dists)
+
     prior.to(device)
-    assert prior.device == device
+    assert prior.device == device, f"Prior was not correctly moved to {device}."
 
     sample_device = prior.sample((100,))
-    assert sample_device.device.type == device.strip(":0")
+    assert sample_device.device.type == device.strip(":0"), (
+        f"sample was not correctly moved to {device}."
+    )
     log_probs = prior.log_prob(sample_device)
-    assert log_probs.device.type == device.strip(":0")
+    assert log_probs.device.type == device.strip(":0"), (
+        f"log_prob was not correctly moved to {device}."
+    )

--- a/tests/prior_device_tests.py
+++ b/tests/prior_device_tests.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from sbi.utils.torchutils import BoxUniform
+from sbi.utils.user_input_checks_utils import PytorchReturnTypeWrapper
 
 
 @pytest.mark.gpu
@@ -18,3 +19,13 @@ def test_BoxUniform(device: str):
     assert prior.low.device.type == device
     assert prior.high.device.type == device
     prior.sample((1,))
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_ReturnTypeWrapper(device: str):
+    prior = torch.distributions.Normal(loc=0.0, scale=1.0)
+    prior = PytorchReturnTypeWrapper(prior)
+
+    prior.to(device)
+    assert prior.device == device


### PR DESCRIPTION
We implemented the `.to(device)` method for all priors supported by `sbi`. 

`CustomPriorWrapper` raises a `NotImplementedError` because `scipy` does not support `to(device)`. 

This PR will add `.to(device)` to `TorchReturnTypeWrapper`, `BoxUniform`, and `MultipleIndependent`. Corresponding tests are in `prior_device_test.py`.