### PR TITLE
fix: ImproperEmpirical is inefficient

### DIFF
--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -17,9 +17,7 @@ from sbi.neural_nets.estimators.shape_handling import (
 )
 from sbi.sbi_types import TorchTransform
 from sbi.utils.sbiutils import (
-    ImproperEmpirical,
     mcmc_transform,
-    warn_empirical_prior_memory_risk,
     within_support,
 )
 from sbi.utils.torchutils import ensure_theta_batched
@@ -102,9 +100,6 @@ class PosteriorBasedPotential(BasePotential):
         self.device = device
         self.posterior_estimator.to(device)
         if self.prior is not None:
-            is_empirical = isinstance(self.prior, ImproperEmpirical)
-            if is_empirical and torch.device(device).type == "cuda":
-                warn_empirical_prior_memory_risk("moving empirical prior to CUDA")
             self.prior.to(device)  # type: ignore
         if self._x_o is not None:
             self._x_o = self._x_o.to(device)

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -53,7 +53,6 @@ from sbi.utils import (
 from sbi.utils.sbiutils import (
     ImproperEmpirical,
     mask_sims_from_prior,
-    warn_empirical_prior_memory_risk,
 )
 from sbi.utils.torchutils import assert_all_finite
 
@@ -470,18 +469,10 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             to unconstrained space.
         """
 
-        is_empirical = isinstance(prior, ImproperEmpirical)
-        if is_empirical:
-            warn_empirical_prior_memory_risk(
-                "disabling parameter transforms for empirical prior"
-            )
-
         potential_fn, theta_transform = posterior_estimator_based_potential(
             posterior_estimator=estimator,
             prior=prior,
             x_o=None,
-            # Disable transforms if prior is empirical to avoid sampling issues.
-            enable_transform=not is_empirical,
         )
         return potential_fn, theta_transform
 

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-import warnings
 from typing import Tuple
 
 import matplotlib.pyplot as plt
@@ -21,7 +20,7 @@ from sbi.inference import NPE, NPE_A
 from sbi.inference.trainers.npe.npe_a import NPE_A_MDN
 from sbi.neural_nets import classifier_nn, likelihood_nn, posterior_nn
 from sbi.utils import BoxUniform, get_kde
-from sbi.utils.sbiutils import ImproperEmpirical, mcmc_transform, z_score_parser
+from sbi.utils.sbiutils import z_score_parser
 
 
 def test_conditional_density_1d():
@@ -555,15 +554,3 @@ def test_z_scoring_structured(z_x, z_theta, builder):
     # plt.plot(x_zstructured.T)
     # plt.title('z-scored: structured dims');
     # plt.show()
-
-
-def test_mcmc_transform_emits_warning_for_improper_empirical():
-    values = torch.randn(100, 3)
-    logw = torch.zeros(values.shape[0])
-    prior = ImproperEmpirical(values, log_weights=logw)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        _ = mcmc_transform(prior, enable_transform=True)
-        assert any("Empirical prior memory/VRAM risk" in str(ww.message) for ww in w), (
-            "Expected generic empirical prior memory/VRAM risk warning."
-        )


### PR DESCRIPTION
Addresses #1635 

As  mentioned in #1635, `ImproperEmpirical` currently saves all the prior samples. However, these samples are never actually used, and `ImproperEmpirical` itself is only used for single round, posterior-estimation methods (so NPE, NPSE, MNPE, etc.), and even when it is used, we turn off `mcmc_transform`. We currently warn the user if the number of samples is big, that the memory usage will be large.

This PR makes some changes to `ImproperEmpirical`:

- Instead of saving all the samples, it simply computes the mean and standard deviation of the samples
- It allows `mcmc_transform` to z-score the parameters even when the prior is `ImproperEmpirical` (this was turned off before)
- It raises a warning if `sample()` or `log_prob()` is called for `ImproperEmpirical`. The first we have to turn off if we don't want to save the samples. In principle, we can keep the current behaviour for `log_prob` of returning zeros for any value, but this is a bit weird for me - an empirical prior is unlikely to actually be uniform (improper), and if we need to call `log_prob()`, we would want the values to reflect what the log prob actually is (so either a proper prior, or to use the `pyro.Empirical` if we don't know what the prior is, which would be a mixture of delta distributions). Raising this warning did not create any test failures, because we never call `log_prob()` when using `ImproperEmpirical`