### PR TITLE
Training dataclasses

### DIFF
--- a/sbi/inference/trainers/_contracts.py
+++ b/sbi/inference/trainers/_contracts.py
@@ -1,0 +1,153 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+"""
+Typed contracts shared by trainer implementations.
+
+This module centralizes small, import-light dataclasses and type aliases that
+express trainer-facing contracts. Keep runtime imports minimal to avoid cycles
+and heavy dependencies; prefer forward-referenced annotations.
+
+Notes
+- Do not import torch/torch.distributions at runtime here.
+- Only use typing/dataclasses; rely on from __future__ import annotations so
+    forward references like "Tensor" stay as strings at runtime.
+- Keep these structures stable and documented; they define cross-trainer
+    expectations and enable LSP-friendly hooks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
+
+if TYPE_CHECKING:  # import-heavy deps only for type checkers
+    from torch import Tensor
+    from torch.distributions import Distribution
+
+    from sbi.inference.posteriors.base_posterior import NeuralPosterior
+
+# ---------------------------------------------------------------------------
+# Contexts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StartIndexContext:
+    """Inputs for computing the start index of training.
+
+    Consolidates parameters that previously varied across subclasses, enabling a
+    single base signature: `_get_start_index(ctx: StartIndexContext) -> int`.
+
+    Fields are optional where method families differ; subclasses read only what
+    they need.
+    """
+
+    # Common across methods (e.g., NLE/NRE);
+    discard_prior_samples: bool
+
+    # SNPE-specific knobs (optional, read if relevant):
+    force_first_round_loss: Optional[bool] = None
+    use_non_atomic_loss: Optional[bool] = None
+    ran_final_round: Optional[bool] = None
+
+    # Generic training state:
+    resume_training: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Training configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrainConfig:
+    """Configuration for the core training path.
+
+    This captures loop-level hyperparameters and toggles that are independent of
+    any specific estimator family. Subclass `train(...kwargs)` wrappers translate
+    user kwargs into this config and delegate to the base core.
+    """
+
+    # Data & optimization
+    training_batch_size: int
+    learning_rate: float
+
+    # Loop controls
+    validation_fraction: float
+    stop_after_epochs: int
+    max_num_epochs: int
+
+    # Lifecycle
+    resume_training: bool
+    retrain_from_scratch: bool
+
+    # UX
+    show_train_summary: bool
+
+    # Regularization / safety
+    clip_max_norm: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Typed loss arguments per estimator family
+# ---------------------------------------------------------------------------
+
+# To avoid runtime imports, we rely on forward references (strings) for types
+# like "Tensor", "Distribution", and "NeuralPosterior".
+
+
+@dataclass(frozen=True)
+class LossArgsNRE:
+    """Typed args for ratio-estimation losses (NRE family)."""
+
+    num_atoms: int
+
+
+@dataclass(frozen=True)
+class LossArgsBNRE(LossArgsNRE):
+    regularization_strength: float
+
+
+@dataclass(frozen=True)
+class LossArgsNRE_C(LossArgsNRE):
+    gamma: float
+
+
+@dataclass(frozen=True)
+class LossArgsNPE:
+    """Typed args for posterior-estimation losses (NPE family).
+
+    proposal may be a torch.distributions.Distribution or a NeuralPosterior;
+    calibration_kernel is callable and may return a Tensor or adjust sampling.
+    """
+
+    proposal: Optional[Union["Distribution", "NeuralPosterior"]] = None
+    calibration_kernel: Optional[Callable[..., "Tensor"]] = None
+    force_first_round_loss: bool = False
+
+
+@dataclass(frozen=True)
+class LossArgsVF:
+    """Typed args for vector-field estimation losses (VF family)."""
+
+    proposal: Optional[Union["Distribution", "NeuralPosterior"]] = None
+    calibration_kernel: Optional[Callable[..., "Tensor"]] = None
+    times: Optional["Tensor"] = None
+    force_first_round_loss: bool = False
+
+
+# Union/TypeVar helpers if generics are desired in core signatures
+LossArgs = Union[LossArgsNRE, LossArgsNPE, LossArgsVF]
+LossArgsT = TypeVar("LossArgsT", LossArgsNRE, LossArgsNPE, LossArgsVF)
+
+
+__all__ = [
+    "StartIndexContext",
+    "TrainConfig",
+    "LossArgsNRE",
+    "LossArgsNPE",
+    "LossArgsVF",
+    "LossArgs",
+    "LossArgsT",
+]

--- a/sbi/inference/trainers/_contracts.py
+++ b/sbi/inference/trainers/_contracts.py
@@ -91,10 +91,10 @@ class LossArgsNRE:
         num_atoms: Number of atoms to use for classification.
     """
 
