### PR TITLE
Refactor build_posterior to Eliminate Duplication Across Trainers

### DIFF
--- a/docs/tutorials/00_getting_started.ipynb
+++ b/docs/tutorials/00_getting_started.ipynb
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `sbi` toolbox uses neural networks to learn the relationship between parameters and data. In this exampmle, we will use neural perform posterior estimation (NPE). To run NPE, we first instatiate a trainer, which we call `inference`:"
+    "The `sbi` toolbox uses neural networks to learn the relationship between parameters and data. In this example, we will use neural perform posterior estimation (NPE). To run NPE, we first instatiate a trainer, which we call `inference`:"
    ]
   },
   {

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -26,7 +26,7 @@ def likelihood_estimator_based_potential(
     prior: Distribution,  # type: ignore
     x_o: Optional[Tensor],
     enable_transform: bool = True,
-) -> Tuple[Callable, TorchTransform]:
+) -> Tuple["LikelihoodBasedPotential", TorchTransform]:
     r"""Returns potential :math:`\log(p(x_o|\theta)p(\theta))` for likelihood estimator.
 
     It also returns a transformation that can be used to transform the potential into

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -1,7 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 from torch import Tensor, nn
@@ -18,7 +18,7 @@ def ratio_estimator_based_potential(
     prior: Distribution,
     x_o: Optional[Tensor],
     enable_transform: bool = True,
-) -> Tuple[Callable, TorchTransform]:
+) -> Tuple["RatioBasedPotential", TorchTransform]:
     r"""Returns the potential for ratio-based methods.
 
     It also returns a transformation that can be used to transform the potential into

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -63,9 +63,9 @@ class VectorFieldBasedPotential(BasePotential):
         vector_field_estimator: ConditionalVectorFieldEstimator,
         prior: Optional[Distribution],  # type: ignore
         x_o: Optional[Tensor] = None,
+        device: Union[str, torch.device] = "cpu",
         iid_method: Literal["fnpe", "gauss", "auto_gauss", "jac_gauss"] = "auto_gauss",
         iid_params: Optional[Dict[str, Any]] = None,
-        device: Union[str, torch.device] = "cpu",
         neural_ode_backend: str = "zuko",
         neural_ode_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -81,11 +81,11 @@ class VectorFieldBasedPotential(BasePotential):
             vector_field_estimator: The neural network modelling the vector field.
             prior: The prior distribution.
             x_o: The observed data at which to evaluate the posterior.
+            device: The device on which to evaluate the potential.
             iid_method: Which method to use for computing the score in the iid setting.
                 We currently support "fnpe", "gauss", "auto_gauss", "jac_gauss".
             iid_params: Parameters for the iid method, for arguments see
                 `IIDScoreFunction`.
-            device: The device on which to evaluate the potential.
             neural_ode_backend: The backend to use for the neural ODE. Currently,
                 only "zuko" is supported.
             neural_ode_kwargs: Additional keyword arguments for the neural ODE.

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -37,6 +37,9 @@ def vector_field_estimator_based_potential(
         enable_transform: Whether to enable transforms. Not supported yet.
         **kwargs: Additional keyword arguments passed to
             `VectorFieldBasedPotential`.
+    Returns:
+        The potential function and a transformation that maps
+        to unconstrained space.
     """
     device = str(next(vector_field_estimator.parameters()).device)
 

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -22,12 +22,14 @@ from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
 from sbi.inference.posteriors.rejection_posterior import RejectionPosterior
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.posteriors.vi_posterior import VIPosterior
+from sbi.inference.potentials.base_potential import BasePotential
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
     ConditionalEstimator,
     ConditionalVectorFieldEstimator,
 )
 from sbi.neural_nets.ratio_estimators import RatioEstimator
+from sbi.sbi_types import TorchTransform
 from sbi.utils import (
     check_prior,
     get_log_root,
@@ -349,13 +351,6 @@ class NeuralInference(ABC):
         Returns:
             NeuralPosterior object.
         """
-        if estimator is not None and not isinstance(
-            estimator, (ConditionalEstimator, RatioEstimator)
-        ):
-            raise TypeError(
-                "estimator must be ConditionalEstimator or RatioEstimator,",
-                " got {type(estimator).__name__}",
-            )
 
         if prior is None:
             cls_name = self.__class__.__name__
@@ -373,6 +368,11 @@ class NeuralInference(ABC):
             # If internal net is used device is defined.
             device = self._device
         else:
+            if not isinstance(estimator, (ConditionalEstimator, RatioEstimator)):
+                raise TypeError(
+                    "estimator must be ConditionalEstimator or RatioEstimator,",
+                    f" got {type(estimator).__name__}",
+                )
             # Otherwise, infer it from the device of the net parameters.
             device = str(next(estimator.parameters()).device)
 
@@ -396,7 +396,7 @@ class NeuralInference(ABC):
         self,
         prior: Distribution,
         estimator: Union[RatioEstimator, ConditionalEstimator],
-    ) -> Tuple:
+    ) -> Tuple[BasePotential, TorchTransform]:
         """Subclass-specific potential creation"""
         pass
 

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -320,6 +320,15 @@ class NeuralInference(ABC):
     ) -> NeuralPosterior:
         raise NotImplementedError
 
