### PR TITLE
Fix failing test: Make prior more "within train"

### DIFF
--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -661,7 +661,7 @@ def test_prior_guide(vector_field_type, prior_type, covariance_type, K):
     posterior.set_default_x(x_o)
 
     test_prior_mean = zeros(num_dim) + 0.1
-    test_prior_cov = eye(num_dim) * 0.5  # In train priors
+    test_prior_cov = eye(num_dim) * 0.4  # In train priors
     test_prior = MultivariateNormal(
         loc=test_prior_mean, covariance_matrix=test_prior_cov
     )


### PR DESCRIPTION
This fixes currently failing test (by small C2ST margin) by making the test prior more within train domain (i.e. for uniform). 

Not entirely sure why this tests only showed up once merging into main, not within the original feature branch.