### PR TITLE
Use TypeAlias and consistent naming for sbi types

### DIFF
--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -14,7 +14,7 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
@@ -36,7 +36,7 @@ class MNLE(LikelihoodEstimatorTrainer):
         density_estimator: Union[str, Callable] = "mnle",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize MNLE.

--- a/sbi/inference/trainers/nle/nle_a.py
+++ b/sbi/inference/trainers/nle/nle_a.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Union
 from torch.distributions import Distribution
 
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
@@ -24,7 +24,7 @@ class NLE_A(LikelihoodEstimatorTrainer):
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize Neural Likelihood Estimation.

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -15,7 +15,7 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.trainers.npe.npe_c import NPE_C
 from sbi.neural_nets.estimators import MixedDensityEstimator
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
@@ -34,7 +34,7 @@ class MNPE(NPE_C):
         density_estimator: Union[str, Callable] = "mnpe",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize Mixed Neural Posterior Estimation (MNPE).

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -13,9 +13,11 @@ from torch import Tensor
 from torch.distributions import Distribution, MultivariateNormal
 
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
-from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
+from sbi.inference.trainers.npe.npe_base import (
+    PosteriorEstimatorTrainer,
+)
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
-from sbi.sbi_types import TensorboardSummaryWriter, TorchModule
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils import torchutils
 from sbi.utils.sbiutils import (
     batched_mixture_mv,
@@ -51,7 +53,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         num_components: int = 10,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NPE-A [1].
@@ -231,7 +233,7 @@ class NPE_A(PosteriorEstimatorTrainer):
 
     def correct_for_proposal(
         self,
-        density_estimator: Optional[TorchModule] = None,
+        density_estimator: Optional[torch.nn.Module] = None,
     ) -> "NPE_A_MDN":
         r"""Build mixture of Gaussians that approximates the posterior.
 
@@ -285,7 +287,7 @@ class NPE_A(PosteriorEstimatorTrainer):
 
     def build_posterior(
         self,
-        density_estimator: Optional[TorchModule] = None,
+        density_estimator: Optional[torch.nn.Module] = None,
         prior: Optional[Distribution] = None,
         **kwargs,
     ) -> "DirectPosterior":

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -10,7 +10,7 @@ from torch.distributions import Distribution
 import sbi.utils as utils
 from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
 from sbi.neural_nets.estimators.shape_handling import reshape_to_sample_batch_event
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 
 
@@ -36,7 +36,7 @@ class NPE_B(PosteriorEstimatorTrainer):
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NPE-B.

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -16,7 +16,7 @@ from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils import (
     batched_mixture_mv,
     batched_mixture_vmv,
@@ -70,7 +70,7 @@ class NPE_C(PosteriorEstimatorTrainer):
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NPE-C.

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -9,7 +9,7 @@ from torch.distributions import Distribution
 
 from sbi.inference.trainers.nre.nre_a import NRE_A
 from sbi.inference.trainers.nre.nre_base import RatioEstimatorBuilder
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
@@ -32,7 +32,7 @@ class BNRE(NRE_A):
         classifier: Union[str, RatioEstimatorBuilder] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Balanced neural ratio estimation (BNRE).

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -11,7 +11,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorBuilder,
     RatioEstimatorTrainer,
 )
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
@@ -29,7 +29,7 @@ class NRE_A(RatioEstimatorTrainer):
         classifier: Union[str, RatioEstimatorBuilder] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NRE_A.

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -11,7 +11,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorBuilder,
     RatioEstimatorTrainer,
 )
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
@@ -29,7 +29,7 @@ class NRE_B(RatioEstimatorTrainer):
         classifier: Union[str, RatioEstimatorBuilder] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NRE_B.

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -11,7 +11,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorBuilder,
     RatioEstimatorTrainer,
 )
-from sbi.sbi_types import TensorboardSummaryWriter
+from sbi.sbi_types import TensorBoardSummaryWriter
 from sbi.utils.sbiutils import del_entries
 from sbi.utils.torchutils import assert_all_finite
 
@@ -43,7 +43,7 @@ class NRE_C(RatioEstimatorTrainer):
         classifier: Union[str, RatioEstimatorBuilder] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[TensorboardSummaryWriter] = None,
+        summary_writer: Optional[TensorBoardSummaryWriter] = None,
         show_progress_bars: bool = True,
     ):
         r"""Initialize NRE-C.

--- a/sbi/sbi_types.py
+++ b/sbi/sbi_types.py
@@ -1,7 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from typing import NewType, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
@@ -9,7 +9,6 @@ from pyro.distributions import TransformedDistribution  # type: ignore
 from torch import Tensor
 from torch.distributions import Distribution
 from torch.distributions.transforms import Transform
-from torch.nn import Module
 from torch.utils.tensorboard.writer import SummaryWriter
 from typing_extensions import TypeAlias
 
@@ -28,24 +27,20 @@ transform_types = Optional[
     ]
 ]
 
-# Define alias types because otherwise, the documentation by mkdocs became very long and
-# made the website look ugly.
-TensorboardSummaryWriter = NewType("Writer", SummaryWriter)
-# TorchTransform = NewType("torch Transform", Transform)
-TorchModule = NewType("Module", Module)
-TorchDistribution = NewType("torch Distribution", Distribution)
+# Define alias types for better readability in type hints
 # See PEP 613 for the reason why we need to use TypeAlias here.
+TensorBoardSummaryWriter: TypeAlias = SummaryWriter
+TorchDistribution: TypeAlias = Distribution
 TorchTransform: TypeAlias = Transform
 PyroTransformedDistribution: TypeAlias = TransformedDistribution
-TorchTensor = NewType("Tensor", Tensor)
+TorchTensor: TypeAlias = Tensor
 
 __all__ = [
     "Array",
     "Shape",
     "OneOrMore",
     "ScalarFloat",
-    "TensorboardSummaryWriter",
-    "TorchModule",
+    "TensorBoardSummaryWriter",
     "TorchTransform",
     "transform_types",
     "TorchDistribution",

--- a/sbi/sbi_types.py
+++ b/sbi/sbi_types.py
@@ -27,7 +27,7 @@ transform_types = Optional[
     ]
 ]
 
-# Define alias types for better readability in type hints
+# Define alias types for better readability in type hints and checking.
 # See PEP 613 for the reason why we need to use TypeAlias here.
 TensorBoardSummaryWriter: TypeAlias = SummaryWriter
 TorchDistribution: TypeAlias = Distribution


### PR DESCRIPTION
In PR #1633, I noticed that the typing module defines `NewType` instead of using `TypeAlias`. For our purposes, an alias is just fine and comes without consequences for documentation rendering and type checking (`NewType` does not implicitly perform type checking according to the actual underlying type). Therefore: 

- Replace NewType with TypeAlias for SummaryWriter, Distribution, Tensor, Transform.
- Rename TensorboardSummaryWriter → TensorBoardSummaryWriter.
- Remove unused TorchModule alias; use torch.nn.Module where needed (e.g., NPE_A.build_posterior).
- Update imports/annotations across trainers to new alias.

Notes: 
- Type-only refactor; no behavior changes.
- Breaking rename: external imports of TensorboardSummaryWriter/TorchModule must update.