+    @abstractmethod
+    def _get_potential_function(
+        self,
+        prior: Distribution,
+        estimator: Union[RatioEstimator, ConditionalEstimator],
+    ) -> Tuple[BasePotential, TorchTransform]:
+        """Subclass-specific potential creation"""
+        pass
+
     def build_posterior(
         self,
         estimator: Optional[Union[RatioEstimator, ConditionalEstimator]],
@@ -334,6 +343,7 @@ class NeuralInference(ABC):
         This method serves as a base method for constructing a posterior based
         on a given estimator and prior. The posterior can be sampled using one of
         several inference methods specified by `sample_with`.
+
         Args:
             estimator: The estimator that the posterior is based on.
             prior: A probability distribution that expresses prior knowledge about the
@@ -348,6 +358,7 @@ class NeuralInference(ABC):
                 - "sde"
                 - "ode"
             **kwargs: Additional method-specific parameters.
+
         Returns:
             NeuralPosterior object.
         """
@@ -391,15 +402,6 @@ class NeuralInference(ABC):
 
         return deepcopy(self._posterior)
 
-    @abstractmethod
-    def _get_potential_function(
-        self,
-        prior: Distribution,
-        estimator: Union[RatioEstimator, ConditionalEstimator],
-    ) -> Tuple[BasePotential, TorchTransform]:
-        """Subclass-specific potential creation"""
-        pass
-
     def _create_posterior(
         self,
         estimator: Union[RatioEstimator, ConditionalEstimator],
@@ -433,6 +435,7 @@ class NeuralInference(ABC):
             device: torch device on which to train the neural net and on which to
                 perform all posterior operations, e.g. gpu or cpu.
             **kwargs: Additional method-specific parameters. Supported keys:
+
         Returns:
             NeuralPosterior object.
         """

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -571,7 +571,7 @@ class NeuralInference(ABC):
                 prior,
                 device=device,
                 sample_with=sample_with,
-                **kwargs,
+                **(kwargs.get("vectorfield_sampling_parameters") or {}),
             )
         else:
             # Posteriors requiring potential_fn and theta_transform

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -189,11 +189,6 @@ class NeuralInference(ABC):
         self._round = 0
         self._val_loss = float("Inf")
 
-        # XXX We could instantiate here the Posterior for all children. Two problems:
-        #     1. We must dispatch to right PotentialProvider for mcmc based on name
-        #     2. `method_family` cannot be resolved only from `self.__class__.__name__`,
-        #         since SRE, AALR demand different handling but are both in SRE class.
-
         self._summary_writer = (
             self._default_summary_writer() if summary_writer is None else summary_writer
         )
@@ -317,8 +312,7 @@ class NeuralInference(ABC):
         discard_prior_samples: bool = False,
         retrain_from_scratch: bool = False,
         show_train_summary: bool = False,
-    ) -> NeuralPosterior:
-        raise NotImplementedError
+    ) -> NeuralPosterior: ...
 
     @abstractmethod
     def _get_potential_function(

--- a/sbi/inference/trainers/fmpe/fmpe.py
+++ b/sbi/inference/trainers/fmpe/fmpe.py
@@ -2,7 +2,7 @@
 # under the Apache License v2.0, see <https://www.apache.org/licenses/LICENSE-2.0>.
 
 
-from typing import Literal, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -64,7 +64,7 @@ class FMPE(VectorFieldInference):
         vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "ode",
-        **kwargs,
+        vectorfield_sampling_parameters: Optional[Dict[str, Any]] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the flow matching estimator.
 
@@ -87,8 +87,8 @@ class FMPE(VectorFieldInference):
                 the score to do a Langevin diffusion step, while the 'ode' method
                 uses the score to define a probabilistic ODE and solves it with
                 a numerical ODE solver.
-            **kwargs: Additional keyword arguments passed to
-                `VectorFieldBasedPotential`.
+            vectorfield_sampling_parameters: Additional keyword arguments passed to
+                `VectorFieldPosterior`.
 
 
         Returns:
@@ -98,7 +98,7 @@ class FMPE(VectorFieldInference):
             estimator=vector_field_estimator,
             prior=prior,
             sample_with=sample_with,
-            **kwargs,
+            vectorfield_sampling_parameters=vectorfield_sampling_parameters,
         )
 
     def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:

