### PR TITLE
Rename inference trainer classes

### DIFF
--- a/sbi/diagnostics/misspecification.py
+++ b/sbi/diagnostics/misspecification.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimator
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
 from sbi.neural_nets.estimators import UnconditionalDensityEstimator
 from sbi.utils.metrics import check_c2st
 
@@ -113,7 +113,7 @@ def calculate_p_misspecification(
 def calc_misspecification_mmd(
     x_obs: Tensor,
     x: Tensor,
-    inference: Optional[PosteriorEstimator] = None,
+    inference: Optional[PosteriorEstimatorTrainer] = None,
     mode: str = "x_space",
     n_shuffle: int = 1_000,
     max_samples: int = 1_000,

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -8,14 +8,14 @@ from torch.distributions import Distribution
 
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
-from sbi.inference.trainers.nle.nle_base import LikelihoodEstimator
+from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.user_input_checks import check_prior
 
 
-class MNLE(LikelihoodEstimator):
+class MNLE(LikelihoodEstimatorTrainer):
     """Mixed Neural Likelihood Estimation (MNLE) [1].
 
     Like NLE, but designed to be applied to data with mixed types, e.g., continuous

--- a/sbi/inference/trainers/nle/nle_a.py
+++ b/sbi/inference/trainers/nle/nle_a.py
@@ -5,12 +5,12 @@ from typing import Callable, Optional, Union
 
 from torch.distributions import Distribution
 
-from sbi.inference.trainers.nle.nle_base import LikelihoodEstimator
+from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
-class NLE_A(LikelihoodEstimator):
+class NLE_A(LikelihoodEstimatorTrainer):
     """Neural Likelihood Estimation (NLE) as in Papamakarios et al. (2019) [1].
 
     [1] Sequential Neural Likelihood: Fast Likelihood-free Inference with

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -26,7 +26,7 @@ from sbi.utils import check_estimator_arg, check_prior, x_shape_from_simulation
 from sbi.utils.torchutils import assert_all_finite
 
 
-class LikelihoodEstimator(NeuralInference, ABC):
+class LikelihoodEstimatorTrainer(NeuralInference, ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
@@ -82,7 +82,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         from_round: int = 0,
         algorithm: str = "SNLE",
         data_device: Optional[str] = None,
-    ) -> "LikelihoodEstimator":
+    ) -> "LikelihoodEstimatorTrainer":
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/npe/__init__.py
+++ b/sbi/inference/trainers/npe/__init__.py
@@ -1,7 +1,7 @@
 from sbi.inference.trainers.npe.mnpe import MNPE  # noqa: F401
 from sbi.inference.trainers.npe.npe_a import NPE_A  # noqa: F401
 from sbi.inference.trainers.npe.npe_b import NPE_B  # noqa: F401
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimator  # noqa: F401
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer  # noqa: F401
 from sbi.inference.trainers.npe.npe_c import NPE_C  # noqa: F401
 
 SNPE_A = NPE_A

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from torch.distributions import Distribution, MultivariateNormal
 
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimator
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
 from sbi.utils import torchutils
@@ -26,7 +26,7 @@ from sbi.utils.sbiutils import (
 from sbi.utils.torchutils import BoxUniform, assert_all_finite, atleast_2d
 
 
-class NPE_A(PosteriorEstimator):
+class NPE_A(PosteriorEstimatorTrainer):
     r"""Neural Posterior Estimation algorithm as in Papamakarios et al. (2016) [1].
 
     [1] *Fast epsilon-free Inference of Simulation Models with Bayesian

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -8,13 +8,13 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 import sbi.utils as utils
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimator
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
 from sbi.neural_nets.estimators.shape_handling import reshape_to_sample_batch_event
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
-class NPE_B(PosteriorEstimator):
+class NPE_B(PosteriorEstimatorTrainer):
     r"""Neural Posterior Estimation algorithm (NPE-B) as in Lueckmann et al. (2017) [1].
 
     [1] *Flexible statistical inference for mechanistic models of neural

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -45,7 +45,7 @@ from sbi.utils.sbiutils import ImproperEmpirical, mask_sims_from_prior
 from sbi.utils.torchutils import assert_all_finite
 
 
-class PosteriorEstimator(NeuralInference, ABC):
+class PosteriorEstimatorTrainer(NeuralInference, ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
@@ -103,7 +103,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         proposal: Optional[DirectPosterior] = None,
         exclude_invalid_x: Optional[bool] = None,
         data_device: Optional[str] = None,
-    ) -> "PosteriorEstimator":
+    ) -> "PosteriorEstimatorTrainer":
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -10,7 +10,7 @@ from torch import Tensor, eye, nn, ones
 from torch.distributions import Distribution, MultivariateNormal, Uniform
 
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimator
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
@@ -28,7 +28,7 @@ from sbi.utils.sbiutils import mog_log_prob
 from sbi.utils.torchutils import BoxUniform, assert_all_finite
 
 
-class NPE_C(PosteriorEstimator):
+class NPE_C(PosteriorEstimatorTrainer):
     """Neural Posterior Estimation algorithm (NPE-C) as in Greenberg et al. (2019). [1]
 
     [1] *Automatic Posterior Transformation for Likelihood-free Inference*,

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -7,13 +7,13 @@ import torch
 from torch import Tensor, nn, ones
 from torch.distributions import Distribution
 
-from sbi.inference.trainers.nre.nre_base import RatioEstimator
+from sbi.inference.trainers.nre.nre_base import RatioEstimatorTrainer
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
 
-class NRE_A(RatioEstimator):
+class NRE_A(RatioEstimatorTrainer):
     """AALR, here known as Neural Ratio Estimation algorithm (NRE-A) [1].
 
     [1] *Likelihood-free MCMC with Amortized Approximate Likelihood Ratios*, Hermans

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -7,13 +7,13 @@ import torch
 from torch import Tensor, nn
 from torch.distributions import Distribution
 
-from sbi.inference.trainers.nre.nre_base import RatioEstimator
+from sbi.inference.trainers.nre.nre_base import RatioEstimatorTrainer
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
 
-class NRE_B(RatioEstimator):
+class NRE_B(RatioEstimatorTrainer):
     """SRE, here known as Neural Ratio Estimation algorithm (NRE-B) [1].
 
     [1] *On Contrastive Learning for Likelihood-free Inference*, Durkan et al.,

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -26,7 +26,7 @@ from sbi.utils import (
 from sbi.utils.torchutils import repeat_rows
 
 
-class RatioEstimator(NeuralInference, ABC):
+class RatioEstimatorTrainer(NeuralInference, ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
@@ -92,7 +92,7 @@ class RatioEstimator(NeuralInference, ABC):
         from_round: int = 0,
         algorithm: str = "SNRE",
         data_device: Optional[str] = None,
-    ) -> "RatioEstimator":
+    ) -> "RatioEstimatorTrainer":
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -7,13 +7,13 @@ import torch
 from torch import Tensor, nn
 from torch.distributions import Distribution
 
-from sbi.inference.trainers.nre.nre_base import RatioEstimator
+from sbi.inference.trainers.nre.nre_base import RatioEstimatorTrainer
 from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
 
-class NRE_C(RatioEstimator):
+class NRE_C(RatioEstimatorTrainer):
     r"""NRE-C [1] is a generalization of amortized versions of NRE_A and NRE_B.
 
     NRE-C:

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -23,7 +23,7 @@ from sbi.inference import (
     VIPosterior,
     ratio_estimator_based_potential,
 )
-from sbi.inference.trainers.nre.nre_base import RatioEstimator
+from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,
     linear_gaussian,


### PR DESCRIPTION
This PR updates the class names `LikelihoodEstimator` to `LikelihoodEstimatorTrainer`, `RatioEstimator` to `RatioEstimatorTrainer`, and `PosteriorEstimator` to `PosteriorEstimatorTrainer`.

Fixes: #1600 