-    num_atoms: int
+    num_atoms: int = 10
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class LossArgsBNRE(LossArgsNRE):
     r"""
     Typed args for balanced neural ratio estimation losses (BNRE).
@@ -107,7 +107,7 @@ class LossArgsBNRE(LossArgsNRE):
     regularization_strength: float
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class LossArgsNRE_C(LossArgsNRE):
     r"""
     Typed args for NRE_C losses.

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -106,7 +106,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         self._ran_final_round = False
 
         # WARNING: sneaky trick ahead. We proxy the parent's `train` here,
-        # requiring the signature to have `num_atoms`, save it for use below, and
+        # requiring the signature to have `num_components`, save it for use below, and
         # continue. It's sneaky because we are using the object (self) as a namespace
         # to pass arguments between functions, and that's implicit state management.
         kwargs = del_entries(

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -2,6 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from abc import ABC, abstractmethod
+from dataclasses import asdict
 from typing import Any, Callable, Dict, Literal, Optional, Sequence, Tuple, Union
 from warnings import warn
 
@@ -21,7 +22,9 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.potentials import posterior_estimator_based_potential
 from sbi.inference.potentials.posterior_based_potential import PosteriorBasedPotential
+from sbi.inference.trainers._contracts import LossArgsNPE, StartIndexContext
 from sbi.inference.trainers.base import (
+    LossArgs,
     NeuralInference,
     check_if_proposal_has_default_x,
 )
@@ -289,9 +292,11 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             calibration_kernel = default_calibration_kernel
 
         start_idx = self._get_start_index(
-            discard_prior_samples=discard_prior_samples,
-            force_first_round_loss=force_first_round_loss,
-            resume_training=resume_training,
+            ctx=StartIndexContext(
+                discard_prior_samples=discard_prior_samples,
+                force_first_round_loss=force_first_round_loss,
+                resume_training=resume_training,
+            )
         )
 
         # Set the proposal to the last proposal that was passed by the user. For
@@ -313,11 +318,12 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             start_idx=start_idx,
         )
 
