### PR TITLE
Fix device mismatch in NPSE marginal mean/std computation

### DIFF
--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -119,8 +119,7 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         # Now that input_shape and mean_0, std_0 is set, we can compute the proper mean
         # and std for the "base" distribution.
         # Create t on the correct device to avoid CPU/GPU mismatch
-        device = self.mean_0.device
-        t_tensor = torch.as_tensor([t_max], device=device)
+        t_tensor = torch.as_tensor([t_max], device=self.mean_0.device)
         mean_t = self.approx_marginal_mean(t_tensor)
         std_t = self.approx_marginal_std(t_tensor)
         mean_t = torch.broadcast_to(mean_t, (1, *input_shape))

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -120,7 +120,7 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         # and std for the "base" distribution.
         # Create t on the correct device to avoid CPU/GPU mismatch
         device = self.mean_0.device
-        t_tensor = torch.as_tensor([t_max], device=device) 
+        t_tensor = torch.as_tensor([t_max], device=device)
         mean_t = self.approx_marginal_mean(t_tensor)
         std_t = self.approx_marginal_std(t_tensor)
         mean_t = torch.broadcast_to(mean_t, (1, *input_shape))

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -118,8 +118,11 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
 
         # Now that input_shape and mean_0, std_0 is set, we can compute the proper mean
         # and std for the "base" distribution.
-        mean_t = self.approx_marginal_mean(torch.tensor([t_max]))
-        std_t = self.approx_marginal_std(torch.tensor([t_max]))
+        # Create t on the correct device to avoid CPU/GPU mismatch
+        device = self.mean_0.device
+        t_tensor = torch.as_tensor([t_max], device=device) 
+        mean_t = self.approx_marginal_mean(t_tensor)
+        std_t = self.approx_marginal_std(t_tensor)
         mean_t = torch.broadcast_to(mean_t, (1, *input_shape))
         std_t = torch.broadcast_to(std_t, (1, *input_shape))
 


### PR DESCRIPTION
## Summary
This PR fixes a device mismatch issue in NPSE during the computation of marginal mean and standard deviation. The internal time tensor was previously always created on the CPU, which caused failures when NPSE was used on a GPU or within the flexible training interface.

- This closes #1686

## What Was the Problem?
NPSE computes marginal statistics using a `times` tensor. This tensor was constructed on CPU unconditionally, while other buffers (like `mean_0`) could live on a different device. This led to a device mismatch error during vector-field estimator initialization.

## What This PR Changes
Previously, NPSE constructed the internal time tensor (`[t_max]`) using a plain `torch.tensor(...)`, which always defaults to the CPU unless a device is explicitly provided. Because NPSE stores key parameters like `mean_0` and `std_0` as registered buffers, these buffers correctly follow the device of the estimator (CPU orr GPU). However, the time tensor did not, leaving it on CPU even when the rest of the model was on GPU.

This PR updates the construction of the time tensor so that it is explicitly created on the same device as NPSE’s registered buffers. By sourcing the device from `self.mean_0.device`, the time tensor is guaranteed to reside on the correct device regardless of where the estimator is moved (e.g., via `.to(device)` or during GPU training).