### PR TITLE
chore: remove testmon, add codecov test analytics

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run the fast and the slow CPU tests with coverage
-      run: uv run pytest -v -x -n auto -m "not gpu" --cov=sbi --cov-report=xml tests/
+      run: uv run pytest -v -x -n auto -m "not gpu" --cov=sbi --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4-beta
@@ -49,4 +49,10 @@ jobs:
         file: ./coverage.xml
         flags: unittests
         name: codecov-sbi-all-cpu
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,8 @@ jobs:
         restore-keys: |
           uv-${{ runner.os }}-${{ matrix.python-version }}-
 
-    # - name: Cache testmon data
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: .testmondata
-    #     key: testmon-${{ runner.os }}-${{ matrix.python-version }}-${{ github.ref }}
-    #     restore-keys: |
-    #       testmon-${{ runner.os }}-${{ matrix.python-version }}-
-
-    # - name: Fix file permissions for testmondata
-    #   run: |
-    #     [ -f .testmondata ] && chmod u+w .testmondata || true
-
     - name: Run fast CPU tests with coverage
-      run: uv run pytest -v -n auto -m "not slow and not gpu" --cov=sbi --cov-report=xml --splitting-algorithm least_duration --splits ${{ matrix.split_size }} --group ${{ matrix.group_number }} tests/ #--testmon-forceselect
+      run: uv run pytest -v -n auto -m "not slow and not gpu" --cov=sbi --cov-report=xml --junitxml=junit.xml -o junit_family=legacy --splitting-algorithm least_duration --splits ${{ matrix.split_size }} --group ${{ matrix.group_number }} tests/
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
@@ -73,4 +61,10 @@ jobs:
         file: ./coverage.xml
         flags: unittests
         name: codecov-sbi-fast-cpu
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I suggest we add test analytics to our codecov runs, let's see whether it's useful. From the [website](https://docs.codecov.com/docs/test-analytics): 

Test Analytics is a new set of features from Codecov that provides insights into the health of your test framework. It provides you with

- An overview of test run times and failure rates for all tests across main and feature branches
- A list of tests that your PR failed as a PR comment, along with a stack trace : enabling easier debugging
- A list of failed tests that are known to be flaky on main, that your PR failed, as a PR comment : enabling quicker retry and resolution.