### PR TITLE
Fix Gaussian Linear task in mini SBI-BM

### DIFF
--- a/tests/mini_sbibm/gaussian_linear.py
+++ b/tests/mini_sbibm/gaussian_linear.py
@@ -27,8 +27,8 @@ class GaussianLinear(Task):
         """
         Initializes the GaussianLinear task.
         """
-        self.prior_scale = 0.1**0.5
-        self.simulator_scale = 0.1**0.5
+        self.prior_var = 0.1
+        self.simulator_var = 0.1
         self.dim = 10
         super().__init__("gaussian_linear")
 
@@ -64,9 +64,9 @@ class GaussianLinear(Task):
         posterior = true_posterior_linear_gaussian_mvn_prior(
             x_o,
             torch.zeros(self.dim),
-            self.simulator_scale**2 * torch.eye(self.dim),
+            self.simulator_var * torch.eye(self.dim),
             torch.zeros(self.dim),
-            self.prior_scale**2 * torch.eye(self.dim),
+            self.prior_var * torch.eye(self.dim),
         )
 
         return posterior.sample((10_000,))
@@ -107,7 +107,7 @@ class GaussianLinear(Task):
         """
         return MultivariateNormal(
             torch.zeros(self.dim),
-            self.prior_scale**2 * torch.eye(self.dim),
+            self.prior_var * torch.eye(self.dim),
         )
 
     def get_simulator(self) -> Callable:
@@ -119,5 +119,5 @@ class GaussianLinear(Task):
         """
         return partial(
             diagonal_linear_gaussian,
-            std=self.simulator_scale,
+            std=self.simulator_var**0.5,
         )


### PR DESCRIPTION
This fixes #1781. It's a one line fix. The variance was passed instead of the std in `get_simulator`.

