### PR TITLE
Update append_simulations return type to Self

### DIFF
--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -14,6 +14,7 @@ from torch.distributions import Distribution
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard.writer import SummaryWriter
+from typing_extensions import Self
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
@@ -215,7 +216,7 @@ class NeuralInference(ABC):
         from_round: int = 0,
         algorithm: Optional[str] = None,
         data_device: Optional[str] = None,
-    ) -> "NeuralInference":
+    ) -> Self:
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -12,6 +12,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
+from typing_extensions import Self
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials import likelihood_estimator_based_potential
@@ -83,7 +84,7 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
         from_round: int = 0,
         algorithm: str = "SNLE",
         data_device: Optional[str] = None,
-    ) -> "LikelihoodEstimatorTrainer":
+    ) -> Self:
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).
@@ -117,8 +118,8 @@ class LikelihoodEstimatorTrainer(NeuralInference, ABC):
                 "NLE gives systematically wrong results when exclude_invalid_x=True.",
                 stacklevel=2,
             )
-        # pyright false positive, will be fixed with pyright 1.1.310
-        return super().append_simulations(  # type: ignore
+
+        return super().append_simulations(
             theta=theta,
             x=x,
             exclude_invalid_x=exclude_invalid_x,

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -13,6 +13,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
+from typing_extensions import Self
 
 from sbi.inference.posteriors import (
     DirectPosterior,
@@ -109,7 +110,7 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
         proposal: Optional[DirectPosterior] = None,
         exclude_invalid_x: Optional[bool] = None,
         data_device: Optional[str] = None,
-    ) -> "PosteriorEstimatorTrainer":
+    ) -> Self:
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -6,11 +6,12 @@ from typing import Callable, Dict, Optional, Union
 import torch
 from pyknos.mdn.mdn import MultivariateGaussianMDN as mdn
 from pyknos.nflows.transforms import CompositeTransform
-from torch import Tensor, eye, nn, ones
+from torch import Tensor, eye, ones
 from torch.distributions import Distribution, MultivariateNormal, Uniform
 
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
+from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
@@ -113,7 +114,7 @@ class NPE_C(PosteriorEstimatorTrainer):
         retrain_from_scratch: bool = False,
         show_train_summary: bool = False,
         dataloader_kwargs: Optional[Dict] = None,
-    ) -> nn.Module:
+    ) -> ConditionalDensityEstimator:
         r"""Return density estimator that approximates the distribution $p(\theta|x)$.
 
         Args:

--- a/sbi/inference/trainers/npse/vector_field_inference.py
+++ b/sbi/inference/trainers/npse/vector_field_inference.py
@@ -12,6 +12,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
+from typing_extensions import Self
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
@@ -123,7 +124,7 @@ class VectorFieldTrainer(NeuralInference, ABC):
         proposal: Optional[DirectPosterior] = None,
         exclude_invalid_x: Optional[bool] = None,
         data_device: Optional[str] = None,
-    ) -> "VectorFieldTrainer":
+    ) -> Self:
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -12,6 +12,7 @@ from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.optim.adam import Adam
 from torch.utils.tensorboard.writer import SummaryWriter
+from typing_extensions import Self
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials import ratio_estimator_based_potential
@@ -113,7 +114,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
         from_round: int = 0,
         algorithm: str = "SNRE",
         data_device: Optional[str] = None,
-    ) -> "RatioEstimatorTrainer":
+    ) -> Self:
         r"""Store parameters and simulation outputs to use them for later training.
 
         Data are stored as entries in lists for each type of variable (parameter/data).
@@ -147,7 +148,7 @@ class RatioEstimatorTrainer(NeuralInference, ABC):
                 stacklevel=2,
             )
 
-        return super().append_simulations(  # type: ignore
+        return super().append_simulations(
             theta=theta,
             x=x,
             exclude_invalid_x=exclude_invalid_x,


### PR DESCRIPTION
This PR fixes return type mismatch between `NeuralInference` base class and its subclasses( `NLE`, `NPE`, and `vector_field_inference`) by updating the return type annotation for the `append_simulations` method to [Self](https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.Self).

With the current implementation, `pyright` displays an error because the type checker assumes there is a type mismatch when trainer subclasses call the `append_simulations` method from the base class. This occurs because the base class method is annotated to return the base type `NeuralInference`, while subclasses return more specific types. Using the `Self` annotation resolves this problem as it correctly infers the return types.

Fixes: https://github.com/sbi-dev/sbi/issues/1453