### PR TITLE
Refactor build_posterior Posterior Configuration Using Dataclasses

### DIFF
--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
-import torch
-
 from sbi.inference.posteriors.vi_posterior import VIPosterior
 from sbi.sbi_types import PyroTransformedDistribution, TorchTransform
 
@@ -15,14 +13,12 @@ class DirectPosteriorParameters:
     Fields:
         max_sampling_batch_size: Batchsize of samples being drawn from
             the proposal at every iteration.
-        x_shape: Deprecated, should not be passed.
         enable_transform: Whether to transform parameters to unconstrained space
             during MAP optimization. When False, an identity transform will be
             returned for `theta_transform`.
     """
 
     max_sampling_batch_size: int = 10_000
-    x_shape: Optional[torch.Size] = None
     enable_transform: bool = True
 
 
@@ -43,14 +39,12 @@ class ImportanceSamplingPosteriorParameters:
             selected based on its importance weight.
         max_sampling_batch_size: The batch size of samples being drawn from the
             proposal at every iteration.
-        x_shape: Deprecated, should not be passed.
     """
 
     theta_transform: Optional[TorchTransform] = None
     method: Literal["sir", "importance"] = "sir"
     oversampling_factor: int = 32
     max_sampling_batch_size: int = 10_000
-    x_shape: Optional[torch.Size] = None
 
 
 @dataclass(frozen=True)
@@ -91,7 +85,6 @@ class MCMCPosteriorParameters:
             (default), used by Pyro and PyMC samplers. `"fork"` can be significantly
             faster than `"spawn"` but is only supported on POSIX-based systems
             (e.g. Linux and macOS, not Windows).
-        x_shape: Deprecated, should not be passed.
     """
 
     method: Literal[
@@ -111,7 +104,6 @@ class MCMCPosteriorParameters:
     init_strategy_num_candidates: Optional[int] = None
     num_workers: int = 1
     mp_context: Literal["fork", "spawn"] = "spawn"
-    x_shape: Optional[torch.Size] = None
 
 
 @dataclass(frozen=True)
@@ -129,7 +121,6 @@ class RejectionPosteriorParameters:
         num_iter_to_find_max: The number of gradient ascent iterations to find the
             maximum of the `potential_fn / proposal` ratio.
         m: Multiplier to the `potential_fn / proposal` ratio.
-        x_shape: Deprecated, should not be passed.
     """
 
     theta_transform: Optional[TorchTransform] = None
@@ -137,7 +128,6 @@ class RejectionPosteriorParameters:
     num_samples_to_find_max: int = 10_000
     num_iter_to_find_max: int = 100
     m: float = 1.2
-    x_shape: Optional[torch.Size] = None
 
 
 @dataclass(frozen=True)
@@ -195,7 +185,6 @@ class VIPosteriorParameters:
             variance and collapse on multimodal targets (`rKL`, `alpha` for alpha >
             1) and some are `mass covering` i.e. they overestimate variance but
             typically cover all modes (`fKL`, `IW`, `alpha` for alpha < 1).
-        x_shape: Deprecated, should not be passed.
         parameters: List of parameters of the variational posterior. This is only
             required for user-defined q i.e. if q does not have a `parameters`
             attribute.
@@ -211,6 +200,5 @@ class VIPosteriorParameters:
         Callable,
     ] = "maf"
     vi_method: Literal["rKL", "fKL", "IW", "alpha"] = "rKL"
-    x_shape: Optional[torch.Size] = None
     parameters: Optional[Iterable] = None
     modules: Optional[Iterable] = None

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
+
+import torch
+
+from sbi.inference.posteriors.vi_posterior import VIPosterior
+from sbi.sbi_types import PyroTransformedDistribution, TorchTransform
+
+
+@dataclass(frozen=True)
+class DirectPosteriorParameters:
+    """
+    Parameters for initializing DirectPosterior.
+    """
+
+    max_sampling_batch_size: int = 10_000
+    x_shape: Optional[torch.Size] = None
+    enable_transform: bool = True
+
+
+@dataclass(frozen=True)
+class ImportanceSamplingPosteriorParameters:
+    """
+    Parameters for initializing ImportanceSamplingPosterior.
+    """
+
+    theta_transform: Optional[TorchTransform] = None
+    method: Literal["sir", "importance"] = "sir"
+    oversampling_factor: int = 32
+    max_sampling_batch_size: int = 10_000
+    x_shape: Optional[torch.Size] = None
+
+
+@dataclass(frozen=True)
+class MCMCPosteriorParameters:
+    """
+    Parameters for initializing MCMCPosterior.
+    """
+
+    method: Literal[
+        "slice_np",
+        "slice_np_vectorized",
+        "hmc_pyro",
+        "nuts_pyro",
+        "slice_pymc",
+        "hmc_pymc",
+        "nuts_pymc",
+    ] = "slice_np_vectorized"
+    thin: int = -1
+    warmup_steps: int = 200
+    num_chains: int = 20
+    init_strategy: Literal["proposal", "sir", "resample"] = "resample"
+    init_strategy_parameters: Optional[Dict[str, Any]] = None
+    init_strategy_num_candidates: Optional[int] = None
+    num_workers: int = 1
+    mp_context: Literal["fork", "spawn"] = "spawn"
+    x_shape: Optional[torch.Size] = None
+
+
+@dataclass(frozen=True)
+class RejectionPosteriorParameters:
+    """
+    Parameters for initializing RejectionPosterior.
+    """
+
+    theta_transform: Optional[TorchTransform] = None
+    max_sampling_batch_size: int = 10_000
+    num_samples_to_find_max: int = 10_000
+    num_iter_to_find_max: int = 100
+    m: float = 1.2
+    x_shape: Optional[torch.Size] = None
+
+
+@dataclass(frozen=True)
+class VectorFieldPosteriorParameters:
+    """
+    Parameters for initializing VectorFieldPosterior.
+    """
+
+    max_sampling_batch_size: int = 10_000
+    enable_transform: bool = True
+
+
+@dataclass(frozen=True)
+class VIPosteriorParameters:
+    """
+    Parameters for initializing VIPosterior.
+    """
+
+    q: Union[
+        Literal["nsf", "scf", "maf", "mcf", "gaussian", "gaussian_diag"],
+        PyroTransformedDistribution,
+        "VIPosterior",
+        Callable,
+    ] = "maf"
+    vi_method: Literal["rKL", "fKL", "IW", "alpha"] = "rKL"
+    x_shape: Optional[torch.Size] = None
+    parameters: Optional[Iterable] = None
+    modules: Optional[Iterable] = None

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -52,6 +52,7 @@ class PosteriorParameters(ABC):
         Raises:
             ValueError: If any of the provided keys are not valid dataclass fields.
         """
+
         valid_fields = set(self.__dataclass_fields__)
         for key in kwargs:
             if key not in valid_fields:
@@ -74,6 +75,7 @@ class PosteriorParameters(ABC):
             ValueError: If any field fails its Literal constraint or cannot be cast to
                         the expected primitive type.
         """
