### PR TITLE
switch to numfocus code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,134 +1,27 @@
 
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+This project adheres to the [NumFOCUS Code of
+Conduct](https://numfocus.org/code-of-conduct). By participating, you are expected to
+uphold this code. Please report unacceptable behavior to Jan Boelts via Discord or
+directly to the NumFOCUS Code of Conduct Working Group at conduct@numfocus.org or via
+[this report form](https://numfocus.typeform.com/to/ynjGdT).
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+## The Short Version
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+Be kind to others. Do not insult or put down others. Behave professionally. Remember
+that harassment and sexist, racist, or exclusionary jokes are not appropriate for
+NumFOCUS.
 
-## Our Standards
+All communication should be appropriate for a professional audience including people of
+many different backgrounds. Sexual language and imagery is not appropriate.
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless
+of gender, sexual orientation, gender identity and expression, disability, physical
+appearance, body size, race, or religion. We do not tolerate harassment of community
+members in any form.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals but for the overall
-  community
+Thank you for helping make this a welcoming, friendly community for all.
 
-Examples of unacceptable behavior include:
-
-* The use of sexualized language or imagery and sexual attention or advances of
-  any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' confidential information, such as a physical or email address,
-  without their explicit permission
-* Other conduct that could reasonably be considered inappropriate in a
-  professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
-
-## Scope
-
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Representing our community includes using an official e-mail address, posting
-via an official social media account, or acting as an appointed representative
-at an online or offline event.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting `sbi` developer Jan Boelts via email
-(<jan.boelts@mailbox.org>) or anonymously via
-[https://forms.gle/AEmwEznWAKdvrBQbA](https://forms.gle/AEmwEznWAKdvrBQbA). All
-complaints will be reviewed and investigated promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
-
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of
-actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder][Mozilla CoC].
-
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+[Link to full version of the NumFOCUS Code of
+Conduct](https://numfocus.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ how to run each of these methods
 We welcome any feedback on how `sbi` is working for your inference problems (see
 [Discussions](https://github.com/sbi-dev/sbi/discussions)) and are happy to receive bug
 reports, pull requests, and other feedback (see
-[contribute](https://sbi-dev.github.io/sbi/latest/contribute/)). We wish to maintain a positive
-community; please read our [Code of Conduct](CODE_OF_CONDUCT.md).
+[contribute](https://sbi-dev.github.io/sbi/latest/contribute/)). We wish to maintain a
+positive and respectful community; please read our [Code of
+Conduct](CODE_OF_CONDUCT.md).
 
 ## Acknowledgments
 


### PR DESCRIPTION
As discussed in the maintainer team, we will adopt the Code of Conduct of NumFOCUS. 

This PR updates the CoC files and relevant links. 