### PR TITLE
fix: skip GPU tests on MPS devices instead of failing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,12 +35,10 @@ def set_default_tensor_type():
 
 # Pytest hook to skip GPU tests if no devices are available.
 def pytest_collection_modifyitems(config, items):
-    """Skip GPU tests if no devices are available."""
-    gpu_device_available = (
-        torch.cuda.is_available() or torch.backends.mps.is_available()
-    )
+    """Skip GPU tests if no CUDA devices are available."""
+    gpu_device_available = torch.cuda.is_available()
     if not gpu_device_available:
-        skip_gpu = pytest.mark.skip(reason="No devices available")
+        skip_gpu = pytest.mark.skip(reason="No CUDA device available")
 
         for item in items:
             if "gpu" in item.keywords:

--- a/tests/tarp_test.py
+++ b/tests/tarp_test.py
@@ -13,6 +13,7 @@ from sbi.inference import NPE
 from sbi.simulators import linear_gaussian
 from sbi.utils import BoxUniform
 from sbi.utils.metrics import l1, l2
+from sbi.utils.torchutils import process_device
 
 
 def generate_toy_gaussian(nsamples=100, nsims=100, ndims=5, covfactor=1.0):
@@ -154,7 +155,7 @@ def test_run_tarp_correct(distance, z_score_theta, accurate_samples):
 def test_run_tarp_correct_on_cuda_device(accurate_samples):
     z_score_theta = True
     distance = l2
-    dev = device("cuda")
+    dev = device(process_device("gpu"))
     theta, samples = accurate_samples
     theta, samples = theta.to(dev), samples.to(dev)
 
@@ -165,7 +166,7 @@ def test_run_tarp_correct_on_cuda_device(accurate_samples):
         # then we can fix the tarp code
         from torch import histogram
 
-        histogram(zeros((3,)).cuda(), bins=4)
+        histogram(zeros((3,)).to(dev), bins=4)
 
     references = get_tarp_references(theta).to(dev)
 


### PR DESCRIPTION
Fixes #1747

## Problem
GPU tests were running on Mac MPS devices and failing with 50+ errors because most PyTorch operations aren't MPS-compatible. Users had to manually run `pytest -m "not gpu"` to avoid failures.

## Solution
- Updated `tests/conftest.py` to only check `torch.cuda.is_available()` for GPU test collection
- Updated `tests/tarp_test.py` to use `process_device("gpu")` instead of hardcoded `"cuda"` strings
- GPU tests now skip on MPS devices with clear message: "No CUDA device available"

## Testing
-  Mac M2/MPS: Tests skip properly (instead of 50+ failures)
- Linux/CUDA: GPU tests still run and pass
- CI workflows already have `-m "not gpu"` flags, no changes needed

cc @manuelgloeckler @janfb