### PR TITLE
1561 computation of denoising posterior precision matrix in jac method score fn iid

### DIFF
--- a/sbi/inference/potentials/score_fn_iid.py
+++ b/sbi/inference/potentials/score_fn_iid.py
@@ -727,7 +727,7 @@ class JacCorrectedScoreFn(BaseGaussCorrectedScoreFunction):
         std = self.vector_field_estimator.std_fn(time)
         cov0 = std**2 * jac + torch.eye(d)[None, None, :, :]
 
-        denoising_posterior_precision = m**2 / std**2 + torch.inverse(cov0)
+        denoising_posterior_precision = m**2 / std**2 * torch.inverse(cov0)
 
         return denoising_posterior_precision
 

--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -357,18 +357,21 @@ def test_vector_field_sde_ode_sampling_equivalence(vector_field_trained_model):
 # TODO: Currently, c2st is too high for FMPE (e.g., > 3 number of observations),
 # so some tests are skipped so far. This seems to be an issue with the
 # neural network architecture and can be addressed in PR #1501
-@pytest.mark.skip(
-    reason="c2st too high for some cases, has to be fixed in PR #1501 or #1544"
-)
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "iid_method, num_trial",
     [
-        pytest.param("fnpe", 3, id="fnpe-2trials"),
+        pytest.param(
+            "fnpe",
+            3,
+            id="fnpe-3trials",
+            marks=pytest.mark.skip(reason="c2st to high, fixed in PR #1501/1544"),
+        ),
         pytest.param("gauss", 3, id="gauss-3trials"),
         pytest.param("auto_gauss", 8, id="auto_gauss-8trials"),
         pytest.param("auto_gauss", 16, id="auto_gauss-16trials"),
         pytest.param("jac_gauss", 8, id="jac_gauss-8trials"),
+        pytest.param("jac_gauss", 16, id="jac_gauss-16trials"),
     ],
 )
 def test_vector_field_iid_inference(


### PR DESCRIPTION
Fixes #1561 