### PR TITLE
pairplot refactoring

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -4,7 +4,8 @@
 import collections
 import copy
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 from warnings import warn
 
 import matplotlib as mpl
@@ -28,6 +29,194 @@ try:
 except AttributeError:
     collectionsAbc = collections
 
+@dataclass
+class GenericKwargs:
+    def __getitem__(self, key):
+        return eval(f'self.{key}')
+
+    def __setitem__(self, key, item):
+        self.__dict__[key] = item
+
+    def keys(self):
+        return self.__dict__.keys()
+
+    def items(self):
+        return self.__dict__.items()
+
+@dataclass
+class FigKwargs(GenericKwargs):
+    legend: Optional[List[str]] = None
+    legend_kwargs: Dict = field(default_factory=dict) # type: ignore
+    points_labels: list = field(
+        default_factory=lambda: [f"points_{idx}" for idx in range(10)])
+    samples_labels: list = field(
+        default_factory=lambda: [f"samples_{idx}" for idx in range(10)])
+    samples_colors: list = field(
+        default_factory=lambda: plt.rcParams["axes.prop_cycle"].by_key()["color"][0::2])
+    points_colors: list = field(
+        default_factory=lambda: plt.rcParams["axes.prop_cycle"].by_key()["color"][1::2])
+    tickformatter: mpl.ticker.FormatStrFormatter = mpl.ticker.FormatStrFormatter("%g") # type: ignore
+    tick_labels: Optional[Dict] = None
+    points_diag: dict = field(default_factory=dict)
+    points_offdiag: dict = field(
+        default_factory=lambda: {"marker": ".", "markersize": 10,})
+    fig_bg_colors: dict = field(
+        default_factory=lambda: {"offdiag": None, "diag": None, "lower": None})
+    fig_subplots_adjust: dict =  field(default_factory=lambda: {"top": 0.9,})
+    subplots: dict = field(default_factory=dict)
+    despine:  dict = field(default_factory=lambda: {"offset": 5,})
+    title: Optional[str] = None
+    title_format: dict = field(default_factory=lambda: {"fontsize": 16})
+    x_lim_add_eps: float = 1e-5
+    square_subplots: bool = True
+
+@dataclass
+class GenericMplKwargs(GenericKwargs):
+    """MplKwargs is used to generate kwargs that are passed to matplotlib in pairplot.
+    kwargs that are neither in MplKwargs nor used by pairplot are completely ignored.
+    To used the dictionary interface to kwargs, make `'mpl_kwargs'` a dict key.
+
+    Example dictionary interface:
+    pairplot(samples,
+             diag='kde',
+             diag_kwargs={'bw_method': 'scott', 'mpl_kwargs': {'color': 'r'}})
+
+    Example dataclass interface:
+    pairplot(samples,
+            diag='kde',
+            diag_kwargs=DiagKwargsKDE(bw_method='scott',
+                                      mpl_kwargs=MplKwargsKDE(color='r')))
+    """
+
+@dataclass
+class MplKwargsDiagKDE(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+
+@dataclass
+class MplKwargsDiagHist(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+    density: bool = False
+    histtype: str = "step"
+
+@dataclass
+class MplKwargsDiagScatter(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+
+@dataclass
+class DiagKwargsKDE(GenericKwargs):
+    bw_method: str = "scott"
+    bins: int = 50
+    mpl_kwargs: Union[MplKwargsDiagKDE, Dict] = field(
+        default_factory=lambda: MplKwargsDiagKDE())
+
+@dataclass
+class DiagKwargsHist(GenericKwargs):
+    bin_heuristic: str = "Freedman-Diaconis"
+    mpl_kwargs: MplKwargsDiagHist = field(default_factory=lambda: MplKwargsDiagHist())
+
+@dataclass
+class DiagKwargsScatter(GenericKwargs):
+    mpl_kwargs: MplKwargsDiagScatter = field(
+        default_factory=lambda: MplKwargsDiagScatter())
+
+@dataclass
+class MplKwargsOffDiagKDE(GenericMplKwargs):
+    cmap: str = "viridis"
+    origin: str = "lower"
+    aspect: str = "auto"
+
+@dataclass
+class MplKwargsOffDiagHist(GenericMplKwargs):
+    cmap: str = "viridis"
+    origin: str = "lower"
+    aspect: str = "auto"
+
+@dataclass
+class MplKwargsOffDiagScatter(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+    edgecolor: str = "white"
+    alpha: float = 0.5
+    rasterized: bool = False
+
+@dataclass
+class MplKwargsOffDiagContour(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+
+@dataclass
+class MplKwargsOffDiagPlot(GenericMplKwargs):
+    color: Optional[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
+    aspect: str = "auto"
+
+@dataclass
+class OffDiagKwargsKDE(GenericKwargs):
+    bw_method: str = "scott"
+    bins: int = 50
+    mpl_kwargs: MplKwargsOffDiagKDE = field(
+        default_factory=lambda: MplKwargsOffDiagKDE())
+
+@dataclass
+class OffDiagKwargsHist(GenericKwargs):
+    bin_heuristic: Optional[str] = None
+    mpl_kwargs: MplKwargsOffDiagHist = field(
+        default_factory=lambda: MplKwargsOffDiagHist())
+    np_hist_kwargs: dict = field(
+        default_factory=lambda: {"bins": 50, "density": False})
+
+@dataclass
+class OffDiagKwargsScatter(GenericKwargs):
+    mpl_kwargs: MplKwargsOffDiagScatter = field(
+        default_factory=lambda: MplKwargsOffDiagScatter())
+
+@dataclass
+class OffDiagKwargsContour(GenericKwargs):
+    bw_method: str = "scott"
+    bins: int = 50
+    levels: list = field(default_factory=lambda: [0.68, 0.95, 0.99])
+    percentile: bool = True
+    mpl_kwargs: MplKwargsOffDiagContour = field(
+        default_factory=lambda: MplKwargsOffDiagContour())
+
+@dataclass
+class OffDiagKwargsPlot(GenericKwargs):
+    mpl_kwargs: MplKwargsOffDiagPlot = field(
+        default_factory=lambda: MplKwargsOffDiagPlot())
+
+def _get_defaults(pos: str, type: str):
+    match pos:
+        case "diag":
+            match type:
+                case "kde":
+                    return DiagKwargsKDE()
+                case "hist":
+                    return DiagKwargsHist()
+                case "scatter":
+                    return DiagKwargsScatter()
+                case None:
+                    return None
+        case "upper":
+            match type:
+                case "kde":
+                    return OffDiagKwargsKDE()
+                case "hist":
+                    return OffDiagKwargsHist()
+                case "scatter":
+                    return OffDiagKwargsScatter()
+                case "contour":
+                    return OffDiagKwargsContour()
+                case None:
+                    return None
+        case "lower":
+            match type:
+                case "kde":
+                    return OffDiagKwargsKDE()
+                case "hist":
+                    return OffDiagKwargsHist()
+                case "scatter":
+                    return OffDiagKwargsScatter()
+                case "contour":
+                    return OffDiagKwargsContour()
+                case None:
+                    return None
 
 def hex2rgb(hex: str) -> List[int]:
     """Pass 16 to the integer function for change of base"""
@@ -81,8 +270,10 @@ def plt_hist_1d(
     limits: torch.Tensor,
     diag_kwargs: Dict,
 ) -> None:
+    # ax.hist(samples, **diag_kwargs)
+    # return
     """Plot 1D histogram."""
-    hist_kwargs = copy.deepcopy(diag_kwargs["mpl_kwargs"])
+    hist_kwargs = copy.deepcopy(dict(diag_kwargs["mpl_kwargs"]))
     if "bins" not in hist_kwargs or hist_kwargs["bins"] is None:
         if diag_kwargs["bin_heuristic"] == "Freedman-Diaconis":
             # The Freedman-Diaconis heuristic
@@ -545,18 +736,18 @@ def ensure_numpy(t: Union[np.ndarray, torch.Tensor]) -> np.ndarray:
     return t
 
 
-def handle_nan_infs(samples: List[np.ndarray]) -> List[np.ndarray]:
+def handle_nan_infs(samples: np.ndarray) -> np.ndarray:
     """Check if there are NaNs or Infs in the samples."""
-    for i in range(len(samples)):
-        if np.isnan(samples[i]).any():
-            logging.warning("NaNs found in samples, omitting datapoints.")
-        if np.isinf(samples[i]).any():
-            logging.warning("Infs found in samples, omitting datapoints.")
-            # cast inf to nan, so they are omitted in the next step
-            np.nan_to_num(
-                samples[i], copy=False, nan=np.nan, posinf=np.nan, neginf=np.nan
-            )
-        samples[i] = samples[i][~np.isnan(samples[i]).any(axis=1)]
+    # for i in range(len(samples)):
+    if np.isnan(samples).any():
+        logging.warning("NaNs found in samples, omitting datapoints.")
+    if np.isinf(samples).any():
+        logging.warning("Infs found in samples, omitting datapoints.")
+        # cast inf to nan, so they are omitted in the next step
+        np.nan_to_num(
+            samples, copy=False, nan=np.nan, posinf=np.nan, neginf=np.nan
+        )
+    # samples[i] = samples[i][~np.isnan(samples[i]).any(axis=1)]
     return samples
 
 
@@ -584,24 +775,27 @@ def infer_limits(
         points: List of points.
         eps: Relative margin for the limits.
     """
-    limits = []
-    for d in range(dim):
-        # get min and max across all sets of samples
-        min_val = min(np.min(sample[:, d]) for sample in samples)
-        max_val = max(np.max(sample[:, d]) for sample in samples)
-        # include points in the limits
-        if points is not None:
-            min_val = min(min_val, min(np.min(point[:, d]) for point in points))
-            max_val = max(max_val, max(np.max(point[:, d]) for point in points))
-        # add margin
-        max_min_range = max_val - min_val
-        epsilon_range = eps * max_min_range
-        limits.append([min_val - epsilon_range, max_val + epsilon_range])
-    return limits
+    # limits = []
+    # for d in range(dim):
+    # get min and max across all sets of samples
+    min_val = np.min(samples, axis=0)
+    max_val = np.max(samples, axis=0)
+    # include points in the limits
+    if points is not None:
+        points = np.asarray(points) # type: ignore
+        min_val = np.min(np.vstack([min_val[None, :], points]), axis=0) # type: ignore
+        max_val = np.max(np.vstack([max_val[None, :], points]), axis=0) # type: ignore
+    # add margin
+    max_min_range = max_val - min_val
+    epsilon_range = eps * max_min_range
+    # limits.append([min_val - epsilon_range, max_val + epsilon_range])
+    limits = np.vstack([min_val - epsilon_range, max_val + epsilon_range])
+
+    return torch.Tensor(limits.T) # type: ignore
 
 
 def prepare_for_plot(
-    samples: Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor],
+    samples: Union[np.ndarray, torch.Tensor],
     limits: Optional[Union[List, torch.Tensor, np.ndarray]] = None,
     points: Optional[
         Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor]
@@ -612,21 +806,23 @@ def prepare_for_plot(
     of the samples.
     """
 
-    samples = convert_to_list_of_numpy(samples)
+    # samples = convert_to_list_of_numpy(samples)
+    samples = np.asarray(samples)
     if points is not None:
-        points = convert_to_list_of_numpy(points)
+        # points = convert_to_list_of_numpy(points)
+        points = np.asarray(points)
 
     samples = handle_nan_infs(samples)
 
-    dim = samples[0].shape[1]
+    dim = samples.shape[1]
 
     if limits is None or limits == []:
-        limits = infer_limits(samples, dim, points)
+        limits = infer_limits(samples, dim, points) # type: ignore
     else:
         limits = [limits[0] for _ in range(dim)] if len(limits) == 1 else limits
 
     limits = torch.as_tensor(limits)
-    return samples, dim, limits
+    return samples, dim, limits # type: ignore
 
 
 def prepare_for_conditional_plot(condition, opts):
@@ -685,9 +881,9 @@ def get_conditional_diag_func(opts, limits, eps_margins, resolution):
 
     return diag_func
 
-
+TNum = TypeVar('TNum', int, float, np.ndarray, torch.Tensor)
 def pairplot(
-    samples: Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor],
+    samples: Union[np.ndarray, torch.Tensor, List[TNum]],
     points: Optional[
         Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor]
     ] = None,
@@ -703,7 +899,7 @@ def pairplot(
     diag_kwargs: Optional[Union[List[Optional[Dict]], Dict]] = None,
     upper_kwargs: Optional[Union[List[Optional[Dict]], Dict]] = None,
     lower_kwargs: Optional[Union[List[Optional[Dict]], Dict]] = None,
-    fig_kwargs: Optional[Dict] = None,
+    fig_kwargs: Optional[Union[Dict, FigKwargs]] = None,
     fig: Optional[FigureBase] = None,
     axes: Optional[Axes] = None,
     **kwargs: Optional[Any],
@@ -716,7 +912,7 @@ def pairplot(
     2D-marginal of the distribution.
 
     Args:
-        samples: Samples used to build the histogram.
+        samples: Samples used to build the histogram. 2d Array (sample, parameter)
         points: List of additional points to scatter.
         limits: Array containing the plot xlim for each parameter dimension. If None,
             just use the min and max of the passed samples
@@ -733,13 +929,16 @@ def pairplot(
         ticks: Position of the ticks.
         offdiag: deprecated, use upper instead.
         diag_kwargs: Additional arguments to adjust the diagonal plot,
-            see the source code in `_get_default_diag_kwarg()`
+            see the source code in `DiagKwargsKDE`, `DiagKwargsHist`
+            and `DiagKwargsScatter`
         upper_kwargs: Additional arguments to adjust the upper diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `OffDiagKwargsKDE`, `OffDiagKwargsHist`,
+            `OffDiagKwargsScatter`, `OffDiagKwargsContour`, `OffDiagKwargsPlot`
         lower_kwargs: Additional arguments to adjust the lower diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `OffDiagKwargsKDE`, `OffDiagKwargsHist`,
+            `OffDiagKwargsScatter`, `OffDiagKwargsContour`, `OffDiagKwargsPlot`
         fig_kwargs: Additional arguments to adjust the overall figure,
-            see the source code in `_get_default_fig_kwargs()`
+            see the source code in `FigKwargs`
         fig: matplotlib figure to plot on.
         axes: matplotlib axes corresponding to fig.
         **kwargs: Additional arguments to adjust the plot (deprecated).
@@ -756,7 +955,7 @@ def pairplot(
             stacklevel=2,
         )
         fig, axes = pairplot_dep(
-            samples,
+            samples, # type: ignore
             points,
             limits,
             subset,
@@ -772,59 +971,148 @@ def pairplot(
         )
         return fig, axes
 
-    samples, dim, limits = prepare_for_plot(samples, limits, points)
+    samples, dim, limits = prepare_for_plot(samples, limits, points) # type: ignore
 
     # prepate figure kwargs
-    fig_kwargs_filled = _get_default_fig_kwargs()
-    # update the defaults dictionary with user provided values
-    fig_kwargs_filled = _update(fig_kwargs_filled, fig_kwargs)
+    # fig_kwargs_filled = _get_default_fig_kwargs()
+    fig_kwargs_default = FigKwargs()  # Get defaults
+    #if type(fig_kwargs) == FigKwargs:
+    fig_kwargs_user = fig_kwargs if fig_kwargs else fig_kwargs_default
+    fig_kwargs_filled = _update(dict(fig_kwargs_default), dict(fig_kwargs_user))
+
+    # Prepare Diag Defaults
+    if type(diag) is list:
+        diag = diag[0]
+        warn(f"diag uses only the first entry in a list for plot type. "
+             f"diag type is {diag[0]}.", stacklevel=2) # type: ignore
+    diag_defaults = _get_defaults("diag", type=diag) # type: ignore
+
+    if type(diag_kwargs) is list:
+        diag_kwargs = diag_kwargs[0]
+        warn("diag_kwargs lists are currently not supported. "
+             "only the first entry is used for kwargs.", stacklevel=2)
+
+    # warn the user if they provided kwargs that are ignored downstream
+    if diag_kwargs:
+        non_default_diag_kwargs = (set(dict(diag_kwargs).keys()) - # type: ignore
+                                   set(diag_defaults.__annotations__.keys())) # type: ignore
+        if non_default_diag_kwargs:
+            warn(f"diag_kwargs has {len(non_default_diag_kwargs)} args that are "
+                "ignored by pairplot: {non_default_diag_kwargs}. " + "To pass them to "
+                "matplotlib, include them in kwargs={'mpl_kwargs':{}}."
+                "See sbi.analysis.plot.GenericMplKwargs for details.", stacklevel=2)
+
+    if type(upper) is list:
+        upper = upper[0]
+        warn("diag uses only the first entry in a list for plot type. "
+             f"diag type is {upper[0]}.", stacklevel=2) # type: ignore
+    upper_defaults = _get_defaults("upper", type=upper) # type: ignore
+
+    if type(upper_kwargs) is list:
+        upper_kwargs = upper_kwargs[0]
+        warn("upper_kwargs is a list. Lists are currently not supported, "
+             "only the first entry is used for kwargs.", stacklevel=2)
+
+    if upper_kwargs:
+        non_default_diag_kwargs = (set(dict(upper_kwargs).keys()) - # type: ignore
+                                   set(upper_defaults.__annotations__.keys())) # type: ignore
+        if non_default_diag_kwargs:
+            warn(f"upper_kwargs has {len(non_default_diag_kwargs)} args that are "
+                 "ignored by pairplot: {non_default_diag_kwargs}. To pass them to "
+                 "matplotlib, include them in kwargs={'mpl_kwargs':{}}. "
+                 "See sbi.analysis.plot.GenericMplKwargs for details.", stacklevel=2)
+
+    if type(lower) is list:
+        lower = lower[0]
+        warn("diag uses only the first entry in a list for plot type. "
+             f"diag type is {lower[0]}.", stacklevel=2) # type: ignore
+    lower_defaults = _get_defaults("lower", type=lower) # type: ignore
+
+    if type(lower_kwargs) is list:
+        lower_kwargs = lower_kwargs[0]
+        warn("lower_kwargs is a list. Lists are currently not supported, "
+             "only the first entry is used for kwargs.", stacklevel=2)
+
+    if lower_kwargs:
+        non_default_diag_kwargs = (set(dict(lower_kwargs).keys()) - # type: ignore
+                                   set(lower_defaults.__annotations__.keys()))
+        if non_default_diag_kwargs:
+            warn(f"lower_kwargs has {len(non_default_diag_kwargs)} args that are "
+                 f"ignored by pairplot: {non_default_diag_kwargs}. To pass them to "
+                 "matplotlib, include them in kwargs={'mpl_kwargs':{}}. "
+                 "See sbi.analysis.plot.GenericMplKwargs for details.", stacklevel=2)
 
     # checks.
     if fig_kwargs_filled["legend"]:
-        assert len(fig_kwargs_filled["samples_labels"]) >= len(samples), (
+        assert len(fig_kwargs_filled["samples_labels"]) >= samples.shape[1], ( # type: ignore
             "Provide at least as many labels as samples."
         )
     if offdiag is not None:
         warn("offdiag is deprecated, use upper or lower instead.", stacklevel=2)
         upper = offdiag
 
+    # Warn user if lists were passed that ignore most entries
+    if type(upper) is list:
+        warn("upper uses only the first entry in a list for plot type. "
+             f"upper type is {upper[0]}.", stacklevel=2)
+
+    if type(lower) is list:
+        warn(f"lower uses only the first entry in a list for plot type. "
+             f"lower type is {lower[0]}.", stacklevel=2)
+
     # Prepare diag
-    diag_list = to_list_string(diag, len(samples))
-    diag_kwargs_list = to_list_kwargs(diag_kwargs, len(samples))
+    diag_list = to_list_string(diag, samples.shape[1]) # type: ignore
+    diag_kwargs_list = to_list_kwargs(diag_kwargs, samples.shape[1]) # type: ignore
     diag_func = get_diag_funcs(diag_list)
     diag_kwargs_filled = []
-    for i, (diag_i, diag_kwargs_i) in enumerate(
+
+    for _, (_, _) in enumerate(
         zip(diag_list, diag_kwargs_list, strict=False)
     ):
-        diag_kwarg_filled_i = _get_default_diag_kwargs(diag_i, i)
+        # diag_kwarg_filled_i = diag_defaults.__dict__
         # update the defaults dictionary with user provided values
-        diag_kwarg_filled_i = _update(diag_kwarg_filled_i, diag_kwargs_i)
+        if diag_kwargs:
+            diag_kwarg_filled_i = _update(dict(diag_defaults), dict(diag_kwargs)) # type: ignore
+        elif diag_defaults:
+            diag_kwarg_filled_i = dict(diag_defaults)
+        else:
+            diag_kwarg_filled_i = None
         diag_kwargs_filled.append(diag_kwarg_filled_i)
 
     # Prepare upper
-    upper_list = to_list_string(upper, len(samples))
-    upper_kwargs_list = to_list_kwargs(upper_kwargs, len(samples))
+    upper_list = to_list_string(upper, samples.shape[1]) # type: ignore
+    upper_kwargs_list = to_list_kwargs(upper_kwargs, samples.shape[1]) # type: ignore
     upper_func = get_offdiag_funcs(upper_list)
     upper_kwargs_filled = []
-    for i, (upper_i, upper_kwargs_i) in enumerate(
+    for _, (_, _) in enumerate(
         zip(upper_list, upper_kwargs_list, strict=False)
     ):
-        upper_kwarg_filled_i = _get_default_offdiag_kwargs(upper_i, i)
+        # upper_kwarg_filled_i = upper_defaults.__dict__
         # update the defaults dictionary with user provided values
-        upper_kwarg_filled_i = _update(upper_kwarg_filled_i, upper_kwargs_i)
+        if upper_kwargs:
+            upper_kwarg_filled_i = _update(dict(upper_defaults), dict(upper_kwargs)) # type: ignore
+        elif upper_defaults:
+            upper_kwarg_filled_i = dict(upper_defaults)
+        else:
+            upper_kwarg_filled_i = None
         upper_kwargs_filled.append(upper_kwarg_filled_i)
 
     # Prepare lower
-    lower_list = to_list_string(lower, len(samples))
-    lower_kwargs_list = to_list_kwargs(lower_kwargs, len(samples))
+    lower_list = to_list_string(lower, samples.shape[1]) # type: ignore
+    lower_kwargs_list = to_list_kwargs(lower_kwargs, samples.shape[1]) # type: ignore
     lower_func = get_offdiag_funcs(lower_list)
     lower_kwargs_filled = []
-    for i, (lower_i, lower_kwargs_i) in enumerate(
+    for _, (_, _) in enumerate(
         zip(lower_list, lower_kwargs_list, strict=False)
     ):
-        lower_kwarg_filled_i = _get_default_offdiag_kwargs(lower_i, i)
+        # lower_kwarg_filled_i = lower_default.__dict__
         # update the defaults dictionary with user provided values
-        lower_kwarg_filled_i = _update(lower_kwarg_filled_i, lower_kwargs_i)
+        if lower_kwargs:
+            lower_kwarg_filled_i = _update(dict(lower_defaults), dict(lower_kwargs)) # type: ignore
+        elif lower_defaults:
+            lower_kwarg_filled_i = dict(lower_defaults)
+        else:
+            lower_kwarg_filled_i = None
         lower_kwargs_filled.append(lower_kwarg_filled_i)
 
     return _arrange_grid(
@@ -834,7 +1122,7 @@ def pairplot(
         diag_kwargs_filled,
         upper_kwargs_filled,
         lower_kwargs_filled,
-        samples,
+        samples, # type: ignore
         points,
         limits,
         subset,
@@ -883,9 +1171,10 @@ def marginal_plot(
         labels: List of strings specifying the names of the parameters.
         ticks: Position of the ticks.
         diag_kwargs: Additional arguments to adjust the diagonal plot,
-            see the source code in `_get_default_diag_kwarg()`
+            see the source code in `DiagKwargsKDE`, `DiagKwargsHist` and
+            `DiagKwargsScatter`
         fig_kwargs: Additional arguments to adjust the overall figure,
-            see the source code in `_get_default_fig_kwargs()`
+            see the source code in `FigKwargs`
         fig: matplotlib figure to plot on.
         axes: matplotlib axes corresponding to fig.
         **kwargs: Additional arguments to adjust the plot (deprecated)
@@ -915,23 +1204,48 @@ def marginal_plot(
         )
         return fig, axes
 
-    samples, dim, limits = prepare_for_plot(samples, limits)
+    samples, dim, limits = prepare_for_plot(samples, limits) # type: ignore
+
+    if type(diag) is list:
+        diag = diag[0]
+        warn("diag uses only the first entry in a list for plot type. "
+             f"diag type is {diag[0]}.", stacklevel=2) # type: ignore
+    diag_defaults = _get_defaults("diag", type=diag) # type: ignore
+
+    if type(diag_kwargs) is list:
+        diag_kwargs = diag_kwargs[0]
+        warn("diag_kwargs is a list. Lists are currently not supported, "
+             "only the first entry is used for kwargs.", stacklevel=2)
+
+    # warn the user if they provided kwargs that are ignored downstream
+    if diag_kwargs:
+        non_default_diag_kwargs = (set(dict(diag_kwargs).keys()) - # type: ignore
+                                   set(diag_defaults.__annotations__.keys())) # type: ignore
+        if non_default_diag_kwargs:
+            warn(f"diag_kwargs has {len(non_default_diag_kwargs)} args that are "
+                 f"ignored by pairplot: {non_default_diag_kwargs}. To pass them "
+                 "to matplotlib, include them in kwargs={'mpl_kwargs':{}}."
+                 "See sbi.analysis.plot.GenericMplKwargs for details.", stacklevel=2)
 
     # prepare kwargs and functions of the subplots
-    diag_list = to_list_string(diag, len(samples))
-    diag_kwargs_list = to_list_kwargs(diag_kwargs, len(samples))
+    diag_list = to_list_string(diag, samples.shape[1]) # type: ignore
+    diag_kwargs_list = to_list_kwargs(diag_kwargs, samples.shape[1]) # type: ignore
     diag_func = get_diag_funcs(diag_list)
     diag_kwargs_filled = []
-    for i, (diag_i, diag_kwargs_i) in enumerate(
+    for _, (_, _) in enumerate(
         zip(diag_list, diag_kwargs_list, strict=False)
     ):
-        diag_kwarg_filled_i = _get_default_diag_kwargs(diag_i, i)
-        diag_kwarg_filled_i = _update(diag_kwarg_filled_i, diag_kwargs_i)
+        if diag_kwargs:
+            diag_kwarg_filled_i = _update(dict(diag_defaults), dict(diag_kwargs)) # type: ignore
+        else:
+            diag_kwarg_filled_i = dict(diag_defaults) # type: ignore
         diag_kwargs_filled.append(diag_kwarg_filled_i)
 
     # prepare fig_kwargs
-    fig_kwargs_filled = _get_default_fig_kwargs()
-    fig_kwargs_filled = _update(fig_kwargs_filled, fig_kwargs)
+    fig_kwargs_default = FigKwargs()  # Get defaults
+    #if type(fig_kwargs) == FigKwargs:
+    fig_kwargs_user = fig_kwargs if fig_kwargs else fig_kwargs_default
+    fig_kwargs_filled = _update(dict(fig_kwargs_default), dict(fig_kwargs_user))
 
     # generate plot
     return _arrange_grid(
@@ -952,121 +1266,6 @@ def marginal_plot(
         axes,
         fig_kwargs_filled,
     )
-
-
-def _get_default_offdiag_kwargs(offdiag: Optional[str], i: int = 0) -> Dict:
-    """Get default offdiag kwargs."""
-
-    if offdiag == "kde" or offdiag == "kde2d":
-        offdiag_kwargs = {
-            "bw_method": "scott",
-            "bins": 50,
-            "mpl_kwargs": {"cmap": "viridis", "origin": "lower", "aspect": "auto"},
-        }
-
-    elif offdiag == "hist" or offdiag == "hist2d":
-        offdiag_kwargs = {
-            "bin_heuristic": None,  # "Freedman-Diaconis",
-            "mpl_kwargs": {"cmap": "viridis", "origin": "lower", "aspect": "auto"},
-            "np_hist_kwargs": {"bins": 50, "density": False},
-        }
-
-    elif offdiag == "scatter":
-        offdiag_kwargs = {
-            "mpl_kwargs": {
-                "color": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2],  # pyright: ignore[reportOptionalMemberAccess]
-                "edgecolor": "white",
-                "alpha": 0.5,
-                "rasterized": False,
-            }
-        }
-    elif offdiag == "contour" or offdiag == "contourf":
-        offdiag_kwargs = {
-            "bw_method": "scott",
-            "bins": 50,
-            "levels": [0.68, 0.95, 0.99],
-            "percentile": True,
-            "mpl_kwargs": {
-                "colors": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2],  # pyright: ignore[reportOptionalMemberAccess]
-            },
-        }
-    elif offdiag == "plot":
-        offdiag_kwargs = {
-            "mpl_kwargs": {
-                "color": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2],  # pyright: ignore[reportOptionalMemberAccess]
-                "aspect": "auto",
-            }
-        }
-    else:
-        offdiag_kwargs = {}
-    return offdiag_kwargs
-
-
-def _get_default_diag_kwargs(diag: Optional[str], i: int = 0) -> Dict:
-    """Get default diag kwargs."""
-    if diag == "kde":
-        diag_kwargs = {
-            "bw_method": "scott",
-            "bins": 50,
-            "mpl_kwargs": {
-                "color": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2]  # pyright: ignore[reportOptionalMemberAccess]
-            },
-        }
-
-    elif diag == "hist":
-        diag_kwargs = {
-            "bin_heuristic": "Freedman-Diaconis",
-            "mpl_kwargs": {
-                "color": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2],  # pyright: ignore[reportOptionalMemberAccess]
-                "density": False,
-                "histtype": "step",
-            },
-        }
-    elif diag == "scatter":
-        diag_kwargs = {
-            "mpl_kwargs": {
-                "color": plt.rcParams["axes.prop_cycle"].by_key()["color"][i * 2]  # pyright: ignore[reportOptionalMemberAccess]
-            }
-        }
-    else:
-        diag_kwargs = {}
-    return diag_kwargs
-
-
-def _get_default_fig_kwargs() -> Dict:
-    """Get default figure kwargs."""
-    return {
-        "legend": None,
-        "legend_kwargs": {},
-        # labels
-        "points_labels": [f"points_{idx}" for idx in range(10)],  # for points
-        "samples_labels": [f"samples_{idx}" for idx in range(10)],  # for samples
-        # colors: take even colors for samples, odd colors for points
-        "samples_colors": plt.rcParams["axes.prop_cycle"].by_key()["color"][0::2],  # pyright: ignore[reportOptionalMemberAccess]
-        "points_colors": plt.rcParams["axes.prop_cycle"].by_key()["color"][1::2],  # pyright: ignore[reportOptionalMemberAccess]
-        # ticks
-        "tickformatter": mpl.ticker.FormatStrFormatter("%g"),  # type: ignore
-        "tick_labels": None,
-        # formatting points (scale, markers)
-        "points_diag": {},
-        "points_offdiag": {
-            "marker": ".",
-            "markersize": 10,
-        },
-        # other options
-        "fig_bg_colors": {"offdiag": None, "diag": None, "lower": None},
-        "fig_subplots_adjust": {
-            "top": 0.9,
-        },
-        "subplots": {},
-        "despine": {
-            "offset": 5,
-        },
-        "title": None,
-        "title_format": {"fontsize": 16},
-        "x_lim_add_eps": 1e-5,
-        "square_subplots": True,
-    }
 
 
 def conditional_marginal_plot(
@@ -1278,11 +1477,14 @@ def _arrange_grid(
         lower_funcs: List of plotting function that will be executed for the
             lower-diagonal elements of the plot. None if we are in a 1D setting.
         diag_kwargs: Additional arguments to adjust the diagonal plot,
-            see the source code in `_get_default_diag_kwarg()`
+            see the source code in `DiagKwargsKDE`, `DiagKwargsHist` and
+            `DiagKwargsScatter`
         upper_kwargs: Additional arguments to adjust the upper diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `OffDiagKwargsKDE`, `OffDiagKwargsHist`,
+            `OffDiagKwargsScatter`, `OffDiagKwargsContour`, `OffDiagKwargsPlot`
         lower_kwargs: Additional arguments to adjust the lower diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `OffDiagKwargsKDE`, `OffDiagKwargsHist`,
+            `OffDiagKwargsScatter`, `OffDiagKwargsContour`, `OffDiagKwargsPlot`
         samples: List of samples given to the plotting functions
         points: List of additional points to scatter.
         limits: Limits for each dimension / axis.
@@ -1294,13 +1496,16 @@ def _arrange_grid(
         fig: matplotlib figure to plot on.
         axes: matplotlib axes corresponding to fig.
         fig_kwargs: Additional arguments to adjust the overall figure,
-            see the source code in `_get_default_fig_kwargs()`
+            see the source code in `FigKwargs`
 
     Returns:
         Fig: matplotlib figure
         Axes: matplotlib axes
     """
-    dim = samples[0].shape[1]
+    dim = samples.shape[1] # type: ignore
+
+    samples = np.asarray(samples) # type: ignore
+
     # Prepare points
     if points is None:
         points = []
@@ -1396,12 +1601,14 @@ def _arrange_grid(
                 if excl_diag:
                     ax.axis("off")  # pyright: ignore reportOptionalMemberAccess
                 else:
-                    for sample_ind, sample in enumerate(samples):
-                        diag_f = diag_funcs[sample_ind]
-                        if callable(diag_f):  # is callable:
-                            diag_f(
-                                ax, sample[:, row], limits[row], diag_kwargs[sample_ind]
-                            )
+
+                    # for sample_ind, sample in enumerate(samples.T):
+                    diag_f = diag_funcs[0]
+                    if callable(diag_f):  # is callable:
+                        diag_f(
+                            ax, samples[:, row], limits[row], diag_kwargs[0] # type: ignore
+                        )
+
 
                 if len(points) > 0:
                     extent = ax.get_ylim()  # pyright: ignore reportOptionalMemberAccess
@@ -1423,16 +1630,16 @@ def _arrange_grid(
                 if excl_upper:
                     ax.axis("off")  # pyright: ignore reportOptionalMemberAccess
                 else:
-                    for sample_ind, sample in enumerate(samples):
-                        upper_f = upper_funcs[sample_ind]
+                    for _, _ in enumerate(samples.T): # type: ignore
+                        upper_f = upper_funcs[0]
                         if callable(upper_f):
                             upper_f(
                                 ax,
-                                sample[:, col],
-                                sample[:, row],
+                                samples[:, col], # type: ignore
+                                samples[:, row], # type: ignore
                                 limits[col],
                                 limits[row],
-                                upper_kwargs[sample_ind],
+                                upper_kwargs[0],
                             )
                     if len(points) > 0:
                         for n, v in enumerate(points):
@@ -1447,16 +1654,16 @@ def _arrange_grid(
                 if excl_lower:
                     ax.axis("off")  # pyright: ignore reportOptionalMemberAccess
                 else:
-                    for sample_ind, sample in enumerate(samples):
-                        lower_f = lower_funcs[sample_ind]
+                    for _, _ in enumerate(samples.T): # type: ignore
+                        lower_f = lower_funcs[0]
                         if callable(lower_f):
                             lower_f(
                                 ax,
-                                sample[:, row],
-                                sample[:, col],
+                                samples[:, row], # type: ignore
+                                samples[:, col], # type: ignore
                                 limits[row],
                                 limits[col],
-                                lower_kwargs[sample_ind],
+                                lower_kwargs[0],
                             )
                     if len(points) > 0:
                         for n, v in enumerate(points):
@@ -2231,7 +2438,7 @@ def pairplot_dep(
     opts = _update(opts, locals())
     opts = _update(opts, kwargs)
 
-    samples, dim, limits = prepare_for_plot(samples, limits)
+    samples, dim, limits = prepare_for_plot(samples, limits) # type: ignore
 
     # checks.
     if opts["legend"]:
@@ -2407,7 +2614,7 @@ def marginal_plot_dep(
     opts = _update(opts, locals())
     opts = _update(opts, kwargs)
 
-    samples, dim, limits = prepare_for_plot(samples, limits)
+    samples, dim, limits = prepare_for_plot(samples, limits) # type: ignore
 
     # Prepare diag/upper/lower
     if not isinstance(opts["diag"], list):


### PR DESCRIPTION
This PR is my (delayed) contribution to the 2025 hackathon, where I tried to resolve issues with the user interface of the widely used `pairplot` function, as in https://github.com/sbi-dev/sbi/issues/1425

The PR addresses the following main issue:

- The default parameters for kwargs were hardcoded in functions such as `_get_default_diag_kwargs`, which returned  dictionaries. I replaced those functions with dataclasses that contain the default values. These dataclasses can easily be converted to dictionaries by calling `dict(FigKwargs)` so few changes are required internally and users can still use the standard way of passing kwargs as dictionaries. But the dataclasses are considered more Pythonic, they expose their internals more clearly to the user and in the future they could be passed to `pairplot` instead of dictionaries to specify keyword arguments. Although I currently don't know how to best make them available to the user, since they need to be explicitly imported right now. But that could be part of a future PR.
- The `samples` passed by the user were converted internally to a list of numpy arrays. Instead I now call `np.ndarray(samples)`, which creates a copy if necessary but changes nothing if samples are already a numpy array. IMO passing samples as ndarray should be strongly encouraged and it should either be an np.ndarray or a torch.Tensor. But for now lists are also supported for user flexibility.
- `diag_kwarg` `upper_kwargs` `lower_kwargs` `diag`, `upper` and `lower` all accept lists most likely with the intention that the user could chose a different plot type and different parameters for each plot. However, this was actually not working in the main branch. Instead only the first entry was used. I added user warnings that warn the user about this when they pass a list for any of these arguments. We should consider if this feature is actually desired. If not, the code could be massively simplified.
- The way kwargs are passed has caused confusion, because they are passed as a nested dictionary `{'mpl_kwargs': {}}`, where only the entries in `mpl_kwargs` are actually passed to matplotlib. So `{'bins':10, 'mpl_kwargs': {}}`, the `'bins'` entry was siltently ignored. Instead, `{'mpl_kwargs': {'bins':10}}` would be required. If any entries in any `kwargs` is known to be ignored downstream, the user receives a warning about his issue. This is achieved by comparing the user provided dict with the parameter defined in the default dataclasses.

There are still many issues with pairplot.py IMO and I am open to describing them in separate issues and continue work on those.