### PR TITLE
Fix misleading assertion message in NPE train

### DIFF
--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -608,17 +608,12 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
 
         if self._round == 0 and self._neural_net is not None:
             assert context.force_first_round_loss or context.resume_training, (
-                "You have already trained this neural network. After you had trained "
-                "the network, you again appended simulations with `append_simulations"
-                "(theta, x)`, but you did not provide a proposal. If the new "
-                "simulations are sampled from the prior, you can set "
-                "`.train(..., force_first_round_loss=True`). However, if the new "
-                "simulations were not sampled from the prior, you should pass the "
-                "proposal, i.e. `append_simulations(theta, x, proposal)`. If "
-                "your samples are not sampled from the prior and you do not pass a "
-                "proposal and you set `force_first_round_loss=True`, the result of "
-                "SNPE will not be the true posterior. Instead, it will be the proposal "
-                "posterior, which (usually) is more narrow than the true posterior."
+                "This neural network has already been trained. "
+                "If you want to continue training without adding new simulations, "
+                "set resume_training=True. "
+                "If you appended new simulations, you must either provide a proposal "
+                "in append_simulations(), or set force_first_round_loss=True for "
+                "simulations drawn from the prior."
             )
 
         # Starting index for the training set (1 = discard round-0 samples).

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -606,14 +606,21 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         # Load data from most recent round.
         self._round = max(self._data_round_index)
 
-        if self._round == 0 and self._neural_net is not None:
-            assert context.force_first_round_loss or context.resume_training, (
+        if (
+            self._round == 0
+            and self._neural_net is not None
+            and not (context.force_first_round_loss or context.resume_training)
+        ):
+            raise ValueError(
                 "This neural network has already been trained. "
                 "If you want to continue training without adding new simulations, "
                 "set resume_training=True. "
                 "If you appended new simulations, you must either provide a proposal "
                 "in append_simulations(), or set force_first_round_loss=True for "
-                "simulations drawn from the prior."
+                "simulations drawn from the prior. "
+                "Warning: Setting force_first_round_loss=True with simulations not "
+                "drawn from the prior will produce the proposal posterior instead of "
+                "the true posterior, which is typically more narrow."
             )
 
         # Starting index for the training set (1 = discard round-0 samples).


### PR DESCRIPTION
## Issue Reference
- Closes #1676.

## Summary
This PR updates a misleading assertion message in the NPE training workflow. When `train()` is called a second time with `resume_training=False` and  `force_first_round_loss=False`, the current message incorrectly states that `append_simulations()` was called again after training, even when no new simulations were appended. The updated message now reflects the two valid user stories:

1. **No new simulations appended (round 0):**  
   Users should set `resume_training=True` to continue training the same neural network.

2. **New simulations appended (multi-round):**  
   Users must either pass a proposal when calling `append_simulations()`, or explicitly set `force_first_round_loss=True` for simulations drawn from the prior.

## Changes
- Updated the assertion message in `sbi/inference/trainers/npe/npe_base.py` within `_get_start_index()`.  
- No changes were made to the underlying training logic or behavior.

## Reproduced Output After Fix
<details>
<summary>Click to view traceback screenshot</summary>
<img width="1897" height="86" alt="Screenshot 2025-11-19 145352" src="https://github.com/user-attachments/assets/f268603b-87a9-451d-9c9e-28a1b3174711" />
</details>