### PR TITLE
docs: redirect default ReadTheDocs root to stable version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,5 +23,3 @@ python:
 redirects:
   - redirect: /
     to: /en/stable/
-
-    


### PR DESCRIPTION
### Summary
This PR updates the ReadTheDocs configuration so that the default
documentation (`https://sbi.readthedocs.io/en/`) redirects to the **stable** 
version rather than **latest**, as requested in issue #1708.

### Changes
- Added a redirects rule to `.readthedocs.yml` to point `/` → `/en/stable/`.

No other files were modified.
