### PR TITLE
Posterior parameters doc

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,4 +1,4 @@
-{{ fullname }}
+{{ objname }}
 {{ underline }}
 
 .. autoclass:: {{ fullname }}

--- a/docs/how_to_guide/19_posterior_parameters.ipynb
+++ b/docs/how_to_guide/19_posterior_parameters.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "inference = NRE(prior=prior)\n",
     "inference.append_simulations(theta, x)\n",
-    "inference.train()"
+    "inference.train();"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters\n",
+    "from sbi.inference.posteriors import MCMCPosteriorParameters\n",
     "\n",
     "params = MCMCPosteriorParameters(\n",
     "    method=\"slice_np_vectorized\",\n",

--- a/docs/sbi.rst
+++ b/docs/sbi.rst
@@ -144,3 +144,20 @@ Other utilities
    sbi.analysis.conditional_corrcoeff
    sbi.analysis.conditional_potential
    sbi.analysis.ActiveSubspace
+
+
+Posterior Parameters
+--------------------
+
+.. currentmodule:: sbi.inference.posteriors.posterior_parameters
+
+.. autosummary::
+   :toctree: reference/_autosummary
+   :nosignatures:
+
+   DirectPosteriorParameters
+   ImportanceSamplingPosteriorParameters
+   MCMCPosteriorParameters
+   RejectionPosteriorParameters
+   VectorFieldPosteriorParameters
+   VIPosteriorParameters

--- a/docs/sbi.rst
+++ b/docs/sbi.rst
@@ -97,6 +97,21 @@ Posteriors
    sbi.inference.EnsemblePosterior
 
 
+Posterior Parameters
+--------------------
+
+.. autosummary::
+   :toctree: reference/_autosummary
+   :nosignatures:
+
+   sbi.inference.posteriors.DirectPosteriorParameters
+   sbi.inference.posteriors.ImportanceSamplingPosteriorParameters
+   sbi.inference.posteriors.MCMCPosteriorParameters
+   sbi.inference.posteriors.RejectionPosteriorParameters
+   sbi.inference.posteriors.VectorFieldPosteriorParameters
+   sbi.inference.posteriors.VIPosteriorParameters
+
+
 Diagnostics
 -----------
 
@@ -144,20 +159,3 @@ Other utilities
    sbi.analysis.conditional_corrcoeff
    sbi.analysis.conditional_potential
    sbi.analysis.ActiveSubspace
-
-
-Posterior Parameters
---------------------
-
-.. currentmodule:: sbi.inference.posteriors.posterior_parameters
-
-.. autosummary::
-   :toctree: reference/_autosummary
-   :nosignatures:
-
-   DirectPosteriorParameters
-   ImportanceSamplingPosteriorParameters
-   MCMCPosteriorParameters
-   RejectionPosteriorParameters
-   VectorFieldPosteriorParameters
-   VIPosteriorParameters

--- a/sbi/inference/posteriors/__init__.py
+++ b/sbi/inference/posteriors/__init__.py
@@ -5,6 +5,14 @@ from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.posteriors.ensemble_posterior import EnsemblePosterior
 from sbi.inference.posteriors.importance_posterior import ImportanceSamplingPosterior
 from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
+from sbi.inference.posteriors.posterior_parameters import (
+    DirectPosteriorParameters,
+    ImportanceSamplingPosteriorParameters,
+    MCMCPosteriorParameters,
+    RejectionPosteriorParameters,
+    VIPosteriorParameters,
+    VectorFieldPosteriorParameters,
+)
 from sbi.inference.posteriors.rejection_posterior import RejectionPosterior
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.posteriors.vi_posterior import VIPosterior
@@ -17,4 +25,10 @@ __all__ = [
     "RejectionPosterior",
     "VectorFieldPosterior",
     "VIPosterior",
+    "DirectPosteriorParameters",
+    "ImportanceSamplingPosteriorParameters",
+    "MCMCPosteriorParameters",
+    "RejectionPosteriorParameters",
+    "VectorFieldPosteriorParameters",
+    "VIPosteriorParameters",
 ]


### PR DESCRIPTION
This pull request adds the `PosteriorParameters` dataclasses to the Sphinx documentation.
It also updates the class template to display shorter titles to avoid long names being cut off when displaying full paths.