### PR TITLE
fix: Quick fix error on broadcasting refactoring on estimators #1791 

### DIFF
--- a/sbi/neural_nets/estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixed_density_estimator.py
@@ -148,7 +148,7 @@ class MixedDensityEstimator(ConditionalDensityEstimator):
         combined_condition = combined_condition.reshape(combined_batch_size, -1)
 
         disc_log_prob = self.discrete_net.log_prob(
-            input=disc_input, condition=condition_flat
+            input=disc_input, condition=condition
         )
 
         cont_input_reshaped = cont_input.reshape((1, combined_batch_size, -1))


### PR DESCRIPTION
This is a hotfix on unexpected slow test failures from #1791 , maybe @satwiksps can also have a look.

Locally these slow tests pass now. Maybe @janfb can also have a look as its concerning MNLE (a flattening that is no longer necessary).

I also have a general implementation question there:
```python
       num_discrete_variables = self.discrete_net.net.num_variables
       cont_input, disc_input = _separate_input(input, num_discrete_variables)
        # Embed continuous condition
        embedded_condition = self.condition_embedding(condition_flat)
        embedded_condition = embedded_condition.reshape(sample_dim, batch_dim, -1)
        combined_condition = torch.cat((disc_input, embedded_condition), dim=-1)
        combined_condition = combined_condition.reshape(combined_batch_size, -1)

        disc_log_prob = self.discrete_net.log_prob(
            input=disc_input, condition=condition              # Before condition_flat, but why not from the embedding_net output?
        )
```