### PR TITLE
fix path to contribute.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to sbi
 
-The latest contributing guide is available in the repository at `mkdocs/docs/contribute.md`, or online at:
+The latest contributing guide is available in the repository at [`docs/contribute.md`](docs/contribute.md), or online at:
 
 [sbi-dev.github.io/sbi/latest/contribute/](https://sbi-dev.github.io/sbi/latest/contribute/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to sbi
 
-The latest contributing guide is available in the repository at `docs/contribute.md`, or online at:
+The latest contributing guide is available in the repository at `mkdocs/docs/contribute.md`, or online at:
 
 [sbi-dev.github.io/sbi/latest/contribute/](https://sbi-dev.github.io/sbi/latest/contribute/)


### PR DESCRIPTION
I think this was overlooked in the recent overhaul of the documentation page.