### PR TITLE
Minor fix while using unconditional density estimator and LRU embedding

### DIFF
--- a/sbi/diagnostics/misspecification.py
+++ b/sbi/diagnostics/misspecification.py
@@ -209,7 +209,7 @@ def calc_misspecification_logprob(
     log_prob_xo = estimator.log_prob(x_o).detach().item()
 
     n_samples = x_val.shape[0]
-    samples = estimator.sample((n_samples,))
+    samples = estimator.sample(torch.Size((n_samples,)))
     try:
         check_c2st(x_val, samples, 'MarginalEstimator')
     except AssertionError as e:

--- a/sbi/neural_nets/embedding_nets/lru.py
+++ b/sbi/neural_nets/embedding_nets/lru.py
@@ -1,6 +1,6 @@
 import warnings
 from math import sqrt
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -36,7 +36,7 @@ class LRUEmbedding(nn.Module):
         mode: str = "loop",
         dropout: float = 0.0,
         apply_input_normalization: bool = False,
-        aggregate_fcn: [str, Callable] = "mean",
+        aggregate_fcn: Union[str, Callable] = "mean",
     ):
         """
         Args:

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -553,7 +553,7 @@ class UnconditionalDensityEstimator(UnconditionalEstimator):
         self._neural_net.eval()
         return self._neural_net.log_prob(x)
 
-    def sample(self, sample_shape: torch.Size()) -> Tensor:
+    def sample(self, sample_shape: torch.Size) -> Tensor:
         r"""Return samples from the density estimator.
 
         Args:


### PR DESCRIPTION
While creating unconditional density estimator, the `sample_shape` argument of method `sample` throws error. The same goes for LRU embedding while explicitly calling for aggregate function of LRU embeddings. Changed the typedefs to match the expected types.