### PR TITLE
Update sbiutils.py to use one-dimensional batch

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -284,7 +284,7 @@ def standardizing_net(
         # Compute per-dimension (independent) mean.
         t_mean = torch.mean(batch_t[is_valid_t], dim=0)
 
-    if len(batch_t > 1):
+    if len(batch_t) > 1:
         if structured_dims:
             # Compute std per-sample first.
             sample_std = torch.std(batch_t[is_valid_t], dim=1)


### PR DESCRIPTION
This may be my mistake, but it seems the original:
```
len(batch_t > 1):
```
will always evaluate to True (unless batch_t has only one data point), even if there's only one batch. To use `standardizing_net()` as intended to load a pre-trained net with a dummy single-batch data, shouldn't it be:
```
len(batch_t) > 1:
```
Thanks !