+
         for field in self.__dataclass_fields__.values():
             field_name = field.name
             raw_value = getattr(self, field_name)
@@ -119,6 +121,7 @@ class DirectPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate DirectPosteriorParameters fields."""
+
         if not is_positive_int(self.max_sampling_batch_size):
             raise ValueError("max_sampling_batch_size must be greater than 0.")
         if not is_bool(self.enable_transform):
@@ -151,6 +154,7 @@ class ImportanceSamplingPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate ImportanceSamplingPosteriorParameters fields."""
+
         if not (
             self.theta_transform is None
             or isinstance(self.theta_transform, TorchTransform)
@@ -220,6 +224,7 @@ class MCMCPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate MCMCPosteriorParameters fields."""
+
         if not (
             self.init_strategy_parameters is None
             or isinstance(self.init_strategy_parameters, Dict)
@@ -262,6 +267,7 @@ class RejectionPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate RejectionPosteriorParameters fields."""
+
         if not (
             self.theta_transform is None
             or isinstance(self.theta_transform, TorchTransform)
@@ -312,6 +318,7 @@ class VectorFieldPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate VectorFieldPosteriorParameters fields."""
+
         if not is_bool(self.enable_transform):
             raise TypeError("enable_transform must of type bool.")
         if not (self.iid_params is None or isinstance(self.iid_params, Dict)):
@@ -368,6 +375,7 @@ class VIPosteriorParameters(PosteriorParameters):
 
     def validate(self):
         """Validate VIPosteriorParameters fields."""
+
         valid_q = {"nsf", "scf", "maf", "mcf", "gaussian", "gaussian_diag"}
 
         if isinstance(self.q, str) and self.q not in valid_q:

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -11,6 +11,14 @@ from sbi.sbi_types import PyroTransformedDistribution, TorchTransform
 class DirectPosteriorParameters:
     """
     Parameters for initializing DirectPosterior.
+
+    Fields:
+        max_sampling_batch_size: Batchsize of samples being drawn from
+            the proposal at every iteration.
+        x_shape: Deprecated, should not be passed.
+        enable_transform: Whether to transform parameters to unconstrained space
+            during MAP optimization. When False, an identity transform will be
+            returned for `theta_transform`.
     """
 
     max_sampling_batch_size: int = 10_000
@@ -22,6 +30,20 @@ class DirectPosteriorParameters:
 class ImportanceSamplingPosteriorParameters:
     """
     Parameters for initializing ImportanceSamplingPosterior.
+
+    Fields:
+        theta_transform: Transformation that is applied to parameters. Is not used
+            during but only when calling `.map()`.
+        method: Either of [`sir`|`importance`]. This sets the behavior of the
+            `.sample()` method. With `sir`, approximate posterior samples are
+            generated with sampling importance resampling (SIR). With
+            `importance`, the `.sample()` method returns a tuple of samples and
+            corresponding importance weights.
+        oversampling_factor: Number of proposed samples from which only one is
+            selected based on its importance weight.
+        max_sampling_batch_size: The batch size of samples being drawn from the
+            proposal at every iteration.
+        x_shape: Deprecated, should not be passed.
     """
 
     theta_transform: Optional[TorchTransform] = None
@@ -35,6 +57,41 @@ class ImportanceSamplingPosteriorParameters:
 class MCMCPosteriorParameters:
     """
     Parameters for initializing MCMCPosterior.
+
+    Fields:
+        method: Method used for MCMC sampling, one of `slice_np`,
+            `slice_np_vectorized`, `hmc_pyro`, `nuts_pyro`, `slice_pymc`,
+            `hmc_pymc`, `nuts_pymc`. `slice_np` is a custom
+            numpy implementation of slice sampling. `slice_np_vectorized` is
+            identical to `slice_np`, but if `num_chains>1`, the chains are
+            vectorized for `slice_np_vectorized` whereas they are run sequentially
+            for `slice_np`. The samplers ending on `_pyro` are using Pyro, and
+            likewise the samplers ending on `_pymc` are using PyMC.
+        thin: The thinning factor for the chain, default 1 (no thinning).
+        warmup_steps: The initial number of samples to discard.
+        num_chains: The number of chains. Should generally be at most
+            `num_workers - 1`.
+        init_strategy: The initialisation strategy for chains; `proposal` will draw
+            init locations from `proposal`, whereas `sir` will use Sequential-
+            Importance-Resampling (SIR). SIR initially samples
+            `init_strategy_num_candidates` from the `proposal`, evaluates all of
+            them under the `potential_fn` and `proposal`, and then resamples the
+            initial locations with weights proportional to `exp(potential_fn -
+            proposal.log_prob`. `resample` is the same as `sir` but
+            uses `exp(potential_fn)` as weights.
+        init_strategy_parameters: Dictionary of keyword arguments passed to the
+            init strategy, e.g., for `init_strategy=sir` this could be
+            `num_candidate_samples`, i.e., the number of candidates to find init
+            locations (internal default is `1000`), or `device`.
+        init_strategy_num_candidates: Number of candidates to find init
+             locations in `init_strategy=sir` (deprecated, use
+             init_strategy_parameters instead).
+        num_workers: number of cpu cores used to parallelize mcmc
+        mp_context: Multiprocessing start method, either `"fork"` or `"spawn"`
+            (default), used by Pyro and PyMC samplers. `"fork"` can be significantly
+            faster than `"spawn"` but is only supported on POSIX-based systems
+            (e.g. Linux and macOS, not Windows).
+        x_shape: Deprecated, should not be passed.
     """
 
     method: Literal[
@@ -61,6 +118,18 @@ class MCMCPosteriorParameters:
 class RejectionPosteriorParameters:
     """
     Parameters for initializing RejectionPosterior.
+
+    Fields:
+        theta_transform: Transformation that is applied to parameters. Is not used
+            during but only when calling `.map()`.
+        max_sampling_batch_size: The batchsize of samples being drawn from
+            the proposal at every iteration.
+        num_samples_to_find_max: The number of samples that are used to find the
+            maximum of the `potential_fn / proposal` ratio.
+        num_iter_to_find_max: The number of gradient ascent iterations to find the
+            maximum of the `potential_fn / proposal` ratio.
+        m: Multiplier to the `potential_fn / proposal` ratio.
+        x_shape: Deprecated, should not be passed.
     """
 
     theta_transform: Optional[TorchTransform] = None
@@ -75,6 +144,20 @@ class RejectionPosteriorParameters:
 class VectorFieldPosteriorParameters:
     """
     Parameters for initializing VectorFieldPosterior.
+
+    Fields:
+        max_sampling_batch_size: Batchsize of samples being drawn from
+            the proposal at every iteration.
+        enable_transform: Whether to transform parameters to unconstrained space
+            during MAP optimization. When False, an identity transform will be
+            returned for `theta_transform`. True is not supported yet.
+        iid_method: Which method to use for computing the score in the iid setting.
+            We currently support "fnpe", "gauss", "auto_gauss", "jac_gauss".
+        iid_params: Parameters for the iid method, for arguments see
+            `IIDScoreFunction`.
+        neural_ode_backend: The backend to use for the neural ODE. Currently,
+            only "zuko" is supported.
+        neural_ode_kwargs: Additional keyword arguments for the neural ODE.
     """
 
     max_sampling_batch_size: int = 10_000
@@ -92,6 +175,33 @@ class VectorFieldPosteriorParameters:
 class VIPosteriorParameters:
     """
     Parameters for initializing VIPosterior.
+
+    Fields:
+        q: Variational distribution, either string, `TransformedDistribution`, or a
+            `VIPosterior` object. This specifies a parametric class of distribution
+            over which the best possible posterior approximation is searched. For
+            string input, we currently support [nsf, scf, maf, mcf, gaussian,
+            gaussian_diag]. You can also specify your own variational family by
+            passing a pyro `TransformedDistribution`.
+            Additionally, we allow a `Callable`, which allows you the pass a
+            `builder` function, which if called returns a distribution. This may be
+            useful for setting the hyperparameters e.g. `num_transfroms` within the
+            `get_flow_builder` method specifying the number of transformations
+            within a normalizing flow. If q is already a `VIPosterior`, then the
+            arguments will be copied from it (relevant for multi-round training).
+        vi_method: This specifies the variational methods which are used to fit q to
+            the posterior. We currently support [rKL, fKL, IW, alpha]. Note that
+            some of the divergences are `mode seeking` i.e. they underestimate
+            variance and collapse on multimodal targets (`rKL`, `alpha` for alpha >
+            1) and some are `mass covering` i.e. they overestimate variance but
+            typically cover all modes (`fKL`, `IW`, `alpha` for alpha < 1).
+        x_shape: Deprecated, should not be passed.
+        parameters: List of parameters of the variational posterior. This is only
+            required for user-defined q i.e. if q does not have a `parameters`
+            attribute.
+        modules: List of modules of the variational posterior. This is only
+            required for user-defined q i.e. if q does not have a `modules`
+            attribute.
     """
 
     q: Union[

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
 import torch
@@ -79,6 +79,7 @@ class VectorFieldPosteriorParameters:
 
     max_sampling_batch_size: int = 10_000
     enable_transform: bool = True
+    vector_field_estimator_potential_args: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
 import torch
@@ -79,7 +79,13 @@ class VectorFieldPosteriorParameters:
 
     max_sampling_batch_size: int = 10_000
     enable_transform: bool = True
-    vector_field_estimator_potential_args: Dict[str, Any] = field(default_factory=dict)
+
+    # fields passed from VectorfieldPosterior as keyword arguments
+    # to VectorFieldBasedPotential __init__ method
+    iid_method: Literal["fnpe", "gauss", "auto_gauss", "jac_gauss"] = "auto_gauss"
+    iid_params: Optional[Dict[str, Any]] = None
+    neural_ode_backend: str = "zuko"
+    neural_ode_kwargs: Optional[Dict[str, Any]] = None
 
 
 @dataclass(frozen=True)

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -1,3 +1,6 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from typing import (

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -66,7 +66,7 @@ class VectorFieldBasedPotential(BasePotential):
         device: Union[str, torch.device] = "cpu",
         iid_method: Literal["fnpe", "gauss", "auto_gauss", "jac_gauss"] = "auto_gauss",
         iid_params: Optional[Dict[str, Any]] = None,
-        neural_ode_backend: str = "zuko",
+        neural_ode_backend: Literal["zuko"] = "zuko",
         neural_ode_kwargs: Optional[Dict[str, Any]] = None,
     ):
         r"""

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -625,9 +625,9 @@ class NeuralInference(ABC):
                 or kwargs.get("importance_sampling_parameters") is not None
             ):
                 raise ValueError(
-                    "You have passed values to both a configuration dictionary"
-                    "and posterior_parameters."
-                    "Please use either the configuration dictionary"
+                    "You have passed values to both a parameters dictionary"
+                    " and posterior_parameters."
+                    " Please use either the parameters dictionary"
                     " or posterior_parameters."
                 )
             elif isinstance(posterior_parameters, MCMCPosteriorParameters):

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -25,6 +25,7 @@ from sbi.inference.posteriors.posterior_parameters import (
     DirectPosteriorParameters,
     ImportanceSamplingPosteriorParameters,
     MCMCPosteriorParameters,
+    PosteriorParameters,
     RejectionPosteriorParameters,
     VIPosteriorParameters,
     VectorFieldPosteriorParameters,
@@ -410,16 +411,7 @@ class NeuralInference(ABC):
         sample_with: Literal[
             "mcmc", "rejection", "vi", "importance", "direct", "sde", "ode"
         ],
-        posterior_parameters: Optional[
-            Union[
-                VIPosteriorParameters,
-                VectorFieldPosteriorParameters,
-                ImportanceSamplingPosteriorParameters,
-                MCMCPosteriorParameters,
-                DirectPosteriorParameters,
-                RejectionPosteriorParameters,
-            ]
-        ],
+        posterior_parameters: Optional[PosteriorParameters],
         **kwargs,
     ) -> NeuralPosterior:
         r"""Method for building posteriors.
@@ -442,13 +434,7 @@ class NeuralInference(ABC):
                 - "sde"
                 - "ode"
             posterior_parameters: Configuration passed to the init method for the
-                posterior. Must be one of the following:
-                - `VIPosteriorParameters`
-                - `VectorFieldPosteriorParameters`
-                - `ImportanceSamplingPosteriorParameters`
-                - `MCMCPosteriorParameters`
-                - `DirectPosteriorParameters`
-                - `RejectionPosteriorParameters`
+                posterior. Must be of type PosteriorParameters.
             **kwargs: Additional method-specific parameters.
 
         Returns:
@@ -544,25 +530,9 @@ class NeuralInference(ABC):
         sample_with: Literal[
             "mcmc", "rejection", "vi", "importance", "direct", "sde", "ode"
         ],
-        posterior_parameters: Optional[
-            Union[
-                VIPosteriorParameters,
-                VectorFieldPosteriorParameters,
-                ImportanceSamplingPosteriorParameters,
-                MCMCPosteriorParameters,
-                DirectPosteriorParameters,
-                RejectionPosteriorParameters,
-            ]
-        ],
+        posterior_parameters: Optional[PosteriorParameters],
         **kwargs,
-    ) -> Union[
-        VIPosteriorParameters,
-        VectorFieldPosteriorParameters,
-        ImportanceSamplingPosteriorParameters,
-        MCMCPosteriorParameters,
-        DirectPosteriorParameters,
-        RejectionPosteriorParameters,
-    ]:
+    ) -> PosteriorParameters:
         """
         Resolve posterior parameters based on the sampling strategy.
 
@@ -586,6 +556,14 @@ class NeuralInference(ABC):
             A dataclass instance containing the resolved posterior
             parameters.
         """
+
+        if posterior_parameters is not None and not isinstance(
+            posterior_parameters, PosteriorParameters
+        ):
+            raise TypeError(
+                "posterior_parameters must be PosteriorParameters,"
+                f" got {type(posterior_parameters).__name__}",
+            )
 
         if posterior_parameters is None:
             if sample_with == "direct":
@@ -651,16 +629,7 @@ class NeuralInference(ABC):
             )
 
     def _validate_method_consistency(
-        self,
-        posterior_parameters: Union[
-            VIPosteriorParameters,
-            VectorFieldPosteriorParameters,
-            ImportanceSamplingPosteriorParameters,
-            MCMCPosteriorParameters,
-            DirectPosteriorParameters,
-            RejectionPosteriorParameters,
-        ],
-        **kwargs,
+        self, posterior_parameters: PosteriorParameters, **kwargs
     ) -> None:
         """
         This method raises a warning for mistmatches between values passed in
@@ -701,14 +670,7 @@ class NeuralInference(ABC):
             "mcmc", "rejection", "vi", "importance", "direct", "sde", "ode"
         ],
         device: Union[str, torch.device],
