### PR TITLE
Option to add the pretained density estimator directly - instead a callable.

### DIFF
--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -71,8 +71,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
         check_estimator_arg(density_estimator)
         if isinstance(density_estimator, str):
             self._build_neural_net = likelihood_nn(model=density_estimator)
-        else:
+        elif isinstance(density_estimator, Callable):
             self._build_neural_net = density_estimator
+        else:
+            self._neural_net = density_estimator
 
     def append_simulations(
         self,

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -90,8 +90,10 @@ class PosteriorEstimator(NeuralInference, ABC):
         check_estimator_arg(density_estimator)
         if isinstance(density_estimator, str):
             self._build_neural_net = posterior_nn(model=density_estimator)
-        else:
+        elif isinstance(density_estimator, Callable):
             self._build_neural_net = density_estimator
+        else:
+            self._neural_net = density_estimator
 
         self._proposal_roundwise = []
         self.use_non_atomic_loss = False

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -81,8 +81,10 @@ class RatioEstimator(NeuralInference, ABC):
         check_estimator_arg(classifier)
         if isinstance(classifier, str):
             self._build_neural_net = classifier_nn(model=classifier)
-        else:
+        elif isinstance(classifier, Callable):
             self._build_neural_net = classifier
+        else:
+            self._neural_net = classifier
 
     def append_simulations(
         self,

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import inspect
 import warnings
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, cast
 
@@ -708,13 +709,21 @@ def check_sbi_inputs(simulator: Callable, prior: Distribution) -> None:
         num_samples={num_prior_samples}."""
 
 
-def check_estimator_arg(estimator: Union[str, Callable]) -> None:
+def check_estimator_arg(estimator: Union[str, Any]) -> None:
+    # to avoid the circular import.
+    import sbi.neural_nets.estimators as sbi_estimators
+
+    sbi_estimators = tuple(
+        obj for _, obj in inspect.getmembers(sbi_estimators) if inspect.isclass(obj)
+    )
     """Check (density or ratio) estimator argument passed by the user."""
-    assert isinstance(estimator, str) or (
-        isinstance(estimator, Callable) and not isinstance(estimator, nn.Module)
+    assert (
+        isinstance(estimator, str)
+        or (isinstance(estimator, Callable) and not isinstance(estimator, nn.Module))
+        or (isinstance(estimator, sbi_estimators))
     ), (
-        "The passed density estimator / classifier must be a string or a function "
-        f"returning a nn.Module, but is {type(estimator)}"
+        "The passed density estimator / classifier must be either a string or a "
+        f" function or a type from sbi.neural_nets.estimators but is {type(estimator)}"
     )
 
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -21,6 +21,7 @@ from torch.distributions import (
 
 from sbi.inference import NPE_A, NPE_C, simulate_for_sbi
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
+from sbi.neural_nets.net_builders import build_maf
 from sbi.simulators import linear_gaussian
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.utils import mcmc_transform, within_support
@@ -490,6 +491,7 @@ def test_invalid_inputs():
             ),
         ),
         ("fun"),
+        ("sbi_estimators")
     ],
 )
 def test_passing_custom_density_estimator(arg):
@@ -519,6 +521,9 @@ def test_passing_custom_density_estimator(arg):
     elif arg == "fun":
         # A function returning the nn.Module.
         density_estimator = lambda batch_theta, batch_x: mdn
+    elif arg == "sbi_estimators":
+        # A function returning the nn.Module.
+        density_estimator = build_maf(torch.zeros((2,2)), torch.zeros((2,2)))
     else:
         density_estimator = arg
     prior = MultivariateNormal(torch.zeros(2), torch.eye(2))


### PR DESCRIPTION
This PR is potentially related to [[this issue](https://github.com/sbi-dev/sbi/issues/832)](https://github.com/sbi-dev/sbi/issues/832).

When saving a pretrained density estimator to disk, it is likely that users will have an instance from `sbi.neural_nets.estimators`, rather than a simple callable function. Although a workaround was previously suggested, the process for using a pretrained estimator and resuming training is not entirely intuitive.

**Proposed Solution**:  
Introduce an additional option that allows a density estimator to be assigned directly to the `_neural_net` attribute, bypassing the need to use `_build_neural_network`.

**Risk Assessment for this PR**:  
I am not entirely confident that I fully understand [[this specific check](https://github.com/sbi-dev/sbi/blob/b25cc1764906b70660a3f63e86902745f2c91599/sbi/inference/trainers/npe/npe_base.py#L271-L281)](https://github.com/sbi-dev/sbi/blob/b25cc1764906b70660a3f63e86902745f2c91599/sbi/inference/trainers/npe/npe_base.py#L271-L281) and whether it might be affected by this change. However, I have verified that all existing tests pass successfully, and have updated `test_passing_custom_density_estimator` to cover the new changes.

Let me know if it makes sense or further changes are required
