### PR TITLE
fix: adjust leading dimension handling in log prob batched.

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -419,8 +419,11 @@ class DirectPosterior(NeuralPosterior):
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
         event_shape = self.posterior_estimator.input_shape
+        # If theta has 1 leading dim (batch, event), treat it as batch (matching x).
+        # overwise, the leading is sample.
+        num_leading = len(theta.shape) - len(event_shape)
         theta_density_estimator = reshape_to_sample_batch_event(
-            theta, event_shape, leading_is_sample=True
+            theta, event_shape, leading_is_sample=(num_leading > 1)
         )
         x_density_estimator = reshape_to_batch_event(
             x, event_shape=self.posterior_estimator.condition_shape

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -151,6 +151,13 @@ def test_batched_sample_log_prob_with_different_x(
     ), "Sample shape wrong"
     assert batched_log_probs.shape == (10, max(x_o_batch_dim, 1)), "logprob shape wrong"
 
+    # Test with 2D theta (batch, event) — no explicit sample dim.
+    if x_o_batch_dim > 0:
+        theta_2d = samples[0]  # (batch, event)
+        log_probs_2d = posterior.log_prob_batched(theta_2d, x_o)
+        assert log_probs_2d.shape == (1, x_o_batch_dim), "2D theta logprob shape wrong"
+        assert torch.allclose(log_probs_2d[0], batched_log_probs[0], atol=1e-1)
+
     # Test consistency with non-batched log_prob
     # NOTE: Leakage factor is a MC estimate, so we need to relax the tolerance here.
     if x_o_batch_dim == 0:


### PR DESCRIPTION
When calling `log_prob_batched` with `theta` shape `(batch, event)` instead of `(sample, batch, event)` there will be a shape error. 

While the documentation says the theta shape should be `(sample, batch, event)` I think in practice it's often easier to just pass `theta` with `(batch, event)`, e.g., when evaluating a batch of prior-sampled `theta` and `x` under the posterior during hyperparameter search. 

This PR adds small fix to account for the cases where the user passes `theta` with `(batch, event)`. 