### PR TITLE
Raise informative RuntimeError when training with empty simulations

### DIFF
--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -180,6 +180,12 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
             Density estimator that has learned the distribution $p(x|\theta)$.
         """
 
+        if len(self._data_round_index) == 0:
+            raise RuntimeError(
+                "No simulations found. You must call .append_simulations() "
+                "before calling .train()."
+            )
+
         start_idx = self._get_start_index(
             context=StartIndexContext(discard_prior_samples=discard_prior_samples)
         )

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -195,6 +195,12 @@ class NPE_A(PosteriorEstimatorTrainer):
         kwargs["discard_prior_samples"] = True
         kwargs["force_first_round_loss"] = True
 
+        if len(self._data_round_index) == 0:
+            raise RuntimeError(
+                "No simulations found. You must call .append_simulations() "
+                "before calling .train()."
+            )
+
         self._round = max(self._data_round_index)
 
         if final_round:

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -290,6 +290,12 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             Density estimator that approximates the distribution $p(\theta|x)$.
         """
 
+        if len(self._data_round_index) == 0:
+            raise RuntimeError(
+                "No simulations found. You must call .append_simulations() "
+                "before calling .train()."
+            )
+
         train_config = TrainConfig(
             max_num_epochs=max_num_epochs,
             stop_after_epochs=stop_after_epochs,

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -165,6 +165,11 @@ class NPE_C(PosteriorEstimatorTrainer):
             Density estimator that approximates the distribution $p(\theta|x)$.
         """
 
+        if len(self._data_round_index) == 0:
+            raise RuntimeError(
+                "No simulations found. You must call .append_simulations() "
+                "before calling .train()."
+            )
         # WARNING: sneaky trick ahead. We proxy the parent's `train` here,
         # requiring the signature to have `num_atoms`, save it for use below, and
         # continue. It's sneaky because we are using the object (self) as a namespace

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -203,6 +203,12 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
         """
 
+        if len(self._data_round_index) == 0:
+            raise RuntimeError(
+                "No simulations found. You must call .append_simulations() "
+                "before calling .train()."
+            )
+
         train_config = TrainConfig(
             max_num_epochs=max_num_epochs,
             stop_after_epochs=stop_after_epochs,


### PR DESCRIPTION
## Description
Fixes an issue where calling `.train()` without appending simulations raises an uninformative `ValueError: max() iterable argument is empty`.

This PR adds a guard clause to the `train()` methods across all inference families (NPE, NLE, NRE). It checks if `self._data_round_index` is empty and, if so, raises a `RuntimeError` with clear instructions to call `.append_simulations()` first.

## Related Issues/PRs
- Fixes #1730

## Changes
I investigated placing this check in the abstract `base.py`, but it was not feasible because `train` is an abstract method there, and several subclasses (specifically SNPE) execute logic that crashes before calling `super().train()`.

Therefore, I applied the fix to the specific implementation files to ensure full coverage:
- **NPE:** `sbi/inference/trainers/npe/npe_c.py` (covers SNPE-C, MNPE), `npe_a.py`, and `npe_base.py`.
- **NLE:** `sbi/inference/trainers/nle/nle_base.py`.
- **NRE:** `sbi/inference/trainers/nre/nre_base.py`.
