### PR TITLE
fix: add enum for flow options to fix type hints.

### DIFF
--- a/sbi/inference/trainers/marginal/marginal_base.py
+++ b/sbi/inference/trainers/marginal/marginal_base.py
@@ -5,7 +5,7 @@ import time
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -19,7 +19,7 @@ from sbi.neural_nets.estimators import UnconditionalDensityEstimator
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
 )
-from sbi.neural_nets.factory import marginal_nn
+from sbi.neural_nets.factory import DensityEstimator, marginal_nn
 from sbi.utils import check_estimator_arg, get_log_root
 from sbi.utils.torchutils import assert_all_finite, process_device
 
@@ -28,9 +28,8 @@ class MarginalTrainer:
     def __init__(
         self,
         density_estimator: Union[
-            Literal["bpf", "maf", "naf", "ncsf", "nsf", "sospf", "unaf"],
-            Callable[[Tensor], UnconditionalDensityEstimator],
-        ] = "nsf",
+            DensityEstimator, Callable[[Tensor], Any]
+        ] = DensityEstimator.NSF,
         device: str = "cpu",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -74,11 +73,19 @@ class MarginalTrainer:
             epoch_durations_sec=[],
         )
 
-        check_estimator_arg(density_estimator)
-        if isinstance(density_estimator, str):
+        if isinstance(density_estimator, DensityEstimator):
+            check_estimator_arg(density_estimator.value)  # Extract string value
             self._build_neural_net = marginal_nn(model=density_estimator)
-        else:
+        elif callable(density_estimator):
+            check_estimator_arg(density_estimator)  # callable is still valid
             self._build_neural_net = density_estimator
+        else:
+            raise ValueError(
+                (
+                    "density_estimator must be either a DensityEstimator or a "
+                    "Callable[[Tensor], Any]."
+                )
+            )
 
     def get_dataloaders(
         self,

--- a/sbi/inference/trainers/marginal/marginal_base.py
+++ b/sbi/inference/trainers/marginal/marginal_base.py
@@ -78,7 +78,9 @@ class MarginalTrainer:
             self._build_neural_net = marginal_nn(model=density_estimator)
         elif isinstance(density_estimator, str):
             check_estimator_arg(density_estimator)
-            self._build_neural_net = marginal_nn(model=ZukoFlowType(density_estimator))
+            self._build_neural_net = marginal_nn(
+                model=ZukoFlowType(density_estimator.lower())
+            )
         elif callable(density_estimator):
             check_estimator_arg(density_estimator)
             self._build_neural_net = density_estimator

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -60,8 +60,8 @@ model_builders = {
 
 
 # TODO: currently only used for marginal_nn, adapt to use for all
-class DensityEstimator(Enum):
-    """Enumeration of density estimator types."""
+class ZukoFlowType(Enum):
+    """Enumeration of Zuko flow types."""
 
     BPF = "bpf"
     MAF = "maf"
@@ -476,7 +476,7 @@ def posterior_score_nn(
 
 
 def marginal_nn(
-    model: DensityEstimator,
+    model: ZukoFlowType,
     z_score_x: Optional[str] = "independent",
     hidden_features: int = 50,
     num_transforms: int = 5,

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -2,9 +2,10 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 
-from typing import Any, Callable, Literal, Optional, Union
+from enum import Enum
+from typing import Any, Callable, Optional, Union
 
-from torch import nn
+from torch import Tensor, nn
 
 from sbi.neural_nets.net_builders.classifier import (
     build_linear_classifier,
@@ -56,6 +57,20 @@ model_builders = {
     "mlp_flowmatcher": build_mlp_flowmatcher,
     "resnet_flowmatcher": build_resnet_flowmatcher,
 }
+
+
+# TODO: currently only used for marginal_nn, adapt to use for all
+class DensityEstimator(Enum):
+    """Enumeration of density estimator types."""
+
+    BPF = "bpf"
+    MAF = "maf"
+    NAF = "naf"
+    NCSF = "ncsf"
+    NSF = "nsf"
+    SOSPF = "sospf"
+    UNAF = "unaf"
+
 
 embedding_net_warn_msg = """The passed embedding net will be moved to cpu for
                         constructing the net building function."""
@@ -461,7 +476,7 @@ def posterior_score_nn(
 
 
 def marginal_nn(
-    model: Literal["bpf", "maf", "naf", "ncsf", "nsf", "sospf", "unaf"],
+    model: DensityEstimator,
     z_score_x: Optional[str] = "independent",
     hidden_features: int = 50,
     num_transforms: int = 5,
@@ -473,23 +488,13 @@ def marginal_nn(
     Returns a function that builds a density estimator for learning the marginal.
 
     Args:
-        model: The type of density estimator that will be created. One of [`mdn`,
-            `made`, `maf`, `maf_rqs`, `nsf`].
+        model: The type of density estimator that will be created.
         z_score_x: Whether to z-score samples $x$ before passing them into
-            the network, can take one of the following:
-            - `none`, or None: do not z-score.
-            - `independent`: z-score each dimension independently.
-            - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension. Should be used when each
-            sample is, for example, a time series or an image.
+            the network.
         hidden_features: Number of hidden features.
-        num_transforms: Number of transforms when a flow is used. Only relevant if
-            density estimator is a normalizing flow (i.e. currently either a `maf` or a
-            `nsf`). Ignored if density estimator is a `mdn` or `made`.
-        num_bins: Number of bins used for the splines in `nsf`. Ignored if density
-            estimator not `nsf`.
+        num_transforms: Number of transforms when a flow is used.
+        num_bins: Number of bins used for the splines in `nsf`.
         num_components: Number of mixture components for a mixture of Gaussians.
-            Ignored if density estimator is not an mdn.
         kwargs: additional custom arguments passed to downstream build functions.
     """
 
@@ -514,7 +519,9 @@ def marginal_nn(
         **kwargs,
     )
 
-    def build_fn(batch_x):
-        return build_zuko_unconditional_flow(which_nf=model.upper(), batch_x=batch_x)
+    def build_fn(batch_x: Tensor) -> Any:
+        return build_zuko_unconditional_flow(
+            which_nf=model.value.upper(), batch_x=batch_x, **kwargs
+        )
 
     return build_fn


### PR DESCRIPTION
The new `pyright` version detected inconsistencies in our new `Literal["flow", "options"]` in `marginal_nn` (failing on `main`). 

this PR adds an `Enum` on the different flow options as a workaround. Could be a blueprint for the other build functions in the factory. 