### PR TITLE
Add test case for invalid prior type validation in the original

### DIFF
--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -611,3 +611,16 @@ def test_proposal_sharing_weights_with_trainer_raises():
 
     with pytest.raises(ValueError, match="same object"):
         inference.append_simulations(theta, x, proposal=unsafe_proposal)
+import pytest
+from sbi.utils.user_input_checks import check_prior
+
+
+def test_check_prior_invalid_type():
+    """
+    Ensure that check_prior raises a TypeError
+    when given an invalid prior type.
+    """
+    invalid_prior = 123  # clearly not a valid prior object
+
+    with pytest.raises((TypeError, AssertionError, ValueError)):
+        check_prior(invalid_prior)


### PR DESCRIPTION

This pull request adds a test case to validate behavior when an invalid prior type is provided.


- Added a new test to verify that invalid prior types are properly handled.
- Ensures the appropriate exception or validation response is triggered.


This improves robustness of the validation logic by explicitly testing incorrect prior inputs and preventing silent failures.


No changes to core functionality.
Test-only addition.