-        posterior_parameters: Union[
-            VIPosteriorParameters,
-            VectorFieldPosteriorParameters,
-            ImportanceSamplingPosteriorParameters,
-            MCMCPosteriorParameters,
-            DirectPosteriorParameters,
-            RejectionPosteriorParameters,
-        ],
+        posterior_parameters: PosteriorParameters,
     ) -> NeuralPosterior:
         """
         Create a posterior object using the specified inference method.
@@ -732,13 +694,7 @@ class NeuralInference(ABC):
             device: torch device on which to train the neural net and on which to
                 perform all posterior operations, e.g. gpu or cpu.
             posterior_parameters: Configuration passed to the init method for the
-                posterior. Must be one of the following:
-                - `VIPosteriorParameters`
-                - `VectorFieldPosteriorParameters`
-                - `ImportanceSamplingPosteriorParameters`
-                - `MCMCPosteriorParameters`
-                - `DirectPosteriorParameters`
-                - `RejectionPosteriorParameters`
+                posterior. Must be of type PosteriorParameters.
 
         Returns:
             NeuralPosterior object.

--- a/sbi/inference/trainers/fmpe/fmpe.py
+++ b/sbi/inference/trainers/fmpe/fmpe.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import VectorFieldPosteriorParameters
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
     VectorFieldTrainer,
@@ -65,6 +66,7 @@ class FMPE(VectorFieldTrainer):
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "ode",
         vectorfield_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[VectorFieldPosteriorParameters] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the flow matching estimator.
 
@@ -89,16 +91,19 @@ class FMPE(VectorFieldTrainer):
                 a numerical ODE solver.
             vectorfield_sampling_parameters: Additional keyword arguments passed to
                 `VectorFieldPosterior`.
-
+            posterior_parameters: Configuration passed to the init method for
+                VectorFieldPosterior.
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
         """
