### PR TITLE
refactor: decouple hidden features and layers for mixed type nets. 

### DIFF
--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -130,7 +130,9 @@ class ConditionalFlowConfig(_EstimatorConfigBase):
     log_transform_x: Optional[bool] = None
     num_categories_per_variable: Optional[Any] = None
     combined_embedding_net: Optional[Any] = None
-    hidden_layers: Optional[int] = None
+    discrete_hidden_features: Optional[int] = None
+    discrete_hidden_layers: Optional[int] = None
+    continuous_hidden_features: Optional[int] = None
 
     # --- Base distribution ---
     dtype: Optional[Any] = None

--- a/sbi/neural_nets/net_builders/mixed_nets.py
+++ b/sbi/neural_nets/net_builders/mixed_nets.py
@@ -65,9 +65,11 @@ def _build_mixed_density_estimator(
     num_components: int = 5,
     num_bins: int = 5,
     hidden_features: int = 50,
-    hidden_layers: int = 2,
     tail_bound: float = 10.0,
     log_transform_x: bool = False,
+    discrete_hidden_features: Optional[int] = None,
+    discrete_hidden_layers: int = 2,
+    continuous_hidden_features: Optional[int] = None,
     **kwargs,
 ) -> MixedDensityEstimator:
     """Base function for building mixed neural density estimators.
@@ -118,12 +120,20 @@ def _build_mixed_density_estimator(
         num_transforms: number of transforms in the flow model.
         num_components: number of components in the mixture model.
         num_bins: bins per spline for NSF.
-        hidden_features: number of hidden features used in both nets.
-        hidden_layers: number of hidden layers in the categorical net.
+        hidden_features: number of hidden features shared across discrete and
+            continuous sub-nets. Use ``discrete_hidden_features`` and
+            ``continuous_hidden_features`` for independent control.
         tail_bound: spline tail bound for NSF.
         log_transform_x: whether to apply a log-transform to x to move it to unbounded
             space, e.g., in case x consists of reaction time data (bounded by
             zero).
+        discrete_hidden_features: number of hidden features for the discrete
+            (categorical) net. Defaults to ``hidden_features`` if not set.
+        discrete_hidden_layers: number of hidden layers for the discrete
+            (categorical) net.
+        continuous_hidden_features: number of hidden features for the continuous
+            (flow) net and the fallback combined embedding MLP. Defaults to
+            ``hidden_features`` if not set.
         kwargs: additional keyword arguments passed to the flow model and the
             categorical net.
 
@@ -131,6 +141,10 @@ def _build_mixed_density_estimator(
         MixedDensityEstimator: nn.Module for performing MNLE or MNPE.
     """
     check_data_device(batch_x, batch_y)
+
+    # Resolve decoupled parameters, falling back to shared defaults.
+    _discrete_hf = discrete_hidden_features or hidden_features
+    _continuous_hf = continuous_hidden_features or hidden_features
 
     warnings.warn(
         "The mixed neural density estimator assumes that inferred variable contains "
@@ -165,8 +179,8 @@ def _build_mixed_density_estimator(
         batch_y,
         z_score_x="none",  # discrete data should not be z-scored
         z_score_y="none",  # y-embedding net already z-scores
-        num_hidden=hidden_features,
-        num_layers=hidden_layers,
+        num_hidden=_discrete_hf,
+        num_layers=discrete_hidden_layers,
         embedding_net=embedding_net,
         num_categories_per_variable=num_categories_per_variable,
         dropout_probability=kwargs.get("dropout_probability", 0.0),
@@ -176,9 +190,9 @@ def _build_mixed_density_estimator(
         # set up linear embedding net for combining discrete and continuous
         # data.
         combined_embedding_net = nn.Sequential(
-            nn.Linear(combined_condition.shape[-1], hidden_features),
+            nn.Linear(combined_condition.shape[-1], _continuous_hf),
             nn.ReLU(),
-            nn.Linear(hidden_features, hidden_features),
+            nn.Linear(_continuous_hf, _continuous_hf),
             nn.ReLU(),
         )
 
@@ -204,7 +218,7 @@ def _build_mixed_density_estimator(
         num_transforms=num_transforms,
         num_components=num_components,
         tail_bound=tail_bound,
-        hidden_features=hidden_features,
+        hidden_features=_continuous_hf,
         **kwargs,
     )
 


### PR DESCRIPTION
fixes #1790 

for mixed nets, we were using `hidden_layers` and `hidden_features` arguments for both the discrete and the continuous nets. Now we have separate arguments for each net. 

We drop the `hidden_layers` argument and replace it with `discrete_hidden_layers` because it was used only internally, so there is no backward compabitibility issue. 

This does not work for `hidden_features` because it was user-facing in `posterior_nn`, so we keep it for now and document the new options. 

To ensure the same behaviour as before, we set the defaults to `None` and fallback to `hidden_features` if `discrete_hidden_layers` and `discrete_hidden_features` are not passed explicitly. 