### PR TITLE
Improvement of custom density interface passed to Inference classes using Protocols

### DIFF
--- a/sbi/sbi_types.py
+++ b/sbi/sbi_types.py
@@ -30,9 +30,9 @@ transform_types = Optional[
 
 # Define alias types because otherwise, the documentation by mkdocs became very long and
 # made the website look ugly.
-TensorboardSummaryWriter = NewType("Writer", SummaryWriter)
+TensorboardSummaryWriter = NewType("TensorboardSummaryWriter", SummaryWriter)
 # TorchTransform = NewType("torch Transform", Transform)
-TorchModule = NewType("Module", Module)
+TorchModule = NewType("TorchModule", Module)
 TorchDistribution = NewType("torch Distribution", Distribution)
 # See PEP 613 for the reason why we need to use TypeAlias here.
 TorchTransform: TypeAlias = Transform


### PR DESCRIPTION
Addresses the issues #1531 .

Given the rich support of `_neural_net` as an instance of `NFlowsFlow`, it is best for an user to provide a callable which conforms to the present convention of taking parameters and simulations and then return a `NFlowsFlow` object. Its best to have the custom density builder to be of this form. 

Also the name of the parameter `density_estimator` under the `PosteriorEstimator.__init__(...)`, is ambiguous. It should've been `density_estimator_builder` as it is not actually the estimator, rather a callable that builds the estimator. 