--- a/sbi/inference/trainers/fmpe/fmpe.py
+++ b/sbi/inference/trainers/fmpe/fmpe.py
@@ -8,7 +8,7 @@ from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi import utils as utils
-from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
     VectorFieldInference,
@@ -69,7 +69,7 @@ class FMPE(VectorFieldInference):
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "ode",
         **kwargs,
-    ) -> VectorFieldPosterior:
+    ) -> NeuralPosterior:
         r"""Build posterior from the flow matching estimator.
 
         Note that this is the same as the NPSE posterior, but the sample_with method
@@ -98,8 +98,8 @@ class FMPE(VectorFieldInference):
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
         """
-        return self._build_posterior(
-            vector_field_estimator=vector_field_estimator,
+        return super().build_posterior(
+            estimator=vector_field_estimator,
             prior=prior,
             sample_with=sample_with,
             **kwargs,

--- a/sbi/inference/trainers/fmpe/fmpe.py
+++ b/sbi/inference/trainers/fmpe/fmpe.py
@@ -59,10 +59,6 @@ class FMPE(VectorFieldInference):
         # density_estimator name is kept since it is public API, but it is
         # actually misleading since it is a builder for an estimator.
 
-    def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:
-        model = kwargs.pop("vector_field_estimator_builder", "mlp")
-        return flowmatching_nn(model=model, **kwargs)
-
     def build_posterior(
         self,
         vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,
@@ -104,3 +100,7 @@ class FMPE(VectorFieldInference):
             sample_with=sample_with,
             **kwargs,
         )
+
+    def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:
+        model = kwargs.pop("vector_field_estimator_builder", "mlp")
+        return flowmatching_nn(model=model, **kwargs)

--- a/sbi/inference/trainers/marginal/marginal_base.py
+++ b/sbi/inference/trainers/marginal/marginal_base.py
@@ -324,14 +324,6 @@ class MarginalTrainer:
 
         return converged
 
-    @staticmethod
-    def _maybe_show_progress(show: bool, epoch: int) -> None:
-        if show:
-            # end="\r" deletes the print statement when a new one appears.
-            # https://stackoverflow.com/questions/3419984/. `\r` in the beginning due
-            # to #330.
-            print("\r", f"Training neural network. Epochs trained: {epoch}", end="")
-
     def _summarize(
         self,
         round_: int,
@@ -401,3 +393,11 @@ class MarginalTrainer:
             )
 
         self._summary_writer.flush()
+
+    @staticmethod
+    def _maybe_show_progress(show: bool, epoch: int) -> None:
+        if show:
+            # end="\r" deletes the print statement when a new one appears.
+            # https://stackoverflow.com/questions/3419984/. `\r` in the beginning due
+            # to #330.
+            print("\r", f"Training neural network. Epochs trained: {epoch}", end="")

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -8,7 +8,7 @@ from torch.distributions import Distribution
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
-from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
+from sbi.sbi_types import TensorboardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
@@ -89,7 +89,7 @@ class MNLE(LikelihoodEstimatorTrainer):
 
     def build_posterior(
         self,
-        density_estimator: Optional[TorchModule] = None,
+        density_estimator: Optional[MixedDensityEstimator] = None,
         prior: Optional[Distribution] = None,
         sample_with: Literal["mcmc", "rejection", "vi"] = "mcmc",
         mcmc_method: Literal[

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -1,18 +1,15 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from copy import deepcopy
 from typing import Any, Callable, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 
-from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
-from sbi.inference.potentials import likelihood_estimator_based_potential
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
 from sbi.utils.sbiutils import del_entries
-from sbi.utils.user_input_checks import check_prior
 
 
 class MNLE(LikelihoodEstimatorTrainer):
@@ -108,7 +105,7 @@ class MNLE(LikelihoodEstimatorTrainer):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
-    ) -> Union[MCMCPosterior, RejectionPosterior, VIPosterior]:
+    ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
         SNLE trains a neural network to approximate the likelihood $p(x|\theta)$. The
@@ -142,65 +139,20 @@ class MNLE(LikelihoodEstimatorTrainer):
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
             (the returned log-probability is unnormalized).
         """
-        if prior is None:
-            assert (
-                self._prior is not None
-            ), """You did not pass a prior. You have to pass the prior either at
-            initialization `inference = SNLE(prior)` or to `.build_posterior
-            (prior=prior)`."""
-            prior = self._prior
-        else:
-            check_prior(prior)
+        if density_estimator is not None:
+            assert isinstance(
+                density_estimator, MixedDensityEstimator
+            ), f"""net must be of type MixedDensityEstimator but is {
+                type(density_estimator)
+            }."""
 
-        if density_estimator is None:
-            likelihood_estimator = self._neural_net
-            # If internal net is used device is defined.
-            device = self._device
-        else:
-            likelihood_estimator = density_estimator
-            # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
-
-        assert isinstance(
-            likelihood_estimator, MixedDensityEstimator
-        ), f"""net must be of type MixedDensityEstimator but is {
-            type(likelihood_estimator)
-        }."""
-
-        (
-            potential_fn,
-            theta_transform,
-        ) = likelihood_estimator_based_potential(likelihood_estimator, prior, x_o=None)
-
-        if sample_with == "mcmc":
-            self._posterior = MCMCPosterior(
-                potential_fn=potential_fn,
-                theta_transform=theta_transform,
-                proposal=prior,
-                method=mcmc_method,
-                device=device,
-                **mcmc_parameters or {},
-            )
-        elif sample_with == "rejection":
-            self._posterior = RejectionPosterior(
-                potential_fn=potential_fn,
-                proposal=prior,
-                device=device,
-                **rejection_sampling_parameters or {},
-            )
-        elif sample_with == "vi":
-            self._posterior = VIPosterior(
-                potential_fn=potential_fn,
-                theta_transform=theta_transform,
-                prior=prior,  # type: ignore
-                vi_method=vi_method,
-                device=device,
-                **vi_parameters or {},
-            )
-        else:
-            raise NotImplementedError
-
-        # Store models at end of each round.
-        self._model_bank.append(deepcopy(self._posterior))
-
-        return deepcopy(self._posterior)
+        return super().build_posterior(
+            density_estimator=density_estimator,
+            prior=prior,
+            sample_with=sample_with,
+            mcmc_method=mcmc_method,
+            vi_method=vi_method,
+            mcmc_parameters=mcmc_parameters,
+            vi_parameters=vi_parameters,
+            rejection_sampling_parameters=rejection_sampling_parameters,
+        )

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -283,30 +283,6 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
 
         return deepcopy(self._neural_net)
 
-    def _get_potential_function(
-        self, prior: Distribution, estimator: ConditionalDensityEstimator
-    ) -> Tuple[LikelihoodBasedPotential, TorchTransform]:
-        r"""Gets potential :math:`\log(p(x_o|\theta)p(\theta))` for
-        likelihood estimator.
-
-        It also returns a transformation that can be used to transform the potential
-        into unconstrained space.
-
-        Args:
-            prior: The prior distribution.
-            estimator: The density estimator modelling the likelihood.
-
-        Returns:
-            The potential function $p(x_o|\theta)p(\theta)$ and a transformation that
-            maps to unconstrained space.
-        """
-        potential_fn, theta_transform = likelihood_estimator_based_potential(
-            likelihood_estimator=estimator,
-            prior=prior,
-            x_o=None,
-        )
-        return potential_fn, theta_transform
-
     def build_posterior(
         self,
         density_estimator: Optional[ConditionalDensityEstimator] = None,
@@ -374,6 +350,30 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
             rejection_sampling_parameters=rejection_sampling_parameters,
             importance_sampling_parameters=importance_sampling_parameters,
         )
+
+    def _get_potential_function(
+        self, prior: Distribution, estimator: ConditionalDensityEstimator
+    ) -> Tuple[LikelihoodBasedPotential, TorchTransform]:
+        r"""Gets potential :math:`\log(p(x_o|\theta)p(\theta))` for
+        likelihood estimator.
+
+        It also returns a transformation that can be used to transform the potential
+        into unconstrained space.
+
+        Args:
+            prior: The prior distribution.
+            estimator: The density estimator modelling the likelihood.
+
+        Returns:
+            The potential function $p(x_o|\theta)p(\theta)$ and a transformation that
+            maps to unconstrained space.
+        """
+        potential_fn, theta_transform = likelihood_estimator_based_potential(
+            likelihood_estimator=estimator,
+            prior=prior,
+            x_o=None,
+        )
+        return potential_fn, theta_transform
 
     def _loss(self, theta: Tensor, x: Tensor) -> Tensor:
         r"""Return loss for SNLE, which is the likelihood of $-\log q(x_i | \theta_i)$.

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -15,6 +15,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
+from sbi.inference.potentials.likelihood_based_potential import LikelihoodBasedPotential
 from sbi.inference.trainers.base import NeuralInference
 from sbi.neural_nets import likelihood_nn
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
@@ -284,7 +285,7 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
 
     def _get_potential_function(
         self, prior: Distribution, estimator: ConditionalDensityEstimator
-    ) -> Tuple[Callable, TorchTransform]:
+    ) -> Tuple[LikelihoodBasedPotential, TorchTransform]:
         r"""Gets potential :math:`\log(p(x_o|\theta)p(\theta))` for
         likelihood estimator.
 

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -5,13 +5,7 @@ from typing import Any, Callable, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 
-from sbi.inference.posteriors import (
-    DirectPosterior,
-    ImportanceSamplingPosterior,
-    MCMCPosterior,
-    RejectionPosterior,
-    VIPosterior,
-)
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.trainers.npe.npe_c import NPE_C
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
@@ -112,13 +106,7 @@ class MNPE(NPE_C):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
-    ) -> Union[
-        MCMCPosterior,
-        RejectionPosterior,
-        VIPosterior,
-        DirectPosterior,
-        ImportanceSamplingPosterior,
-    ]:
+    ) -> NeuralPosterior:
         """Build posterior from the neural density estimator.
 
         Args:

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -4,7 +4,7 @@
 import time
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Callable, Dict, Literal, Optional, Union
+from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union
 from warnings import warn
 
 import torch
@@ -16,13 +16,10 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors import (
     DirectPosterior,
-    MCMCPosterior,
-    RejectionPosterior,
-    VIPosterior,
 )
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
-from sbi.inference.posteriors.importance_posterior import ImportanceSamplingPosterior
 from sbi.inference.potentials import posterior_estimator_based_potential
+from sbi.inference.potentials.posterior_based_potential import PosteriorBasedPotential
 from sbi.inference.trainers.base import NeuralInference, check_if_proposal_has_default_x
 from sbi.neural_nets import posterior_nn
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
@@ -30,10 +27,10 @@ from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
+from sbi.sbi_types import TorchTransform
 from sbi.utils import (
     RestrictedPrior,
     check_estimator_arg,
-    check_prior,
     handle_invalid_x,
     nle_nre_apt_msg_on_invalid_x,
     npe_msg_on_invalid_x,
@@ -436,6 +433,34 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
 
         return deepcopy(self._neural_net)
 
+    def _get_potential_function(
+        self,
+        prior: Distribution,
+        estimator: ConditionalDensityEstimator,
+    ) -> Tuple[PosteriorBasedPotential, TorchTransform]:
+        r"""Gets the potential for posterior-based methods.
+
+        It also returns a transformation that can be used to transform the potential
+        into unconstrained space.
+
+        The potential is the same as the log-probability of the `posterior_estimator`,
+        but it is set to $-\inf$ outside of the prior bounds.
+
+        Args:
+            prior: The prior distribution.
+            estimator: The neural network modelling the posterior.
+
+        Returns:
+            The potential function and a transformation that maps
+            to unconstrained space.
+        """
+        potential_fn, theta_transform = posterior_estimator_based_potential(
+            posterior_estimator=estimator,
+            prior=prior,
+            x_o=None,
+        )
+        return potential_fn, theta_transform
+
     def build_posterior(
         self,
         density_estimator: Optional[ConditionalDensityEstimator] = None,
@@ -458,13 +483,7 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
-    ) -> Union[
-        MCMCPosterior,
-        RejectionPosterior,
-        VIPosterior,
-        DirectPosterior,
-        ImportanceSamplingPosterior,
-    ]:
+    ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
         For SNPE, the posterior distribution that is returned here implements the
@@ -504,85 +523,18 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
             (the returned log-probability is unnormalized).
         """
-        if prior is None:
-            assert self._prior is not None, (
-                "You did not pass a prior. You have to pass the prior either at "
-                "initialization `inference = SNPE(prior)` or to "
-                "`.build_posterior(prior=prior)`."
-            )
-            prior = self._prior
-        else:
-            check_prior(prior)
-
-        if density_estimator is None:
-            posterior_estimator = self._neural_net
-            # If internal net is used device is defined.
-            device = self._device
-        else:
-            posterior_estimator = density_estimator
-            # Otherwise, infer it from the device of the net parameters.
-            device = str(next(density_estimator.parameters()).device)
-
-        potential_fn, theta_transform = posterior_estimator_based_potential(
-            posterior_estimator=posterior_estimator,
-            prior=prior,
-            x_o=None,
+        return super().build_posterior(
+            density_estimator,
+            prior,
+            sample_with,
+            mcmc_method=mcmc_method,
+            vi_method=vi_method,
+            mcmc_parameters=mcmc_parameters,
+            vi_parameters=vi_parameters,
+            rejection_sampling_parameters=rejection_sampling_parameters,
+            importance_sampling_parameters=importance_sampling_parameters,
+            direct_sampling_parameters=direct_sampling_parameters,
         )
-
-        if sample_with == "direct":
-            self._posterior = DirectPosterior(
-                posterior_estimator=posterior_estimator,  # type: ignore
-                prior=prior,
-                device=device,
-                **direct_sampling_parameters or {},
-            )
-        elif sample_with == "rejection":
-            rejection_sampling_parameters = rejection_sampling_parameters or {}
-            if "proposal" not in rejection_sampling_parameters:
-                raise ValueError(
-                    "You passed `sample_with='rejection' but you did not specify a "
-                    "`proposal` in `rejection_sampling_parameters`. Until sbi "
-                    "v0.22.0, this was interpreted as directly sampling from the "
-                    "posterior. As of sbi v0.23.0, you instead have to use "
-                    "`sample_with='direct'` to do so."
-                )
-            self._posterior = RejectionPosterior(
-                potential_fn=potential_fn,
-                device=device,
-                **rejection_sampling_parameters,
-            )
-        elif sample_with == "mcmc":
-            self._posterior = MCMCPosterior(
-                potential_fn=potential_fn,
-                theta_transform=theta_transform,
-                proposal=prior,
-                method=mcmc_method,
-                device=device,
-                **mcmc_parameters or {},
-            )
-        elif sample_with == "vi":
-            self._posterior = VIPosterior(
-                potential_fn=potential_fn,
-                theta_transform=theta_transform,
-                prior=prior,  # type: ignore
-                vi_method=vi_method,
-                device=device,
-                **vi_parameters or {},
-            )
-        elif sample_with == "importance":
-            self._posterior = ImportanceSamplingPosterior(
-                potential_fn=potential_fn,
-                proposal=prior,
-                device=device,
-                **importance_sampling_parameters or {},
-            )
-        else:
-            raise NotImplementedError
-
-        # Store models at end of each round.
-        self._model_bank.append(deepcopy(self._posterior))
-
-        return deepcopy(self._posterior)
 
     @abstractmethod
     def _log_prob_proposal_posterior(

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -598,6 +598,14 @@ class NPE_C(PosteriorEstimatorTrainer):
 
         return means_pp
 
+    def _maybe_z_score_theta(self, theta: Tensor) -> Tensor:
+        """Return potentially standardized theta if z-scoring was requested."""
+
+        if self.z_score_theta:
+            theta, _ = self._neural_net.net._transform(theta)
+
+        return theta
+
     @staticmethod
     def _logits_proposal_posterior(
         means_pp: Tensor,
@@ -665,11 +673,3 @@ class NPE_C(PosteriorEstimatorTrainer):
         logits_pp = logit_factors + log_sqrt_det_ratio + exponent
 
         return logits_pp
-
-    def _maybe_z_score_theta(self, theta: Tensor) -> Tensor:
-        """Return potentially standardized theta if z-scoring was requested."""
-
-        if self.z_score_theta:
-            theta, _ = self._neural_net.net._transform(theta)
-
-        return theta

--- a/sbi/inference/trainers/npse/npse.py
+++ b/sbi/inference/trainers/npse/npse.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional, Union
 from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
 
-from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
     VectorFieldInference,
@@ -84,7 +84,7 @@ class NPSE(VectorFieldInference):
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "sde",
         **kwargs,
-    ) -> VectorFieldPosterior:
+    ) -> NeuralPosterior:
         r"""Build posterior from the vector field estimator.
 
         Note that this is the same as the FMPE posterior, but the sample_with
@@ -112,8 +112,8 @@ class NPSE(VectorFieldInference):
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
         """
-        return self._build_posterior(
-            vector_field_estimator=vector_field_estimator,
+        return super().build_posterior(
+            estimator=vector_field_estimator,
             prior=prior,
             sample_with=sample_with,
             **kwargs,

--- a/sbi/inference/trainers/npse/npse.py
+++ b/sbi/inference/trainers/npse/npse.py
@@ -74,10 +74,6 @@ class NPSE(VectorFieldInference):
         # score_estimator name is kept since it is public API, but it is
         # actually misleading since it is a builder for an estimator.
 
-    def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:
-        net_type = kwargs.pop("vector_field_estimator_builder", "mlp")
-        return posterior_score_nn(score_net_type=net_type, **kwargs)
-
     def build_posterior(
         self,
         vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,
@@ -118,3 +114,7 @@ class NPSE(VectorFieldInference):
             sample_with=sample_with,
             **kwargs,
         )
+
+    def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:
+        net_type = kwargs.pop("vector_field_estimator_builder", "mlp")
+        return posterior_score_nn(score_net_type=net_type, **kwargs)

--- a/sbi/inference/trainers/npse/npse.py
+++ b/sbi/inference/trainers/npse/npse.py
@@ -1,7 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from typing import Literal, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -79,7 +79,7 @@ class NPSE(VectorFieldInference):
         vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "sde",
-        **kwargs,
+        vectorfield_sampling_parameters: Optional[Dict[str, Any]] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the vector field estimator.
 
@@ -101,8 +101,8 @@ class NPSE(VectorFieldInference):
                 'sde' (default) or 'ode'. The 'sde' method uses the score to
                 do a Langevin diffusion step, while the 'ode' method solves a
                 probabilistic ODE with a numerical ODE solver.
-            **kwargs: Additional keyword arguments passed to
-                `VectorFieldBasedPotential`.
+            vectorfield_sampling_parameters: Additional keyword arguments passed to
+                `VectorFieldPosterior`.
 
 
         Returns:
@@ -112,7 +112,7 @@ class NPSE(VectorFieldInference):
             estimator=vector_field_estimator,
             prior=prior,
             sample_with=sample_with,
-            **kwargs,
+            vectorfield_sampling_parameters=vectorfield_sampling_parameters,
         )
 
     def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -488,6 +488,15 @@ class VectorFieldInference(NeuralInference, ABC):
     def _get_potential_function(
         self, prior: Distribution, estimator: ConditionalVectorFieldEstimator
     ) -> Tuple[VectorFieldBasedPotential, TorchTransform]:
+        r"""Gets the potential function gradient for vector field estimators.
+
+        Args:
+            prior: The prior distribution.
+            estimator: The neural network modelling the vector field.
+        Returns:
+            The potential function and a transformation that maps
+            to unconstrained space.
+        """
         potential_fn, theta_transform = vector_field_estimator_based_potential(
             estimator,
             prior,

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -4,7 +4,7 @@
 import time
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Callable, Literal, Optional, Protocol, Union
+from typing import Any, Callable, Optional, Protocol, Union
 
 import torch
 from torch import Tensor, ones
@@ -18,7 +18,6 @@ from sbi.inference import NeuralInference
 from sbi.inference.posteriors import (
     DirectPosterior,
 )
-from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.utils import (
     check_estimator_arg,
@@ -483,69 +482,6 @@ class VectorFieldInference(NeuralInference, ABC):
 
     def _get_potential_function(self, prior, estimator):
         pass
-
-    def _build_posterior(
-        self,
-        vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,
-        prior: Optional[Distribution] = None,
-        sample_with: Literal["ode", "sde"] = "sde",
-        **kwargs,
-    ) -> VectorFieldPosterior:
-        r"""Build posterior from the vector field estimator.
-
-        For NPSE, the posterior distribution that is returned here implements the
-        following functionality over the raw neural density estimator:
-        - correct the calculation of the log probability such that it compensates for
-            the leakage.
-        - reject samples that lie outside of the prior bounds.
-
-        Args:
-            vector_field_estimator: The vector field estimator that the posterior
-                is based on. If `None`, use the latest vector field estimator that was
-                trained.
-            prior: Prior distribution.
-            sample_with: Method to use for sampling from the posterior. Can be one of
-                'sde' (default) or 'ode'. The 'sde' method uses the vector field to
-                do a Langevin diffusion step, while the 'ode' solves a probabilistic ODE
-                with a numerical ODE solver.
-            **kwargs: Additional keyword arguments passed to
-                `VectorFieldBasedPotential`.
-
-        Returns:
-            Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
-        """
-        if prior is None:
-            cls_name = self.__class__.__name__
-            assert self._prior is not None, (
-                "You did not pass a prior. You have to pass the prior either at "
-                f"initialization `inference = {cls_name}(prior)` or to "
-                "`.build_posterior(prior=prior)`."
-            )
-            prior = self._prior
-        else:
-            utils.check_prior(prior)
-
-        if vector_field_estimator is None:
-            vector_field_estimator = self._neural_net
-            # If internal net is used device is defined.
-            device = self._device
-        # Otherwise, infer it from the device of the net parameters.
-        else:
-            device = str(next(vector_field_estimator.parameters()).device)
-
-        posterior = VectorFieldPosterior(
-            vector_field_estimator,
-            prior,
-            device=device,
-            sample_with=sample_with,
-            **kwargs,
-        )
-
-        self._posterior = posterior
-        # Store models at end of each round.
-        self._model_bank.append(deepcopy(self._posterior))
-
-        return deepcopy(self._posterior)
 
     def _loss_proposal_posterior(
         self,

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -481,6 +481,9 @@ class VectorFieldInference(NeuralInference, ABC):
 
         return deepcopy(self._neural_net)
 
+    def _get_potential_function(self, prior, estimator):
+        pass
+
     def _build_posterior(
         self,
         vector_field_estimator: Optional[ConditionalVectorFieldEstimator] = None,

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -4,7 +4,7 @@
 import time
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Callable, Optional, Protocol, Union
+from typing import Any, Callable, Optional, Protocol, Tuple, Union
 
 import torch
 from torch import Tensor, ones
@@ -18,7 +18,12 @@ from sbi.inference import NeuralInference
 from sbi.inference.posteriors import (
     DirectPosterior,
 )
+from sbi.inference.potentials.vector_field_potential import (
+    VectorFieldBasedPotential,
+    vector_field_estimator_based_potential,
+)
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
+from sbi.sbi_types import TorchTransform
 from sbi.utils import (
     check_estimator_arg,
     handle_invalid_x,
@@ -480,8 +485,15 @@ class VectorFieldInference(NeuralInference, ABC):
 
         return deepcopy(self._neural_net)
 
-    def _get_potential_function(self, prior, estimator):
-        pass
+    def _get_potential_function(
+        self, prior: Distribution, estimator: ConditionalVectorFieldEstimator
+    ) -> Tuple[VectorFieldBasedPotential, TorchTransform]:
+        potential_fn, theta_transform = vector_field_estimator_based_potential(
+            estimator,
+            prior,
+            x_o=None,
+        )
+        return potential_fn, theta_transform
 
     def _loss_proposal_posterior(
         self,

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -348,7 +348,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
         raise NotImplementedError
 
     def _get_potential_function(
-        self, prior: Distribution, estimator: nn.Module
+        self, prior: Distribution, estimator: RatioEstimator
     ) -> Tuple[Callable, TorchTransform]:
         r"""Gets the potential for ratio-based methods.
 
@@ -373,7 +373,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
 
     def build_posterior(
         self,
-        density_estimator: Optional[nn.Module] = None,
+        density_estimator: Optional[RatioEstimator] = None,
         prior: Optional[Distribution] = None,
         sample_with: Literal["mcmc", "rejection", "vi", "importance"] = "mcmc",
         mcmc_method: Literal[

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -4,7 +4,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Callable, Dict, Literal, Optional, Protocol, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Protocol, Tuple, Union
 
 import torch
 from torch import Tensor, eye, nn, ones
@@ -15,6 +15,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials import ratio_estimator_based_potential
+from sbi.inference.potentials.ratio_based_potential import RatioBasedPotential
 from sbi.inference.trainers.base import NeuralInference
 from sbi.neural_nets import classifier_nn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
@@ -349,7 +350,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
 
     def _get_potential_function(
         self, prior: Distribution, estimator: RatioEstimator
-    ) -> Tuple[Callable, TorchTransform]:
+    ) -> Tuple[RatioBasedPotential, TorchTransform]:
         r"""Gets the potential for ratio-based methods.
 
         It also returns a transformation that can be used to transform the potential

--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -100,7 +100,9 @@ def test_c2st_vector_field_on_linearGaussian(
         posterior = inference.build_posterior(
             score_estimator,
             sample_with=method,
-            neural_ode_backend="zuko",
+            vectorfield_sampling_parameters={
+                "neural_ode_backend": "zuko",
+            },
         )
         posterior.set_default_x(x_o)
         samples = posterior.sample((num_samples,))

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -14,6 +14,7 @@ from sbi.inference import (
     NPE_A,
     NPE_C,
     NPSE,
+    NRE,
     NRE_A,
     NRE_B,
     NRE_C,
@@ -379,7 +380,7 @@ def test_build_posterior_raises_with_invalid_estimator():
     theta = prior.sample((300,))
     x = simulator(theta)
 
-    inference = NRE_A(prior=prior)
+    inference = NRE(prior=prior)
     inference.append_simulations(theta, x)
 
     inference.train(max_num_epochs=1)

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-from torch import eye, ones, zeros
+from torch import eye, nn, ones, zeros
 from torch.distributions import Independent, MultivariateNormal, Uniform
 
 from sbi.inference import (
@@ -26,6 +26,7 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils.diagnostics_utils import get_posterior_samples_on_batch
 from sbi.utils.metrics import check_c2st
+from sbi.utils.torchutils import BoxUniform
 
 
 @pytest.mark.parametrize("snpe_method", [NPE_A, NPE_C])
@@ -363,3 +364,23 @@ def test_batched_sampling_and_logprob_accuracy(density_estimator: str):
         assert torch.allclose(
             target_log_probs.exp(), log_probs.exp(), atol=0.4, rtol=0.4
         ), "Batched log probs are not consistent with non-batched log probs."
+
+
+@pytest.mark.xfail(
+    raises=TypeError,
+    reason="Invalid density_estimator type passed to build_posterior",
+)
+def test_build_posterior_raises_with_invalid_estimator():
+    def simulator(theta):
+        return 1.0 + theta + torch.randn(theta.shape, device=theta.device) * 0.1
+
+    num_dim = 3
+    prior = BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    theta = prior.sample((300,))
+    x = simulator(theta)
+
+    inference = NRE_A(prior=prior)
+    inference.append_simulations(theta, x)
+
+    inference.train(max_num_epochs=1)
+    inference.build_posterior(density_estimator=nn.Module())


### PR DESCRIPTION
## Problem
With the current implementation each trainer class `build_posterior` method contains duplicated logic for creating a posterior, violating the DRY principle and making it hard for modification.  

## Fix
This PR adds a `build_posterior` method in the `NeuralInference` base class for handling posterior creation. With the updated implementation trainers inheriting from the `NeuralInference` base class now call the parent method to create a posterior, thus centralizing the posterior creation logic to a single place and removing duplicated conditional posterior creation logic previously found in each sub-class. 

## Note
The `density_estimator` argument is intentionally retained in the subclasses (instead of renaming to a more general name like `estimator`) to avoid breaking changes for users relying on the current API.