### PR TITLE
fix: resolve logger warnings

### DIFF
--- a/sbi/samplers/rejection/rejection.py
+++ b/sbi/samplers/rejection/rejection.py
@@ -244,7 +244,7 @@ def accept_reject_sample(
         acceptance rates for each observation.
     """
     if kwargs:
-        logging.warn(
+        logging.warning(
             f"You passed arguments to `rejection_sampling_parameters` that "
             f"are unused when you do not specify a `proposal` in the same "
             f"dictionary. The unused arguments are: {kwargs}"


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
