### PR TITLE
fix: replace 'in' operator with '==' for proper classifier comparison

### DIFF
--- a/sbi/diagnostics/lc2st.py
+++ b/sbi/diagnostics/lc2st.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
-from sklearn.base import BaseEstimator, ClassifierMixin, clone
+from sklearn.base import BaseEstimator, clone
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import KFold
 from sklearn.neural_network import MLPClassifier
@@ -24,7 +24,7 @@ class LC2ST:
         seed: int = 1,
         num_folds: int = 1,
         num_ensemble: int = 1,
-        classifier: Union[str, Type[ClassifierMixin]] = MLPClassifier,
+        classifier: Union[str, Type[BaseEstimator]] = MLPClassifier,
         z_score: bool = False,
         classifier_kwargs: Optional[Dict[str, Any]] = None,
         num_trials_null: int = 100,
@@ -122,8 +122,8 @@ class LC2ST:
                     'Expected "mlp", "random_forest", '
                     'or a valid scikit-learn classifier class.'
                 )
-        assert issubclass(classifier, ClassifierMixin), (
-            "classifier must be a subclass of sklearn's ClassifierMixin"
+        assert issubclass(classifier, BaseEstimator), (
+            "classifier must be a subclass of sklearn's BaseEstimator"
         )
         self.clf_class = classifier
 

--- a/sbi/diagnostics/lc2st.py
+++ b/sbi/diagnostics/lc2st.py
@@ -111,7 +111,7 @@ class LC2ST:
         self.num_ensemble = num_ensemble
 
         # initialize classifier
-        if "mlp" in classifier.lower():
+        if classifier.lower() == "mlp":
             ndim = thetas.shape[-1]
             self.clf_class = MLPClassifier
             if clf_kwargs is None:
@@ -123,19 +123,17 @@ class LC2ST:
                     "early_stopping": True,
                     "n_iter_no_change": 50,
                 }
-        elif "random_forest" in classifier.lower():
+        elif classifier.lower() == "random_forest":
             self.clf_class = RandomForestClassifier
             if clf_kwargs is None:
                 self.clf_kwargs = {}
-        elif "custom":
+        else:
             if clf_class is None or clf_kwargs is None:
                 raise ValueError(
                     "Please provide a valid sklearn classifier class and kwargs."
                 )
             self.clf_class = clf_class
             self.clf_kwargs = clf_kwargs
-        else:
-            raise NotImplementedError
 
         # initialize classifiers, will be set after training
         self.trained_clfs = None

--- a/tests/lc2st_test.py
+++ b/tests/lc2st_test.py
@@ -16,7 +16,7 @@ from sbi.simulators.gaussian_mixture import (
 
 
 @pytest.mark.parametrize("method", (LC2ST, LC2ST_NF))
-@pytest.mark.parametrize("classifier", ('mlp', 'random_forest', 'custom'))
+@pytest.mark.parametrize("classifier", ('mlp', 'random_forest', MLPClassifier))
 @pytest.mark.parametrize("cv_folds", (1, 2))
 @pytest.mark.parametrize("num_ensemble", (1, 3))
 @pytest.mark.parametrize("z_score", (True, False))
@@ -72,9 +72,6 @@ def test_running_lc2st(method, classifier, cv_folds, num_ensemble, z_score):
             "num_eval": num_eval,
         }
         kwargs_eval = {}
-    if classifier == "custom":
-        kwargs_test["clf_class"] = MLPClassifier
-        kwargs_test["clf_kwargs"] = {"alpha": 0.0, "max_iter": 2500}
     kwargs_test["classifier"] = classifier
 
     lc2st = method(


### PR DESCRIPTION
This PR improves the equality check for the Local-C2ST coverage get score method.

Fixes: #1549 