+
         return super().build_posterior(
             estimator=vector_field_estimator,
             prior=prior,
             sample_with=sample_with,
             vectorfield_sampling_parameters=vectorfield_sampling_parameters,
+            posterior_parameters=posterior_parameters,
         )
 
     def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -6,6 +6,11 @@ from typing import Any, Callable, Dict, Literal, Optional, Union
 from torch.distributions import Distribution
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+)
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
@@ -105,6 +110,13 @@ class MNLE(LikelihoodEstimatorTrainer):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[
+            Union[
+                MCMCPosteriorParameters,
+                VIPosteriorParameters,
+                RejectionPosteriorParameters,
+            ]
+        ] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
@@ -134,6 +146,11 @@ class MNLE(LikelihoodEstimatorTrainer):
             vi_parameters: Additional kwargs passed to `VIPosterior`.
             rejection_sampling_parameters: Additional kwargs passed to
                 `RejectionPosterior`.
+            posterior_parameters: Configuration passed to the init method for the
+                posterior. Must be one of the following
+                - `VIPosteriorParameters`
+                - `MCMCPosteriorParameters`
+                - `RejectionPosteriorParameters`
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
@@ -150,6 +167,7 @@ class MNLE(LikelihoodEstimatorTrainer):
             density_estimator=density_estimator,
             prior=prior,
             sample_with=sample_with,
