### PR TITLE
Add explicit init() to BasePotential and NeuralPosterior

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -82,7 +82,7 @@ class NeuralPosterior:
         self._initialized = False
 
     def init(self):
-        """Initialize the underlying potential before sampling."""       
+        """Initialize the underlying potential before sampling."""
         self.potential_fn.init()
         self._initialized = True
         return self

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -78,6 +78,15 @@ class NeuralPosterior:
         # already to the potential function builder. If so, this `x_o` will be used
         # as default x.
         self._x = self.potential_fn.return_x_o()
+        
+        self._initialized = False
+        
+    def init(self):
+        """Initialize the underlying potential before sampling."""
+        if hasattr(self.potential_fn, "init"):
+            self.potential_fn.init()
+        self._initialized = True
+        return self
 
     def potential(
         self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False
@@ -93,6 +102,8 @@ class NeuralPosterior:
                 This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
         """
+        if not self._initialized:
+            raise RuntimeError("Call init() before using the posterior.")
         self.potential_fn.set_x(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -78,9 +78,9 @@ class NeuralPosterior:
         # already to the potential function builder. If so, this `x_o` will be used
         # as default x.
         self._x = self.potential_fn.return_x_o()
-        
+
         self._initialized = False
-        
+
     def init(self):
         """Initialize the underlying potential before sampling."""
         if hasattr(self.potential_fn, "init"):

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -102,7 +102,7 @@ class NeuralPosterior:
                 consumption.
         """
         if not self._initialized:
-            raise RuntimeError("Call init() before using the posterior.")
+            self.init()
         self.potential_fn.set_x(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -82,9 +82,8 @@ class NeuralPosterior:
         self._initialized = False
 
     def init(self):
-        """Initialize the underlying potential before sampling."""
-        if hasattr(self.potential_fn, "init"):
-            self.potential_fn.init()
+        """Initialize the underlying potential before sampling."""       
+        self.potential_fn.init()
         self._initialized = True
         return self
 
@@ -103,7 +102,9 @@ class NeuralPosterior:
                 consumption.
         """
         if not self._initialized:
-            self.init()
+            raise RuntimeError(
+                "Call init() before using the posterior."
+            )
         self.potential_fn.set_x(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -102,9 +102,7 @@ class NeuralPosterior:
                 consumption.
         """
         if not self._initialized:
-            raise RuntimeError(
-                "Call init() before using the posterior."
-            )
+            raise RuntimeError("Call init() before using the posterior.")
         self.potential_fn.set_x(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -103,7 +103,7 @@ class NeuralPosterior:
                 consumption.
         """
         if not self._initialized:
-            raise RuntimeError("Call init() before using the posterior.")
+            self.init()
         self.potential_fn.set_x(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -143,8 +143,6 @@ class CustomPotentialWrapper(BasePotential):
         Note, x_o is re-used from the initialization of the potential function.
         """
         if not self._initialized:
-            raise RuntimeError(
-                "Call init() before using this potential."
-            )
+            raise RuntimeError("Call init() before using this potential.")
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -143,6 +143,6 @@ class CustomPotentialWrapper(BasePotential):
         Note, x_o is re-used from the initialization of the potential function.
         """
         if not self._initialized:
-            raise RuntimeError("Call init() before using this potential.")
+            self.init()
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -30,6 +30,12 @@ class BasePotential(metaclass=ABCMeta):
         self.device = device
         self.prior = prior
         self.set_x(x_o)
+        self._initialized = False
+        
+    def init(self, *args, **kwargs):
+        """Initialize potential (can be overridden by subclasses)."""
+        self._initialized = True
+        return self
 
     @abstractmethod
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
@@ -136,5 +142,7 @@ class CustomPotentialWrapper(BasePotential):
 
         Note, x_o is re-used from the initialization of the potential function.
         """
+        if not self._initialized:
+            raise RuntimeError("Call init() before using this potential.")
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -31,7 +31,7 @@ class BasePotential(metaclass=ABCMeta):
         self.prior = prior
         self.set_x(x_o)
         self._initialized = False
-        
+
     def init(self, *args, **kwargs):
         """Initialize potential (can be overridden by subclasses)."""
         self._initialized = True

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -32,7 +32,7 @@ class BasePotential(metaclass=ABCMeta):
         self.set_x(x_o)
         self._initialized = False
 
-    def init(self, *args, **kwargs):
+    def init(self):
         """Initialize potential (can be overridden by subclasses)."""
         self._initialized = True
         return self
@@ -143,6 +143,8 @@ class CustomPotentialWrapper(BasePotential):
         Note, x_o is re-used from the initialization of the potential function.
         """
         if not self._initialized:
-            self.init()
+            raise RuntimeError(
+                "Call init() before using this potential."
+            )
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)


### PR DESCRIPTION
### Summary
Added an `_initialized` flag and an `init()` method to `BasePotential` and `NeuralPosterior`.

### What changed
You can now explicitly initialize the posterior or potential by calling `init()`.  
At the same time, things will still work as before if `init()` is not called.

### Why
In some cases, using the posterior or potential without proper initialization could lead to subtle issues.  
This change makes initialization clearer and more explicit, while keeping everything backward compatible.

### Example
```python
posterior = NeuralPosterior(potential_fn)

# optional explicit initialization
posterior.init().sample()

# still works without calling init()
posterior.sample()