### PR TITLE
Add utils to docs

### DIFF
--- a/docs/reference/sbi.utils.rst
+++ b/docs/reference/sbi.utils.rst
@@ -1,0 +1,4 @@
+Utils
+=====
+
+.. autofunction:: sbi.utils.pyroutils.to_pyro_distribution

--- a/docs/sbi.rst
+++ b/docs/sbi.rst
@@ -11,3 +11,4 @@ API Reference
    reference/sbi.posteriors
    reference/sbi.potentials
    reference/sbi.analysis
+   reference/sbi.utils

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -3,6 +3,7 @@ from sbi.utils.analysis_utils import get_1d_marginal_peaks_from_kde
 from sbi.utils.io import get_data_root, get_log_root, get_project_root
 from sbi.utils.kde import KDEWrapper, get_kde
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
+from sbi.utils.pyroutils import to_pyro_distribution
 from sbi.utils.restriction_estimator import (
     RestrictedPrior,
     RestrictionEstimator,

--- a/sbi/utils/pyroutils.py
+++ b/sbi/utils/pyroutils.py
@@ -197,7 +197,7 @@ def to_pyro_distribution(
 
     Args:
         estimator: A trained `sbi` estimator. Either a `ConditionalDensityEstimator` or
-        a `RatioEstimator`.
+            a `RatioEstimator`.
         condition: The conditioning parameter for the estimator.
 
     Returns:
@@ -205,7 +205,7 @@ def to_pyro_distribution(
 
     Raises:
         ValueError: If `estimator` is not a `ConditionalDensityEstimator` or
-        `RatioEstimator`.
+            `RatioEstimator`.
 
     Note:
         If `estimator` input has discrete or mixed support (e.g.


### PR DESCRIPTION
This PR fixes #1511 by adding a utils section to the docs, containing just for now `to_pyro_distribution`. Because the docstrings don't indicate the model in which the function being rendered lives, I also imported `to_pyro_distribution` into `sbi.utils`. A few fixes to the docstring were required.