-        loss_kwargs = dict(
+        loss_args = LossArgsNPE(
             proposal=proposal,
             calibration_kernel=calibration_kernel,
             force_first_round_loss=force_first_round_loss,
         )
+
         return self._run_training_loop(
             train_loader=train_loader,
             val_loader=val_loader,
@@ -327,7 +333,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             resume_training=resume_training,
             clip_max_norm=clip_max_norm,
             show_train_summary=show_train_summary,
-            loss_kwargs=loss_kwargs,
+            loss_args=loss_args,
         )
 
     def build_posterior(
@@ -570,22 +576,15 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
                 "with `append_simulations(..., proprosal=None)`."
             )
 
-    def _get_start_index(
-        self,
-        discard_prior_samples: bool,
-        force_first_round_loss: bool,
-        resume_training: bool,
-    ) -> int:
+    def _get_start_index(self, ctx: StartIndexContext) -> int:
         """
         Determine the starting index for training based on previous rounds.
 
         Args:
-            discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
-                from the prior.
-
+            ctx: StartIndexContext dataclass values used to determine the starting
+                index of the training set.
         Returns:
-            If `discard_prior_samples` is True and previous rounds exist,
-            the method will return 1 to skip samples from round 0; otherwise,
+            The method will return 1 to skip samples from round 0; otherwise,
             it returns 0.
         """
 
@@ -593,7 +592,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         self._round = max(self._data_round_index)
 
         if self._round == 0 and self._neural_net is not None:
-            assert force_first_round_loss or resume_training, (
+            assert ctx.force_first_round_loss or ctx.resume_training, (
                 "You have already trained this neural network. After you had trained "
                 "the network, you again appended simulations with `append_simulations"
                 "(theta, x)`, but you did not provide a proposal. If the new "
@@ -608,7 +607,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             )
 
         # Starting index for the training set (1 = discard round-0 samples).
-        start_idx = int(discard_prior_samples and self._round > 0)
+        start_idx = int(ctx.discard_prior_samples and self._round > 0)
 
         # For non-atomic loss, we can not reuse samples from previous rounds as of now.
         # SNPE-A can, by construction of the algorithm, only use samples from the last
@@ -657,14 +656,14 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             del theta, x
 
     def _get_losses(
-        self, batch: Sequence[Tensor], loss_kwargs: Dict[str, Any]
+        self, batch: Sequence[Tensor], loss_args: LossArgs | None
     ) -> Tensor:
         """
         Compute losses for a batch of data.
 
         Args:
             batch: A batch of data.
-            loss_kwargs: Additional keyword arguments passed to self._loss fn.
+            loss_args: Additional arguments passed to self._loss fn.
 
         Returns:
             A tensor containing the computed losses for each sample in the batch.
@@ -675,7 +674,14 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             batch[1].to(self._device),
             batch[2].to(self._device),
         )
+
+        if not isinstance(loss_args, LossArgsNPE):
+            raise TypeError(
+                "Expected type of loss_args to be LossArgsNPE,"
+                f" but got {type(loss_args)}"
+            )
+
         # Take negative loss here to get validation log_prob.
-        losses = self._loss(theta_batch, x_batch, masks_batch, **loss_kwargs)
+        losses = self._loss(theta_batch, x_batch, masks_batch, **asdict(loss_args))
 
         return losses

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -113,7 +113,6 @@ class BNRE(NRE_A):
 
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         kwargs["loss_kwargs"] = LossArgsBNRE(
-            num_atoms=10,
             regularization_strength=kwargs.pop("regularization_strength"),
         )
 

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -1,12 +1,14 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import warnings
 from typing import Any, Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn, ones
 from torch.distributions import Distribution
 
+from sbi.inference.trainers._contracts import LossArgsNRE
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
@@ -105,10 +107,17 @@ class NRE_A(RatioEstimatorTrainer):
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
         """
 
+        if loss_kwargs is not None:
+            warnings.warn(
+                "loss_kwargs argument is not used and will be ignored.", stacklevel=2
+            )
+
         # AALR is defined for `num_atoms=2`.
         # Proxy to `super().__call__` to ensure right parameter.
         kwargs = del_entries(locals(), entries=("self", "__class__"))
-        return super().train(**kwargs, num_atoms=2)
+        kwargs["loss_kwargs"] = LossArgsNRE(num_atoms=2)
+
+        return super().train(**kwargs)
 
     def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:
         """Returns the binary cross-entropy loss for the trained classifier.

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi.inference.trainers._contracts import LossArgsNRE
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
@@ -105,6 +106,8 @@ class NRE_B(RatioEstimatorTrainer):
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
         """
         kwargs = del_entries(locals(), entries=("self", "__class__"))
+        kwargs["loss_kwargs"] = LossArgsNRE(num_atoms=kwargs.pop("num_atoms"))
+
         return super().train(**kwargs)
 
     def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -223,7 +223,7 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             )
 
         if loss_kwargs is None:
-            loss_kwargs = LossArgsNRE(num_atoms=10)
+            loss_kwargs = LossArgsNRE()
             warnings.warn(
                 "You haven't passed a value to loss_kwargs argument a default of"
                 f" {loss_kwargs.num_atoms} is set for number of atoms used for"

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -3,6 +3,7 @@
 
 import warnings
 from abc import ABC, abstractmethod
+from dataclasses import asdict, replace
 from typing import Any, Dict, Literal, Optional, Sequence, Tuple, Union
 
 import torch
@@ -20,7 +21,11 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.potentials import ratio_estimator_based_potential
 from sbi.inference.potentials.ratio_based_potential import RatioBasedPotential
-from sbi.inference.trainers.base import NeuralInference
+from sbi.inference.trainers._contracts import LossArgsNRE, StartIndexContext
+from sbi.inference.trainers.base import (
+    LossArgs,
+    NeuralInference,
+)
 from sbi.neural_nets import classifier_nn
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
 from sbi.neural_nets.ratio_estimators import RatioEstimator
@@ -146,7 +151,7 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
 
     def train(
         self,
-        num_atoms: int = 10,
+        num_atoms: Optional[int] = None,
         training_batch_size: int = 200,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
@@ -158,12 +163,13 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
         retrain_from_scratch: bool = False,
         show_train_summary: bool = False,
         dataloader_kwargs: Optional[Dict] = None,
-        loss_kwargs: Optional[Dict[str, Any]] = None,
+        loss_kwargs: Optional[LossArgsNRE] = None,
     ) -> RatioEstimator:
         r"""Return classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
 
         Args:
-            num_atoms: Number of atoms to use for classification.
+            num_atoms: Number of atoms to use for classification, this value must be
+                passed through the loss_kwargs argument.
             training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
@@ -193,7 +199,31 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
         """
 
-        start_idx = self._get_start_index(discard_prior_samples=discard_prior_samples)
+        if num_atoms is not None:
+            warnings.warn(
+                "num_atoms value is ignored. The value must be passed through"
+                " the loss_kwargs argument.",
+                stacklevel=2,
+            )
+
+        if loss_kwargs is None:
+            loss_kwargs = LossArgsNRE(num_atoms=10)
+            warnings.warn(
+                "You haven't passed a value to loss_kwargs argument a default of"
+                f" {loss_kwargs.num_atoms} is set for number of atoms used for"
+                " classification.",
+                stacklevel=2,
+            )
+
+        if not issubclass(type(loss_kwargs), LossArgsNRE):
+            raise TypeError(
+                "Expected loss_kwargs to be a subclass of LossArgsNRE,"
+                f" but got {type(loss_kwargs)}"
+            )
+
+        start_idx = self._get_start_index(
+            ctx=StartIndexContext(discard_prior_samples=discard_prior_samples)
+        )
 
         train_loader, val_loader = self.get_dataloaders(
             start_idx,
@@ -207,19 +237,20 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
 
         num_atoms = int(
             clamp_and_warn(
-                "num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size
+                "num_atoms",
+                loss_kwargs.num_atoms,
+                min_val=2,
+                max_val=clipped_batch_size,
             )
         )
+
+        # Update num_atoms field in loss_kwargs
+        loss_kwargs = replace(loss_kwargs, **dict(num_atoms=num_atoms))
 
         self._initialize_neural_network(
             retrain_from_scratch=retrain_from_scratch,
             start_idx=start_idx,
         )
-
-        if loss_kwargs is None:
-            loss_kwargs = {}
-
-        loss_kwargs["num_atoms"] = num_atoms
 
         return self._run_training_loop(
             train_loader=train_loader,
@@ -230,7 +261,7 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             resume_training=resume_training,
             clip_max_norm=clip_max_norm,
             show_train_summary=show_train_summary,
-            loss_kwargs=loss_kwargs,
+            loss_args=loss_kwargs,
         )
 
     def build_posterior(
@@ -363,24 +394,23 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
 
         return potential_fn, theta_transform
 
-    def _get_start_index(self, discard_prior_samples: bool) -> int:
+    def _get_start_index(self, ctx: StartIndexContext) -> int:
         """
         Determine the starting index for training based on previous rounds.
 
         Args:
-            discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
-                from the prior.
+            ctx: StartIndexContext dataclass values used to determine the starting
+                index of the training set.
 
         Returns:
-            If `discard_prior_samples` is True and previous rounds exist,
-            the method will return 1 to skip samples from round 0; otherwise,
+            The method will return 1 to skip samples from round 0; otherwise,
             it returns 0.
         """
 
         # Load data from most recent round.
         self._round = max(self._data_round_index)
         # Starting index for the training set (1 = discard round-0 samples).
-        start_idx = int(discard_prior_samples and self._round > 0)
+        start_idx = int(ctx.discard_prior_samples and self._round > 0)
 
         return start_idx
 
@@ -413,14 +443,14 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             del x, theta
 
     def _get_losses(
-        self, batch: Sequence[Tensor], loss_kwargs: Dict[str, Any]
+        self, batch: Sequence[Tensor], loss_args: LossArgs | None
     ) -> Tensor:
         """
         Compute losses for a batch of data.
 
         Args:
             batch: A batch of data.
-            loss_kwargs: Additional keyword arguments passed to self._loss fn.
+            loss_args: Additional arguments passed to self._loss fn.
 
         Returns:
             A tensor containing the computed losses for each sample in the batch.
@@ -430,6 +460,13 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             batch[0].to(self._device),
             batch[1].to(self._device),
         )
-        losses = self._loss(theta_batch, x_batch, **loss_kwargs)
+
+        if loss_args is None or not issubclass(type(loss_args), LossArgsNRE):
+            raise TypeError(
+                "Expected loss_args to be a subclass of LossArgsNRE,"
+                f" but got {type(loss_args)}"
+            )
+
+        losses = self._loss(theta_batch, x_batch, **asdict(loss_args))
 
         return losses

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -1,12 +1,13 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi.inference.trainers._contracts import LossArgs, LossArgsNRE_C
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
@@ -129,9 +130,12 @@ class NRE_C(RatioEstimatorTrainer):
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
         """
+
         kwargs = del_entries(locals(), entries=("self", "__class__"))
-        kwargs["num_atoms"] = kwargs.pop("num_classes") + 1
-        kwargs["loss_kwargs"] = {"gamma": kwargs.pop("gamma")}
+        kwargs["loss_kwargs"] = LossArgsNRE_C(
+            num_atoms=kwargs.pop("num_classes") + 1, gamma=kwargs.pop("gamma")
+        )
+
         return super().train(**kwargs)
 
     def _loss(
@@ -215,3 +219,14 @@ class NRE_C(RatioEstimatorTrainer):
         p_joint = gamma / (1 + gamma)
         p_marginal = 1 / (1 + gamma)
         return p_marginal, p_joint
+
+    def _get_losses(
+        self, batch: Sequence[Tensor], loss_args: LossArgs | None
+    ) -> Tensor:
+        if not isinstance(loss_args, LossArgsNRE_C):
+            raise TypeError(
+                "Expected type of loss_args to be LossArgsNRE_C,"
+                f" but got {type(loss_args)}"
+            )
+
+        return super()._get_losses(batch=batch, loss_args=loss_args)


### PR DESCRIPTION
This pull request further refactors the train method across inference classes by introducing typed configurations.
- Adds a `StartIndexContext` dataclass for passing arguments to the `_get_start_index` method and makes the signature consistent across inference classes.
- Adds dataclasses for passing arguments to the `_loss` function, and adds better strong typing compared to the previous dictionary implementation.
- Adds a `TrainConfig` dataclass for passing hyperparameters, currently only used internally, and doesn't update user-facing arguments.

Additional changes:
- Updates the type and default value for `num_atoms` and `loss_kwargs` train method arguments in `NRE` base class.
- Adds warnings for showing which way to use arguments, and for unused arguments.
- Add an abstract `_loss` method in the NeuralInference base class.