+            posterior_parameters=posterior_parameters,
             mcmc_method=mcmc_method,
             vi_method=vi_method,
             mcmc_parameters=mcmc_parameters,

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -7,6 +7,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.posteriors.posterior_parameters import (
+    ImportanceSamplingPosteriorParameters,
     MCMCPosteriorParameters,
     RejectionPosteriorParameters,
     VIPosteriorParameters,
@@ -110,11 +111,13 @@ class MNLE(LikelihoodEstimatorTrainer):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
+        importance_sampling_parameters: Optional[Dict[str, Any]] = None,
         posterior_parameters: Optional[
             Union[
                 MCMCPosteriorParameters,
                 VIPosteriorParameters,
                 RejectionPosteriorParameters,
+                ImportanceSamplingPosteriorParameters,
             ]
         ] = None,
     ) -> NeuralPosterior:
@@ -146,11 +149,14 @@ class MNLE(LikelihoodEstimatorTrainer):
             vi_parameters: Additional kwargs passed to `VIPosterior`.
             rejection_sampling_parameters: Additional kwargs passed to
                 `RejectionPosterior`.
+            importance_sampling_parameters: Additional kwargs passed to
+                `ImportanceSamplingPosterior`
             posterior_parameters: Configuration passed to the init method for the
                 posterior. Must be one of the following
                 - `VIPosteriorParameters`
                 - `MCMCPosteriorParameters`
                 - `RejectionPosteriorParameters`
+                - `ImportanceSamplingPosteriorParameters`
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
@@ -173,4 +179,5 @@ class MNLE(LikelihoodEstimatorTrainer):
             mcmc_parameters=mcmc_parameters,
             vi_parameters=vi_parameters,
             rejection_sampling_parameters=rejection_sampling_parameters,
+            importance_sampling_parameters=importance_sampling_parameters,
         )

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -14,6 +14,12 @@ from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+)
 from sbi.inference.potentials import likelihood_estimator_based_potential
 from sbi.inference.potentials.likelihood_based_potential import LikelihoodBasedPotential
 from sbi.inference.trainers.base import NeuralInference
@@ -302,6 +308,14 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[
+            Union[
+                MCMCPosteriorParameters,
+                VIPosteriorParameters,
+                RejectionPosteriorParameters,
+                ImportanceSamplingPosteriorParameters,
+            ]
+        ] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
@@ -333,7 +347,12 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
                 `RejectionPosterior`.
             importance_sampling_parameters: Additional kwargs passed to
                 `ImportanceSamplingPosterior`.
-
+            posterior_parameters: Configuration passed to the init method for the
+                posterior. Must be one of the following
+                - `VIPosteriorParameters`
+                - `ImportanceSamplingPosteriorParameters`
+                - `MCMCPosteriorParameters`
+                - `RejectionPosteriorParameters`
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
             (the returned log-probability is unnormalized).
@@ -343,6 +362,7 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
             density_estimator,
             prior,
             sample_with,
+            posterior_parameters,
             mcmc_method=mcmc_method,
             vi_method=vi_method,
             mcmc_parameters=mcmc_parameters,

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -6,6 +6,13 @@ from typing import Any, Callable, Dict, Literal, Optional, Union
 from torch.distributions import Distribution
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    DirectPosteriorParameters,
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+)
 from sbi.inference.trainers.npe.npe_c import NPE_C
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.sbi_types import TensorboardSummaryWriter
@@ -106,6 +113,15 @@ class MNPE(NPE_C):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[
+            Union[
+                DirectPosteriorParameters,
+                MCMCPosteriorParameters,
+                VIPosteriorParameters,
+                RejectionPosteriorParameters,
+                ImportanceSamplingPosteriorParameters,
+            ]
+        ] = None,
     ) -> NeuralPosterior:
         """Build posterior from the neural density estimator.
 
@@ -131,6 +147,13 @@ class MNPE(NPE_C):
                 RejectionPosterior`.
             importance_sampling_parameters: Additional kwargs passed to
                 `ImportanceSamplingPosterior`.
+            posterior_parameters: Configuration passed to the init method for the
+                posterior. Must be one of the following
+                - `VIPosteriorParameters`
+                - `ImportanceSamplingPosteriorParameters`
+                - `MCMCPosteriorParameters`
+                - `DirectPosteriorParameters`
+                - `RejectionPosteriorParameters`
 
         Returns:
             Posterior $p(\theta|x)$ with `.sample()` and `.log_prob()` methods.
@@ -146,6 +169,7 @@ class MNPE(NPE_C):
             density_estimator=density_estimator,
             prior=prior,
             sample_with=sample_with,
+            posterior_parameters=posterior_parameters,
             mcmc_method=mcmc_method,
             vi_method=vi_method,
             direct_sampling_parameters=direct_sampling_parameters,

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -599,23 +599,17 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
             posterior_parameters: Configuration for building the posterior.
         """
 
