### PR TITLE
fix: use .any() instead of .all() in VIPosterior observation check

### DIFF
--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -347,7 +347,7 @@ class VIPosterior(NeuralPosterior):
             Samples from posterior.
         """
         x = self._x_else_default_x(x)
-        if self._trained_on is None or (x != self._trained_on).all():
+        if self._trained_on is None or (x != self._trained_on).any():
             raise AttributeError(
                 f"The variational posterior was not fit on the specified `default_x` "
                 f"{x}. Please train using `posterior.train()`."
@@ -386,7 +386,7 @@ class VIPosterior(NeuralPosterior):
             `len($\theta$)`-shaped log-probability.
         """
         x = self._x_else_default_x(x)
-        if self._trained_on is None or (x != self._trained_on).all():
+        if self._trained_on is None or (x != self._trained_on).any():
             raise AttributeError(
                 f"The variational posterior was not fit using observation {x}.\
                      Please train."


### PR DESCRIPTION
## **Summary**

This PR fixes a logic error in the observation-mismatch guard in:

```
sbi/inference/posteriors/vi_posterior.py
```

`VIPosterior` should only be used with the observation it was trained on (`self._trained_on`). However, the guard in `sample()` and `log_prob()` used the wrong boolean reduction and failed to catch partial mismatches.

Buggy logic:

```python
if self._trained_on is None or (x != self._trained_on).all():
    raise AttributeError(...)
```

This only raised when *all* elements differed. If even one coordinate matched, the check passed and the posterior trained on a different observation was used.

---

## **Fix**

Replaced `.all()` with `.any()` in both guards:

```python
if self._trained_on is None or (x != self._trained_on).any():
    raise AttributeError(...)
```

This correctly raises when the new observation differs in any coordinate and matches the intended logic already used in `train()`:

```python
(x == self._trained_on).all()
```

---

## **Impact**

Now, any observation mismatch is detected and reported instead of silently producing wrong results.

---
