### PR TITLE
docs: add posterior parameters dataclass how to guide

### DIFF
--- a/docs/how_to_guide.rst
+++ b/docs/how_to_guide.rst
@@ -79,3 +79,12 @@ Visualization
    :maxdepth: 1
 
    how_to_guide/05_conditional_distributions.ipynb
+
+
+Posterior Parameters
+--------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   how_to_guide/19_posterior_parameters.ipynb

--- a/docs/how_to_guide/19_posterior_parameters.ipynb
+++ b/docs/how_to_guide/19_posterior_parameters.ipynb
@@ -29,7 +29,7 @@
    "id": "8c4df01a",
    "metadata": {},
    "source": [
-    "# Usage"
+    "## Usage"
    ]
   },
   {


### PR DESCRIPTION
This PR adds the how-to guide for using posterior parameters dataclasses to the Sphinx documentation.