### PR TITLE
layernorm and various activations for FC embedding

### DIFF
--- a/sbi/neural_nets/embedding_nets/fully_connected.py
+++ b/sbi/neural_nets/embedding_nets/fully_connected.py
@@ -13,6 +13,8 @@ class FCEmbedding(nn.Module):
         output_dim: int = 20,
         num_layers: int = 2,
         num_hiddens: int = 50,
+        enable_layer_norm: bool = False,
+        activation: nn.Module = nn.ReLU,
     ):
         """Fully-connected multi-layer neural network to be used as embedding network.
 
@@ -21,16 +23,24 @@ class FCEmbedding(nn.Module):
             output_dim: Dimensionality of the output.
             num_layers: Number of layers of the embedding network. (Minimum of 2).
             num_hiddens: Number of hidden units in each layer of the embedding network.
+            enable_layer_norm: Enable layer normalization. Default is False.
+            activation: Activation function. Default is nn.ReLU.
         """
         super().__init__()
-        layers = [nn.Linear(input_dim, num_hiddens), nn.ReLU()]
+        layer_norm = nn.LayerNorm if enable_layer_norm else nn.Identity
+        layers = [
+            nn.Linear(input_dim, num_hiddens),
+            layer_norm(num_hiddens),
+            activation(),
+        ]
         # first and last layer is defined by the input and output dimension.
         # therefor the "number of hidden layeres" is num_layers-2
         for _ in range(num_layers - 2):
             layers.append(nn.Linear(num_hiddens, num_hiddens))
-            layers.append(nn.ReLU())
+            layers.append(layer_norm(num_hiddens))
+            layers.append(activation())
         layers.append(nn.Linear(num_hiddens, output_dim))
-        layers.append(nn.ReLU())
+        layers.append(activation())
         self.net = nn.Sequential(*layers)
 
     def forward(self, x: Tensor) -> Tensor:

--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -7,7 +7,7 @@ import math
 
 import pytest
 import torch
-from torch import Tensor, eye, ones, zeros
+from torch import Tensor, eye, nn, ones, zeros
 from torch.distributions import MultivariateNormal
 
 from sbi import utils
@@ -172,6 +172,44 @@ def test_1d_and_2d_cnn_embedding_net(input_shape, num_channels):
         x = x.unsqueeze(1).repeat(
             1, num_channels, *[1 for _ in range(len(input_shape))]
         )
+
+    trainer = NPE(prior=prior, density_estimator=estimator_provider)
+    trainer.append_simulations(theta, x).train(max_num_epochs=2)
+    posterior = trainer.build_posterior().set_default_x(xo)
+
+    s = posterior.sample((10,))
+    posterior.potential(s)
+
+
+@pytest.mark.parametrize("input_shape", [(2,), (128,)])
+@pytest.mark.parametrize("num_layers", [2, 4])
+@pytest.mark.parametrize("num_hiddens", [32, 64])
+@pytest.mark.parametrize("layer_norm", [True, False])
+@pytest.mark.parametrize("activation", [nn.ReLU, nn.GELU])
+def test_1d_fc_embedding_net(
+    input_shape, num_layers, num_hiddens, layer_norm, activation
+):
+    estimator_provider = posterior_nn(
+        "mdn",
+        embedding_net=FCEmbedding(
+            input_shape[0], 20, num_layers, num_hiddens, layer_norm, activation
+        ),
+    )
+
+    num_dim = input_shape[0]
+
+    def simulator1d(theta):
+        return torch.rand_like(theta) + theta
+
+    if len(input_shape) == 1:
+        simulator = simulator1d
+        xo = torch.ones(1, *input_shape)
+
+    prior = MultivariateNormal(torch.zeros(num_dim), torch.eye(num_dim))
+
+    num_simulations = 1000
+    theta = prior.sample(torch.Size((num_simulations,)))
+    x = simulator(theta)
 
     trainer = NPE(prior=prior, density_estimator=estimator_provider)
     trainer.append_simulations(theta, x).train(max_num_epochs=2)


### PR DESCRIPTION
Hi everyone, 

We had a lot of success in using a slightly modified version of the FC embedding in our work. Adding the layer normalization and modifying the activation to GELU greatly increased the performances of the SBI pipeline in our use case. 

In this PR, I propose to add slight variations when building the FC embedding importable from SBI, and let the user enable the layer normalization and use a custom activation. This simply comes handy and allows us not to define a full network on our own. This change should be retro-compatible, and the behaviour of the FC embedding is not changed if used with the default parameters. 

Tell me if this is of your interest 😄 