### PR TITLE
 Enhance plot_summary with grouped tags, titles, and improved UX

### DIFF
--- a/docs/how_to_guide/21_tensorboard_summary.ipynb
+++ b/docs/how_to_guide/21_tensorboard_summary.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "79928597",
+   "metadata": {},
+   "source": [
+    "# Plotting Tensorboard Summaries\n",
+    "\n",
+    "`sbi` allows logging training progress via Tensorboard. You can inspect these logs using `tensorboard --logdir=...` in your terminal, or you can use `sbi.analysis.plot_summary` to plot the logged metrics directly in your notebook or python script.\n",
+    "\n",
+    "This guide shows how to use `plot_summary` to visualize training and validation losses, and other metrics.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37c9e353",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import shutil\n",
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "from torch.utils.tensorboard import SummaryWriter\n",
+    "from sbi.analysis import plot_summary\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Create dummy tensorboard logs for demonstration\n",
+    "log_dir = \"dummy_logs_guide\"\n",
+    "if Path(log_dir).exists():\n",
+    "    shutil.rmtree(log_dir)\n",
+    "\n",
+    "writer = SummaryWriter(log_dir)\n",
+    "for i in range(100):\n",
+    "    # Simulate training loss decreasing\n",
+    "    writer.add_scalar(\"training_loss\", np.exp(-0.05 * i) + np.random.normal(0, 0.01), i)\n",
+    "    # Simulate validation loss decreasing but slightly higher\n",
+    "    writer.add_scalar(\"validation_loss\", np.exp(-0.05 * i) + 0.1 + np.random.normal(0, 0.01), i)\n",
+    "    # Simulate some other metric increasing\n",
+    "    writer.add_scalar(\"accuracy\", 1 - np.exp(-0.05 * i) + np.random.normal(0, 0.01), i)\n",
+    "writer.close()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67ab8b15",
+   "metadata": {},
+   "source": [
+    "## Basic Usage\n",
+    "\n",
+    "By default, `plot_summary` plots a single metric (defaulting to \"validation_loss\" if not specified). You can specify a list of tags to plot multiple metrics in separate subplots.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b85d9125",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot training_loss and validation_loss in separate subplots\n",
+    "fig, axes = plot_summary(Path(log_dir), tags=[\"training_loss\", \"validation_loss\"])\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8595773c",
+   "metadata": {},
+   "source": [
+    "## Grouping Tags\n",
+    "\n",
+    "You can plot multiple tags on the same axis by providing a list of tags as an element in the `tags` list. This is useful for comparing metrics, such as training and validation loss.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb9a9d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot training_loss and validation_loss on the same subplot, and accuracy on another\n",
+    "fig, axes = plot_summary(\n",
+    "    Path(log_dir), \n",
+    "    tags=[[\"training_loss\", \"validation_loss\"], \"accuracy\"]\n",
+    ")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec72180a",
+   "metadata": {},
+   "source": [
+    "## Customization\n",
+    "\n",
+    "You can customize the figure size, font size, and add titles.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8e77491",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plot_summary(\n",
+    "    Path(log_dir), \n",
+    "    tags=[[\"training_loss\", \"validation_loss\"], \"accuracy\"],\n",
+    "    figsize=(12, 5),\n",
+    "    fontsize=14,\n",
+    "    ylabel=[\"Loss\", \"Accuracy\"],\n",
+    "    title=\"Training Summary\",\n",
+    "    titles=[\"Losses\", \"Accuracy Metric\"]\n",
+    ")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5adbdcb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cleanup\n",
+    "if Path(log_dir).exists():\n",
+    "    shutil.rmtree(log_dir)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/tensorboard_output_test.py
+++ b/tests/tensorboard_output_test.py
@@ -1,0 +1,52 @@
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.pyplot import close
+from torch.utils.tensorboard.writer import SummaryWriter
+
+from sbi.analysis.tensorboard_output import plot_summary
+
+
+def test_plot_summary_grouped(tmp_path):
+    log_dir = tmp_path / "logs"
+    writer = SummaryWriter(log_dir)
+    for i in range(10):
+        writer.add_scalar("loss/train", np.exp(-i), i)
+        writer.add_scalar("loss/val", np.exp(-i) + 0.1, i)
+        writer.add_scalar("acc", i * 0.1, i)
+    writer.close()
+
+    # Test single tag
+    fig, axes = plot_summary(log_dir, tags=["loss/train"])
+    assert len(axes) == 1
+    close()
+
+    # Test grouped tags
+    fig, axes = plot_summary(log_dir, tags=[["loss/train", "loss/val"], "acc"])
+    assert len(axes) == 2
+    assert axes[0].get_legend() is not None
+    close()
+
+    # Test grouped tags with ylabel
+    fig, axes = plot_summary(
+        log_dir,
+        tags=[["loss/train", "loss/val"]],
+        ylabel=["Custom Loss"]
+    )
+    assert axes[0].get_ylabel() == "Custom Loss"
+    close()
+
+    # Test titles
+    fig, axes = plot_summary(
+        log_dir,
+        tags=["loss/train"],
+        title="Figure Title",
+        titles=["Subplot Title"]
+    )
+    assert fig._suptitle.get_text() == "Figure Title"
+    assert axes[0].get_title() == "Subplot Title"
+    close()


### PR DESCRIPTION
This PR enhances the plot_summary function in sbi.analysis.tensorboard_output to support more flexible plotting options and improves the overall user experience.

Changes:

Grouped Tags Support: The tags argument now accepts a list of lists (e.g., tags=[['training_loss', 'validation_loss'], 'other_metric']). This allows multiple Tensorboard tags to be plotted on the same subplot, which is particularly useful for comparing training and validation losses.
Legends: When multiple tags are plotted on the same axis, a legend is automatically added to distinguish them.
Titles: Added title (for the whole figure) and titles (list of strings for each subplot) arguments to plot_summary.
Grid: Enabled grid lines by default (with alpha=0.3) for better readability.
Dynamic Figure Size: The default figsize now scales dynamically with the number of subplots ((6 * len(tags), 6)) if not manually specified.
Documentation: Added a new How-To Guide notebook docs/how_to_guide/21_tensorboard_summary.ipynb demonstrating these new features and added it to the docs/how_to_guide.rst index.
Tests: Added tests/tensorboard_output_test.py to verify the new functionality.
Example Usage:

from sbi.analysis import plot_summary

# Plot training and validation loss on the same axis
plot_summary(
    inference_object,
    tags=[['training_loss', 'validation_loss'], 'accuracy'],
    title="Training Progress",
    titles=["Loss Curves", "Accuracy"]
)
Related Issue: Fixes #1733