### PR TITLE
Trigger workflow when PR is marked ready for review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
## Description

This is a suggestion based on my personal experience to smooth out the contribution workflow. If this limitation is intentional (e.g., to save runner resources) or preferred by the maintainers, I am completely fine with rejecting the PR without merging

This PR updates the Continuous Integration (CI) workflow to automatically trigger when a Pull Request is converted from "**Draft**" to "**Ready for Review**"

Currently, the `ci.yml` workflow is configured to skip runs on Draft PRs which is fine. However, because the default `pull_request` trigger only listens for `opened`, `synchronize`, and `reopened` events, the CI pipeline ignores the `ready_for_review` event

So when a contributor marks a Draft PR as "Ready for Review," the CI does not run. Contributors are forced to push an empty commit (e.g., `git commit --allow-empty`) just to trigger the tests. This PR removes that friction to improve DX


## Changes
- Modified `.github/workflows/ci.yml` to explicitly define `pull_request` trigger types
- Added `ready_for_review` to the list of types, ensuring the workflow captures the transition from Draft to Ready