### PR TITLE
Gpu test for VectorFieldPosterior

### DIFF
--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -585,6 +585,10 @@ class VectorFieldInference(NeuralInference, ABC):
         Returns:
             Calibration kernel-weighted loss implemented by the vector field estimator.
         """
+
+        if times is not None:
+            times = times.to(self._device)
+
         cls_name = self.__class__.__name__
         if self._round == 0 or force_first_round_loss:
             # First round loss.

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -720,7 +720,9 @@ def test_to_method_on_posteriors(device: str, sampling_method: str):
 @pytest.mark.parametrize(
     "iid_method", ["fnpe", "gauss", "auto_gauss", "jac_gauss", None]
 )
-def test_VectorFieldPosterior_device_handling(device: str, device_inference: str, iid_method: str):
+def test_VectorFieldPosterior_device_handling(
+    device: str, device_inference: str, iid_method: str
+):
     """Test VectorFieldPosterior on different devices training and inference devices.
 
     Args:

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -623,7 +623,7 @@ def test_direct_posterior_on_gpu(device: str, device_inference: str):
     ],
 )
 def test_to_method_on_potentials(device: str, potential: Union[ABC, BasePotential]):
-    """Test to method on potential.
+    """Test .to() method on potential.
 
     Args:
         device: device where to move the model.
@@ -668,7 +668,7 @@ def test_to_method_on_potentials(device: str, potential: Union[ABC, BasePotentia
     "sampling_method", ["rejection", "importance", "mcmc", "direct"]
 )
 def test_to_method_on_posteriors(device: str, sampling_method: str):
-    """Test that the .to() method works on posteriors.
+    """Test .to() method on posteriors.
 
     Args:
         device: device to train and sample the model on.
@@ -720,9 +720,8 @@ def test_to_method_on_posteriors(device: str, sampling_method: str):
 @pytest.mark.parametrize(
     "iid_method", ["fnpe", "gauss", "auto_gauss", "jac_gauss", None]
 )
-def test_VectorFieldPosterior(device: str, device_inference: str, iid_method: str):
-    """Test that VectorFieldPosterior works on different devices,
-    both for training as well as on inference.
+def test_VectorFieldPosterior_device_handling(device: str, device_inference: str, iid_method: str):
+    """Test VectorFieldPosterior on different devices training and inference devices.
 
     Args:
         device: device to train the model on.


### PR DESCRIPTION
Following PR https://github.com/sbi-dev/sbi/pull/1527 and issue https://github.com/sbi-dev/sbi/issues/1530 , improved the test for vector field methods. 

- Added testing for training and/or sampling on device. Cross test for cpu-gpu are handled by setting two devices.
- Removed testing both on `FMPE` and `NPSE` since they are redundant (both share log_prob implementation).
- Fixed minor bug on time tensor in `_loss` function not being on the same device when moving to device the training.
- Added docstrings for GPU tests.

This one is small! Let me know if anything is missing or you think that it can be improved @StarostinV @janfb 