### PR TITLE
MNPE fix for categorical variables

### DIFF
--- a/sbi/neural_nets/net_builders/categorial.py
+++ b/sbi/neural_nets/net_builders/categorial.py
@@ -63,9 +63,12 @@ def build_categoricalmassestimator(
             unique(col).numel() for col in batch_x_discrete.T
         ])
         num_categories = inferred_categories
+    # get all the unique values for each column
+    categorical_values = [unique(col) for col in batch_x.T]
 
     categorical_net = CategoricalMADE(
         num_categories=num_categories,
+        categorical_values=categorical_values,
         num_hidden_features=num_hidden,
         num_context_features=y_numel,
         num_blocks=num_layers,


### PR DESCRIPTION
This PR fixes https://github.com/sbi-dev/sbi/issues/1665

The original issue was not about mixed number of categories in the discrete variables (that was already handled) but it was a mismatch between category value and index. For example in `dt2= torch.randint(low=10, high=20, size=(100, 1))`, the catgories are [10, 20] and not [0, 10] as indices. 

Now with this PR we internally map the categories to indices and back. So users can use any set of category values and we map that to indices for the CategoricalMADE and also revesely for sampling we map the indices back to their values.