-        if sample_with == "rejection" and prior is None:
+        if (
+            sample_with == "rejection"
+            or isinstance(posterior_parameters, RejectionPosteriorParameters)
+        ) and prior is None:
             raise ValueError(
-                "You passed `sample_with='rejection' but you did not specify a "
-                "`prior`. Until sbi v0.22.0, this was interpreted as directly"
-                " sampling from the posterior. As of sbi v0.23.0, you instead have"
-                " to use `sample_with='direct'` to do so."
-            )
-        elif (
-            isinstance(posterior_parameters, RejectionPosteriorParameters)
-            and prior is None
-        ):
-            raise ValueError(
-                "You passed `posterior_parameters=RejectionPosteriorParameters`"
-                " but you did not specify a `prior`. Until sbi v0.22.0, this "
-                "was interpreted as directly sampling from the posterior. As of "
-                "sbi v0.23.0, you instead have to use "
-                "`posterior_parameters=DirectPosteriorParameters` to do so."
+                "You indicated sampling via rejection sampling but "
+                "haven't passed a prior. As of sbi v0.23.0, you either have"
+                " to pass a prior to perform rejection sampling using the prior"
+                " as proposal, or to use the posterior as proposal, you have to"
+                " use a DirectPosterior via `sample_with='direct' or"
+                " `posterior_parameters=DirectPosteriorParameters`."
             )
 
     def _loss(

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -18,6 +18,13 @@ from sbi.inference.posteriors import (
     DirectPosterior,
 )
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    DirectPosteriorParameters,
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+)
 from sbi.inference.potentials import posterior_estimator_based_potential
 from sbi.inference.potentials.posterior_based_potential import PosteriorBasedPotential
 from sbi.inference.trainers.base import NeuralInference, check_if_proposal_has_default_x
@@ -464,6 +471,15 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[
+            Union[
+                DirectPosteriorParameters,
+                MCMCPosteriorParameters,
+                VIPosteriorParameters,
+                RejectionPosteriorParameters,
+                ImportanceSamplingPosteriorParameters,
+            ]
+        ] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
@@ -499,6 +515,13 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
                 `RejectionPosterior`.
             importance_sampling_parameters: Additional kwargs passed to
                 `ImportanceSamplingPosterior`.
+            posterior_parameters: Configuration passed to the init method for the
+                posterior. Must be one of the following
+                - `VIPosteriorParameters`
+                - `ImportanceSamplingPosteriorParameters`
+                - `MCMCPosteriorParameters`
+                - `DirectPosteriorParameters`
+                - `RejectionPosteriorParameters`
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
@@ -508,6 +531,7 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
             density_estimator,
             prior,
             sample_with,
+            posterior_parameters,
             mcmc_method=mcmc_method,
             vi_method=vi_method,
             mcmc_parameters=mcmc_parameters,

--- a/sbi/inference/trainers/npse/npse.py
+++ b/sbi/inference/trainers/npse/npse.py
@@ -7,6 +7,7 @@ from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import VectorFieldPosteriorParameters
 from sbi.inference.trainers.npse.vector_field_inference import (
     VectorFieldEstimatorBuilder,
     VectorFieldTrainer,
@@ -80,6 +81,7 @@ class NPSE(VectorFieldTrainer):
         prior: Optional[Distribution] = None,
         sample_with: Literal["ode", "sde"] = "sde",
         vectorfield_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[VectorFieldPosteriorParameters] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the vector field estimator.
 
@@ -103,7 +105,8 @@ class NPSE(VectorFieldTrainer):
                 probabilistic ODE with a numerical ODE solver.
             vectorfield_sampling_parameters: Additional keyword arguments passed to
                 `VectorFieldPosterior`.
-
+            posterior_parameters: Configuration passed to the init method for
+                VectorFieldPosterior.
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
@@ -113,6 +116,7 @@ class NPSE(VectorFieldTrainer):
             prior=prior,
             sample_with=sample_with,
             vectorfield_sampling_parameters=vectorfield_sampling_parameters,
+            posterior_parameters=posterior_parameters,
         )
 
     def _build_default_nn_fn(self, **kwargs) -> VectorFieldEstimatorBuilder:

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -14,6 +14,12 @@ from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+)
 from sbi.inference.potentials import ratio_estimator_based_potential
 from sbi.inference.potentials.ratio_based_potential import RatioBasedPotential
 from sbi.inference.trainers.base import NeuralInference
@@ -345,6 +351,14 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
         vi_parameters: Optional[Dict[str, Any]] = None,
         rejection_sampling_parameters: Optional[Dict[str, Any]] = None,
         importance_sampling_parameters: Optional[Dict[str, Any]] = None,
