### PR TITLE
Fix memory bloat in multi-round inference

### DIFF
--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -209,7 +209,6 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
         self._theta_roundwise = []
         self._x_roundwise = []
         self._prior_masks = []
-        self._model_bank = []
 
         # Initialize list that indicates the round from which simulations were drawn.
         self._data_round_index = []
@@ -499,6 +498,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
 
         prior = self._resolve_prior(prior)
         estimator, device = self._resolve_estimator(estimator)
+        estimator = deepcopy(estimator)
 
         posterior_parameters = self._resolve_posterior_parameters(
             sample_with, posterior_parameters, **kwargs
@@ -512,10 +512,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
             posterior_parameters,
         )
 
-        # Store models at end of each round.
-        self._model_bank.append(deepcopy(self._posterior))
-
-        return deepcopy(self._posterior)
+        return self._posterior
 
     def _resolve_prior(self, prior: Optional[Distribution]) -> Distribution:
         """
@@ -996,7 +993,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
         # cause memory leakage when benchmarking.
         self._neural_net.zero_grad(set_to_none=True)
 
-        return deepcopy(self._neural_net)
+        return self._neural_net
 
     def _train_epoch(
         self,

--- a/sbi/inference/trainers/marginal/marginal_base.py
+++ b/sbi/inference/trainers/marginal/marginal_base.py
@@ -281,7 +281,7 @@ class MarginalTrainer:
         # cause memory leakage when benchmarking.
         self._neural_net.zero_grad(set_to_none=True)
 
-        return deepcopy(self._neural_net)
+        return self._neural_net
 
     def _default_summary_writer(self) -> SummaryWriter:
         """Return summary writer logging to method- and simulator-specific directory."""

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -2,7 +2,6 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import warnings
-from copy import deepcopy
 from functools import partial
 from typing import Any, Callable, Dict, Literal, Optional, Union
 
@@ -322,7 +321,7 @@ class NPE_A(PosteriorEstimatorTrainer):
             prior=prior,
             **kwargs,
         )
-        return self._posterior
+        return self._posterior  # type: ignore
 
     def _log_prob_proposal_posterior(
         self,

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -252,9 +252,7 @@ class NPE_A(PosteriorEstimatorTrainer):
             Posterior $p(\theta|x)$  with `.sample()` and `.log_prob()` methods.
         """
         if density_estimator is None:
-            density_estimator = deepcopy(
-                self._neural_net
-            )  # PosteriorEstimator.train() also returns a deepcopy, mimic this here
+            density_estimator = self._neural_net
             # If internal net is used device is defined.
             device = self._device
         else:
@@ -324,7 +322,7 @@ class NPE_A(PosteriorEstimatorTrainer):
             prior=prior,
             **kwargs,
         )
-        return deepcopy(self._posterior)  # type: ignore
+        return self._posterior
 
     def _log_prob_proposal_posterior(
         self,

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -563,7 +563,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
                 isinstance(proposal, NeuralPosterior)
                 and hasattr(proposal, "posterior_estimator")
                 and self._neural_net is not None
-                and proposal.posterior_estimator is self._neural_net
+                and proposal.posterior_estimator is self._neural_net  # type: ignore
             ):
                 raise ValueError(
                     "The proposal's posterior_estimator is the same object as the "

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -559,7 +559,19 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         """
         if proposal is not None:
             check_if_proposal_has_default_x(proposal)
-
+            if (
+                isinstance(proposal, NeuralPosterior)
+                and hasattr(proposal, "posterior_estimator")
+                and self._neural_net is not None
+                and proposal.posterior_estimator is self._neural_net
+            ):
+                raise ValueError(
+                    "The proposal's posterior_estimator is the same object as the "
+                    "trainer's neural network. This will cause incorrect training "
+                    "because the proposal's weights will change during optimization. "
+                    "Use `deepcopy(estimator)` when creating the proposal, or use "
+                    "`trainer.build_posterior()` which handles this automatically."
+                )
             if isinstance(proposal, RestrictedPrior):
                 if proposal._prior is not self._prior:
                     warnings.warn(

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import asdict
 
 import numpy as np
@@ -319,7 +320,7 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
             theta, x, proposal=prior
         ).train()
         posterior1 = DirectPosterior(
-            prior=prior, posterior_estimator=posterior_estimator
+            prior=prior, posterior_estimator=deepcopy(posterior_estimator)
         ).set_default_x(x_o)
         theta = posterior1.sample((1000,))
         x = simulator(theta)
@@ -335,7 +336,7 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
         x = simulator(theta)
         posterior_estimator = inference.append_simulations(theta, x).train()
         posterior1 = DirectPosterior(
-            prior=prior, posterior_estimator=posterior_estimator
+            prior=prior, posterior_estimator=deepcopy(posterior_estimator)
         ).set_default_x(x_o)
         theta = posterior1.sample((1000,))
         x = simulator(theta)

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -93,8 +93,13 @@ class TorchUtilsTest(torchtestcase.TorchTestCase):
         right_boundaries = bin_locations[:-1] + 0.1
         mid_points = bin_locations[:-1] + 0.05
 
-        for inputs in [left_boundaries, right_boundaries, mid_points]:
-            with self.subTest(inputs=inputs):
+        test_cases = [
+            ("left_boundaries", left_boundaries),
+            ("right_boundaries", right_boundaries),
+            ("mid_points", mid_points),
+        ]
+        for name, inputs in test_cases:
+            with self.subTest(name=name):
                 idx = torchutils.searchsorted(bin_locations[None, :], inputs)
                 self.assertEqual(idx, torch.arange(0, 9))
 


### PR DESCRIPTION
## Description
I have addressed the significant memory accumulation that happens during multi-round inference. The main issue was that the code was making deep copies of the neuarl network in places where they weren't actually needed, and storing them in a list that never got used.

## Refrence Issues/PRs
- Fixes #1616

## Changes
1.  **Removed `_model_bank`**: I deleted the `self._model_bank` list in `sbi/inference/trainers/base.py`. This list was effectively "write-only", it kept adding new copies of the posterior every round but never read them back, which was just wasting memory.
2.  **Optimized `train()`**: I updated `train()` to return the actual neural network object (`self._neural_net`) instead of a deep copy. This creates a huge memory saving because we aren't duplicating the entire network every time the training loop runs.
3.  **Safety Snapshot in `build_posterior()`**: To make sure we don't break iterative methods like SNPE-B or SNPE-C, I moved the copying logic into `build_posterior()`.
    * Now, when you build a posterior, it takes a "snapshot" (deep copy) of the network at that exact moment.
    * This ensures that the posterior remains "frozen" in time. If the trainer updates the network in a future round, this posterior won't change. This keeps the math correct for previous rounds without the need for triple redundancy.
4.  **Cleanup**: I removed the extra copy operations in `npe_a.py` to match this new logic.
5. **Proposal Safety Check**: I added a guardrail in `npe_base.py` to catch "self-referential" proposals. If a user manually constructs a posterior from the live network without copying it and passes it as a proposal, the code now raises a `ValueError`. This prevents silent numerical instability where the proposal mutates during training.

## Additional Notes
`inference.train()` now returns a **reference** to the network, not a copy. This aligns better with standard PyTorch practices.
* **For most users**: This changes nothing except making code faster and lighter.
* **For manual workflows**: If a user manually builds a posterior using `DirectPosterior(net, ...)` instead of `build_posterior()`, they will now hold a live reference. If they need that specific version to stay static while they keep training, they could manually `deepcopy` it (The new safety check now enforces this to prevent bugs).
