### PR TITLE
Refactor embedding net API tests with shared helper

### DIFF
--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -179,11 +179,8 @@ def test_1d_and_2d_cnn_embedding_net(input_shape, num_channels):
 def test_1d_fc_embedding_net(
     input_shape, num_layers, num_hiddens, layer_norm, activation
 ):
-    estimator_provider = posterior_nn(
-        "mdn",
-        embedding_net=FCEmbedding(
-            input_shape[0], 20, num_layers, num_hiddens, layer_norm, activation
-        ),
+    embedding_net = FCEmbedding(
+        input_shape[0], 20, num_layers, num_hiddens, layer_norm, activation
     )
 
     num_dim = input_shape[0]
@@ -196,17 +193,8 @@ def test_1d_fc_embedding_net(
         xo = torch.ones(1, *input_shape)
 
     prior = MultivariateNormal(torch.zeros(num_dim), torch.eye(num_dim))
-
-    num_simulations = 1000
-    theta = prior.sample(torch.Size((num_simulations,)))
-    x = simulator(theta)
-
-    trainer = NPE(prior=prior, density_estimator=estimator_provider)
-    trainer.append_simulations(theta, x).train(max_num_epochs=2)
-    posterior = trainer.build_posterior().set_default_x(xo)
-
-    s = posterior.sample((10,))
-    posterior.potential(s)
+    _test_embedding_forward_pass(embedding_net, input_shape, 20)
+    _train_and_infer_with_embedding(prior, xo, simulator, embedding_net, "mdn", "NPE")
 
 
 @pytest.mark.parametrize("input_shape", [(3, 30), (2, 3, 30)])
@@ -365,7 +353,7 @@ def _train_and_infer_with_embedding(
     prior: utils.BoxUniform | MultivariateNormal,
     xo: Tensor,
     simulator: Callable,
-    net: torch.nn.Module,
+    net: nn.Module,
     model: str,
     method: str,
     posterior_parameters: MCMCPosteriorParameters | None = None,
@@ -406,7 +394,7 @@ def _train_and_infer_with_embedding(
 
 
 def _test_embedding_forward_pass(
-    net: torch.nn.Module, input_shape: tuple, expected_output_dim: int
+    net: nn.Module, input_shape: tuple, expected_output_dim: int
 ):
     """Fast test that embedding produces correct output shape."""
     x = torch.randn(4, *input_shape)


### PR DESCRIPTION
### Description
This PR cleans up and simplifies the embedding network tests by removing duplicate logic and moving everything to a shared helper function.
### Related issue
- Fixes #1506
### Changes

- Added reusable embedding test helpers
Refactored `_test_helper_embedding_net` .
Added `_test_embedding_forward_pass` for lightweight checks.

- Gradient-flow verification after training
Added a parameter snapshot check before and after training to verify that embedding parameters are updated.
Used weight-change verification instead of `.grad` checks, since gradients are cleared after training via `zero_grad(set_to_none=True)`.

- Refactored tests to use the shared helper
Refactored the following tests to use `_test_helper_embedding_net`:
1. `test_embedding_net_api`
2. `test_1d_and_2d_cnn_embedding_net`
3. `test_spectral_conf_embedding`
4. `test_1d_causal_cnn_embedding_net`
5. `test_2d_ResNet_cnn_embedding_net`
6. `test_1d_ResNet_fc_embedding_net`

- Model selection note
Model selection parameter was kept in `_test_helper_embedding_net` .
This preserves prior test behavior and API coverage.

- Performance improvements
Reduced smoke-test simulation and sample sizes:
1. simulation(1000 → 100)
2. num_thetas(1000→100)
3. helper sampling (10,) → (1,)

-  Small bug fix
Fixed `test_1d_ResNet_fc_embedding_net` to correctly pass `c_hidden_final` into ResNetEmbedding1D.
The parameter was previously accepted by the test but not forwarded to the embedding class.