+        posterior_parameters: Optional[
+            Union[
+                MCMCPosteriorParameters,
+                VIPosteriorParameters,
+                RejectionPosteriorParameters,
+                ImportanceSamplingPosteriorParameters,
+            ]
+        ] = None,
     ) -> NeuralPosterior:
         r"""Build posterior from the neural density estimator.
 
@@ -379,6 +393,12 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
                 `RejectionPosterior`.
             importance_sampling_parameters: Additional kwargs passed to
                 `ImportanceSamplingPosterior`.
+            posterior_parameters: Configuration passed to the init method for the
+                posterior. Must be one of the following:
+                - `VIPosteriorParameters`
+                - `ImportanceSamplingPosteriorParameters`
+                - `MCMCPosteriorParameters`
+                - `RejectionPosteriorParameters`
 
         Returns:
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods
@@ -388,6 +408,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
             density_estimator,
             prior,
             sample_with,
+            posterior_parameters,
             mcmc_method=mcmc_method,
             vi_method=vi_method,
             mcmc_parameters=mcmc_parameters,

--- a/sbi/utils/typechecks.py
+++ b/sbi/utils/typechecks.py
@@ -12,12 +12,20 @@ def is_int(x):
     return isinstance(x, int)
 
 
+def is_float(x):
+    return isinstance(x, float)
+
+
 def is_positive_int(x):
     return is_int(x) and x > 0
 
 
 def is_nonnegative_int(x):
     return is_int(x) and x >= 0
+
+
+def is_positive_float(x):
+    return is_float(x) and x > 0
 
 
 def is_power_of_two(n):

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -197,12 +197,10 @@ def test_training_and_mcmc_on_device(
         elif sampling_method in ["rejection", "direct"]:
             # all other cases: rejection, direct
             posterior = inferer.build_posterior(
+                prior=prior
+                if sampling_method == "rejection" and method == NPE_C
+                else None,
                 sample_with=sampling_method,
-                rejection_sampling_parameters=(
-                    {"proposal": prior}
-                    if sampling_method == "rejection" and method == NPE_C
-                    else {}
-                ),
             )
         else:
             # build potential for NLE or NRE and construct ImportanceSamplingPosterior
@@ -685,7 +683,6 @@ def test_to_method_on_posteriors(device: str, sampling_method: str):
         posterior = inference.build_posterior(
             density_estimator=estimator,
             prior=prior,
-            rejection_sampling_parameters={"proposal": prior},
             sample_with=sampling_method,
         )
     else:

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -11,6 +11,7 @@ from torch.distributions import Independent, MultivariateNormal, Uniform
 from sbi.inference import (
     FMPE,
     NLE_A,
+    NPE,
     NPE_A,
     NPE_C,
     NPSE,
@@ -20,6 +21,7 @@ from sbi.inference import (
     NRE_C,
     DirectPosterior,
 )
+from sbi.inference.posteriors.posterior_parameters import RejectionPosteriorParameters
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,
     linear_gaussian,
@@ -385,3 +387,24 @@ def test_build_posterior_raises_with_invalid_estimator():
 
     inference.train(max_num_epochs=1)
     inference.build_posterior(density_estimator=nn.Module())
+
+
+@pytest.mark.xfail(
+    raises=ValueError,
+    reason="Prior must be passed through build_posterior method for rejection"
+    " sampling in NPE",
+)
+def test_build_posterior_raises_error_for_rejection_sampling():
+    def simulator(theta):
+        return 1.0 + theta + torch.randn(theta.shape, device=theta.device) * 0.1
+
+    num_dim = 3
+    prior = BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    theta = prior.sample((300,))
+    x = simulator(theta)
+
+    inference = NPE(prior=prior)
+    inference.append_simulations(theta, x)
+
+    inference.train(max_num_epochs=1)
+    inference.build_posterior(posterior_parameters=RejectionPosteriorParameters())

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -1,3 +1,6 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
 import inspect
 from dataclasses import fields
 

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -20,7 +20,7 @@ from sbi.inference.potentials.vector_field_potential import VectorFieldBasedPote
 
 
 @pytest.mark.parametrize(
-    ("parameter_dataclass", "init_target_class", "skipped_arguments"),
+    ("parameter_dataclass", "init_target_class", "skipped_fields_and_parameters"),
     [
         (
             DirectPosteriorParameters,
@@ -76,23 +76,24 @@ from sbi.inference.potentials.vector_field_potential import VectorFieldBasedPote
     ],
 )
 def test_signature_consistency(
-    parameter_dataclass, init_target_class, skipped_arguments
+    parameter_dataclass, init_target_class, skipped_fields_and_parameters
 ):
     dataclass_signature = inspect.signature(parameter_dataclass)
     class_signature = inspect.signature(init_target_class.__init__)
 
-    skipped_arguments.add("self")
+    skipped_fields_and_parameters.add("self")
 
     class_dict = {
         name: param
         for name, param in class_signature.parameters.items()
-        if name not in skipped_arguments and param.kind != inspect.Parameter.VAR_KEYWORD
+        if name not in skipped_fields_and_parameters
+        and param.kind != inspect.Parameter.VAR_KEYWORD
     }
 
     dataclass_dict = {
         name: param
         for name, param in dataclass_signature.parameters.items()
-        if name not in skipped_arguments
+        if name not in skipped_fields_and_parameters
     }
 
     # Compare if the dataclass and posterior_class have the same argument names

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -16,10 +16,11 @@ from sbi.inference.posteriors.posterior_parameters import (
 from sbi.inference.posteriors.rejection_posterior import RejectionPosterior
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.posteriors.vi_posterior import VIPosterior
+from sbi.inference.potentials.vector_field_potential import VectorFieldBasedPotential
 
 
 @pytest.mark.parametrize(
-    ("parameter_dataclass", "posterior_class", "skipped_arguments"),
+    ("parameter_dataclass", "init_target_class", "skipped_arguments"),
     [
         (
             DirectPosteriorParameters,
@@ -49,13 +50,36 @@ from sbi.inference.posteriors.vi_posterior import VIPosterior
         (
             VectorFieldPosteriorParameters,
             VectorFieldPosterior,
-            {"vector_field_estimator", "device", "prior", "sample_with"},
+            {
+                "vector_field_estimator",
+                "device",
+                "prior",
+                "sample_with",
+                "iid_method",
+                "iid_params",
+                "neural_ode_backend",
+                "neural_ode_kwargs",
+            },
+        ),
+        (
+            VectorFieldPosteriorParameters,
+            VectorFieldBasedPotential,
+            {
+                "vector_field_estimator",
+                "device",
+                "prior",
+                "x_o",
+                "enable_transform",
+                "max_sampling_batch_size",
+            },
         ),
     ],
 )
-def test_signature_consistency(parameter_dataclass, posterior_class, skipped_arguments):
+def test_signature_consistency(
+    parameter_dataclass, init_target_class, skipped_arguments
+):
     dataclass_signature = inspect.signature(parameter_dataclass)
-    class_signature = inspect.signature(posterior_class.__init__)
+    class_signature = inspect.signature(init_target_class.__init__)
 
     skipped_arguments.add("self")
 
@@ -90,7 +114,7 @@ def test_signature_consistency(parameter_dataclass, posterior_class, skipped_arg
             dataclass_dict[name].annotation,
         )
         assert class_default == dataclass_default, (
-            f"Default mismatch for '{name}': "
+            f"Default value mismatch for '{name}': "
             f"class={class_default}, dataclass={dataclass_default}"
         )
         assert class_annotation == dataclass_annotation, (

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -85,6 +85,7 @@ def test_signature_consistency(
     class_signature = inspect.signature(init_target_class.__init__)
 
     skipped_fields_and_parameters.add("self")
+    skipped_fields_and_parameters.add("x_shape")
 
     class_dict = {
         name: param

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -1,0 +1,99 @@
+import inspect
+
+import pytest
+
+from sbi.inference.posteriors.direct_posterior import DirectPosterior
+from sbi.inference.posteriors.importance_posterior import ImportanceSamplingPosterior
+from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    DirectPosteriorParameters,
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+    VectorFieldPosteriorParameters,
+)
+from sbi.inference.posteriors.rejection_posterior import RejectionPosterior
+from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
+from sbi.inference.posteriors.vi_posterior import VIPosterior
+
+
+@pytest.mark.parametrize(
+    ("parameter_dataclass", "posterior_class", "skipped_arguments"),
+    [
+        (
+            DirectPosteriorParameters,
+            DirectPosterior,
+            {"posterior_estimator", "prior", "device"},
+        ),
+        (
+            ImportanceSamplingPosteriorParameters,
+            ImportanceSamplingPosterior,
+            {"potential_fn", "proposal", "device"},
+        ),
+        (
+            MCMCPosteriorParameters,
+            MCMCPosterior,
+            {"potential_fn", "proposal", "device", "theta_transform"},
+        ),
+        (
+            RejectionPosteriorParameters,
+            RejectionPosterior,
+            {"potential_fn", "device", "proposal"},
+        ),
+        (
+            VIPosteriorParameters,
+            VIPosterior,
+            {"potential_fn", "prior", "theta_transform", "device"},
+        ),
+        (
+            VectorFieldPosteriorParameters,
+            VectorFieldPosterior,
+            {"vector_field_estimator", "device", "prior", "sample_with"},
+        ),
+    ],
+)
+def test_signature_consistency(parameter_dataclass, posterior_class, skipped_arguments):
+    dataclass_signature = inspect.signature(parameter_dataclass)
+    class_signature = inspect.signature(posterior_class.__init__)
+
+    skipped_arguments.add("self")
+
+    class_dict = {
+        name: param
+        for name, param in class_signature.parameters.items()
+        if name not in skipped_arguments and param.kind != inspect.Parameter.VAR_KEYWORD
+    }
+
+    dataclass_dict = {
+        name: param
+        for name, param in dataclass_signature.parameters.items()
+        if name not in skipped_arguments
+    }
+
+    # Compare if the dataclass and posterior_class have the same argument names
+    assert class_dict.keys() == dataclass_dict.keys(), (
+        f"Parameter mismatch:\n"
+        f"In class but not dataclass: {class_dict.keys() - dataclass_dict.keys()}\n"
+        f"In dataclass but not class: {dataclass_dict.keys() - class_dict.keys()}"
+    )
+
+    # Compare if the dataclass and posterior_class
+    # have the same annotation and default value
+    for name in class_dict:
+        class_default, class_annotation = (
+            class_dict[name].default,
+            class_dict[name].annotation,
+        )
+        dataclass_default, dataclass_annotation = (
+            dataclass_dict[name].default,
+            dataclass_dict[name].annotation,
+        )
+        assert class_default == dataclass_default, (
+            f"Default mismatch for '{name}': "
+            f"class={class_default}, dataclass={dataclass_default}"
+        )
+        assert class_annotation == dataclass_annotation, (
+            f"Annotation mismatch for '{name}': "
+            f"class={class_annotation}, dataclass={dataclass_annotation}"
+        )


### PR DESCRIPTION
### Problem
Currently, sbi uses string-typed code to pass configuration to the `build_posterior` methods of trainer classes. This approach makes it difficult for users to understand which values are required.

### Solution
This pull request builds upon https://github.com/sbi-dev/sbi/pull/1610 by introducing data classes for creating posterior instances. These changes bring:

#### 1. Type safety and IDE auto-completion for users

Instead of going over the documentation for acceptable fields, users now get auto-completion and static checks via `dataclass` definitions:
<img width="1101" height="355" alt="{279F5DCF-2CF7-42E1-9FC1-22604E485576}" src="https://github.com/user-attachments/assets/455b254c-6b48-4a97-b525-fadf94e95b0f" />

#### 2. Includes conversions for primitive data type values (`int`, `bool`, and `float`) 
```python
from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters

params = MCMCPosteriorParameters(num_chains="4", warmup_steps="100", thin=1.0)
inference.build_posterior(posterior_parameters=params)
```
The fields will be automatically cast to the correct types.

#### 3. Validation for each field before being passed to posterior classes.
```python
from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters

params=MCMCPosteriorParameters(num_chains=-1)
# Raises ValueError: num_chains must be positive
inference.build_posterior(posterior_parameters=params)
```

#### 4. Single unified parameter for passing posterior class parameters from the build_posterior method
Replaces multiple separate keyword arguments (`mcmc_parameters`, `vi_parameters`, etc.) with a single posterior_parameters field.
```python
from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters

inference.build_posterior(
    posterior_parameters=MCMCPosteriorParameters(num_chains=10, warmup_steps=100)
)
```

#### 5. Changes maintain backward compatibility with the existing string-based configuration for current users.
```python
inference.build_posterior(mcmc_parameters={"warmup_steps": 100, "num_chains": 10})
```
