### PR TITLE
Fix process_device dropping CUDA device index

### DIFF
--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -54,7 +54,7 @@ def process_device(device: Union[str, torch.device]) -> str:
             if isinstance(device, torch.device):
                 device = device.type
             check_device(device)
-            
+
         return device
 
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -52,7 +52,8 @@ def process_device(device: Union[str, torch.device]) -> str:
         # Else, check whether the custom device is valid.
         else:
             if isinstance(device, torch.device):
-                device = device.type
+                device = str(device)
+
             check_device(device)
 
         return device

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -51,10 +51,10 @@ def process_device(device: Union[str, torch.device]) -> str:
                 )
         # Else, check whether the custom device is valid.
         else:
-            check_device(device)
             if isinstance(device, torch.device):
                 device = device.type
-
+            check_device(device)
+            
         return device
 
 


### PR DESCRIPTION
Fix process_device dropping CUDA device index.

Previously, passing torch.device('cuda:1') returned 'cuda',
which caused loss of the device index information.

This was due to converting torch.device using `.type`, which
removes the index. This fix converts torch.device to string
before validation, preserving the full device specification
(e.g. 'cuda:1').

This change is minimal and does not affect behavior for other
valid inputs such as 'cpu', 'cuda', or 'mps'.