### PR TITLE
build: Move notebook dependency to 'notebook' extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "arviz",
     "joblib>=1.0.0",
     "matplotlib",
-    "notebook <= 6.4.12",
     "numpy",
     "pillow",
     "pyknos>=0.16.0",
@@ -48,7 +47,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+notebook = ["notebook<=6.4.12"]
 doc = [
+    "sbi[notebook]",
     # Documentation
     "ipython <= 8.9.0",
     "jupyter_contrib_nbextensions",


### PR DESCRIPTION
Resolves #1713 

* As sbi does not have any use of the notebook library itself it should not be a required dependency. Remove it from 'dependencies' and create a 'notebook' extra instead.