### PR TITLE
refactor: rename VectorFieldInference to VectorFieldTrainer

### DIFF
--- a/sbi/inference/trainers/fmpe/fmpe.py
+++ b/sbi/inference/trainers/fmpe/fmpe.py
@@ -11,13 +11,13 @@ from sbi import utils as utils
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
-    VectorFieldInference,
+    VectorFieldTrainer,
 )
 from sbi.neural_nets import flowmatching_nn
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 
 
-class FMPE(VectorFieldInference):
+class FMPE(VectorFieldTrainer):
     """Flow Matching Posterior Estimation (FMPE)."""
 
     def __init__(

--- a/sbi/inference/trainers/npse/npse.py
+++ b/sbi/inference/trainers/npse/npse.py
@@ -9,13 +9,13 @@ from torch.utils.tensorboard.writer import SummaryWriter
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
-    VectorFieldInference,
+    VectorFieldTrainer,
 )
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.neural_nets.factory import posterior_score_nn
 
 
-class NPSE(VectorFieldInference):
+class NPSE(VectorFieldTrainer):
     """Neural Posterior Score Estimation as in Geffner et al. and Sharrock et al.
 
     Instead of performing conditonal *density* estimation, NPSE methods perform

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -51,7 +51,7 @@ class VectorFieldEstimatorBuilder(Protocol):
         ...
 
 
-class VectorFieldInference(NeuralInference, ABC):
+class VectorFieldTrainer(NeuralInference, ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
@@ -119,7 +119,7 @@ class VectorFieldInference(NeuralInference, ABC):
         proposal: Optional[DirectPosterior] = None,
         exclude_invalid_x: Optional[bool] = None,
         data_device: Optional[str] = None,
-    ) -> "VectorFieldInference":
+    ) -> "VectorFieldTrainer":
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).
@@ -146,7 +146,7 @@ class VectorFieldInference(NeuralInference, ABC):
                 much VRAM can set to 'cpu' to store data on system memory instead.
 
         Returns:
-            VectorFieldInference object (returned so that this function is chainable).
+            VectorFieldTrainer object (returned so that this function is chainable).
         """
         inference_name = self.__class__.__name__
         assert proposal is None, (


### PR DESCRIPTION
This PR renames `VectorFieldInference` to `VectorFieldTrainer` to keep it consistent with the other trainer classes, which were renamed in this [PR](https://github.com/sbi-dev/sbi/pull/1605).