### PR TITLE
Add foundation types and renames for NN Builder refactor

### DIFF
--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -15,7 +15,7 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators import MixedDensityEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
 
@@ -66,7 +66,7 @@ class MNLE(LikelihoodEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["mnle"],
-            ConditionalEstimatorBuilder[MixedDensityEstimator],
+            ConditionalEstimatorBuildFn[MixedDensityEstimator],
         ] = "mnle",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -83,7 +83,7 @@ class MNLE(LikelihoodEstimatorTrainer):
             density_estimator: If it is a string, it must be "mnle" to use the
                 preconfiugred neural nets for MNLE. Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/nle/nle_a.py
+++ b/sbi/inference/trainers/nle/nle_a.py
@@ -9,7 +9,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 from sbi.inference.trainers.nle.nle_base import LikelihoodEstimatorTrainer
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
 )
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -60,7 +60,7 @@ class NLE_A(LikelihoodEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -77,7 +77,7 @@ class NLE_A(LikelihoodEstimatorTrainer):
             density_estimator: If it is a string, use a pre-configured network of the
                 provided type (one of nsf, maf, mdn, made). Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -23,7 +23,7 @@ from sbi.inference.trainers._contracts import StartIndexContext, TrainConfig
 from sbi.inference.trainers.base import NeuralInference
 from sbi.neural_nets import likelihood_nn
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
 )
@@ -38,7 +38,7 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -56,7 +56,7 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
             density_estimator: If it is a string, use a pre-configured network of the
                 provided type (one of nsf, maf, mdn, made). Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -16,7 +16,7 @@ from sbi.inference.posteriors.posterior_parameters import (
 )
 from sbi.inference.trainers.npe.npe_c import NPE_C
 from sbi.neural_nets.estimators import MixedDensityEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
 
@@ -68,7 +68,7 @@ class MNPE(NPE_C):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["mnpe"],
-            ConditionalEstimatorBuilder[MixedDensityEstimator],
+            ConditionalEstimatorBuildFn[MixedDensityEstimator],
         ] = "mnpe",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -85,7 +85,7 @@ class MNPE(NPE_C):
             density_estimator: If it is a string, it must be "mnpe" to use the
                 preconfigured neural nets for MNPE. Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -16,7 +16,7 @@ from sbi.inference.trainers.npe.npe_base import (
 )
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.mixture_density_estimator import (
     MixtureDensityEstimator,
@@ -90,7 +90,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["mdn_snpe_a"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "mdn_snpe_a",
         num_components: int = 10,
         device: str = "cpu",
@@ -109,7 +109,7 @@ class NPE_A(PosteriorEstimatorTrainer):
             density_estimator: If it is a string (only "mdn_snpe_a" is valid), use a
                 pre-configured mixture of densities network. Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -14,7 +14,7 @@ from sbi.inference.trainers.npe.npe_base import (
 )
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.shape_handling import reshape_to_sample_batch_event
 from sbi.sbi_types import Tracker
@@ -73,7 +73,7 @@ class NPE_B(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -89,7 +89,7 @@ class NPE_B(PosteriorEstimatorTrainer):
             density_estimator: If it is a string, use a pre-configured network of the
                 provided type (one of nsf, maf, mdn, made). Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -34,7 +34,7 @@ from sbi.inference.trainers.base import (
 )
 from sbi.neural_nets import posterior_nn
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
@@ -63,7 +63,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -81,7 +81,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             density_estimator: If it is a string, use a pre-configured network of the
                 provided type (one of nsf, maf, mdn, made). Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -14,7 +14,7 @@ from sbi.inference.trainers.npe.npe_base import (
 )
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.mixture_density_estimator import (
     MixtureDensityEstimator,
@@ -90,7 +90,7 @@ class NPE_C(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            ConditionalEstimatorBuilder[ConditionalDensityEstimator],
+            ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -106,7 +106,7 @@ class NPE_C(PosteriorEstimatorTrainer):
             density_estimator: If it is a string, use a pre-configured network of the
                 provided type (one of nsf, maf, mdn, made). Alternatively, a function
                 that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuilder` protocol can be provided. The function
+                `ConditionalEstimatorBuildFn` protocol can be provided. The function
                 will be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. The
                 density estimator needs to provide the methods `.log_prob` and

--- a/sbi/inference/trainers/npe/npe_pfn.py
+++ b/sbi/inference/trainers/npe/npe_pfn.py
@@ -27,7 +27,7 @@ from sbi.inference.trainers.base import NeuralInference
 from sbi.neural_nets import posterior_nn
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.tabpfn_flow import TabPFNFlow
 from sbi.sbi_types import TorchTransform, Tracker
@@ -53,7 +53,7 @@ class NPE_PFN(NeuralInference[ConditionalDensityEstimator]):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        density_estimator: Optional[ConditionalEstimatorBuilder[TabPFNFlow]] = None,
+        density_estimator: Optional[ConditionalEstimatorBuildFn[TabPFNFlow]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -10,7 +10,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi.inference.trainers._contracts import LossArgs, LossArgsBNRE
 from sbi.inference.trainers.nre.nre_a import NRE_A
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -65,7 +65,7 @@ class BNRE(NRE_A):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuilder[RatioEstimator]] = "resnet",
+        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -81,7 +81,7 @@ class BNRE(NRE_A):
             classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuilder` protocol. The callable will
+                `ConditionalEstimatorBuildFn` protocol. The callable will
                 be called with the first batch of simulations (theta, x), which can thus
                 be used for shape inference and potentially for z-scoring. It returns a
                 `RatioEstimator`.

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -12,7 +12,7 @@ from sbi.inference.trainers._contracts import LossArgsNRE_A
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -63,7 +63,7 @@ class NRE_A(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuilder[RatioEstimator]] = "resnet",
+        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -79,7 +79,7 @@ class NRE_A(RatioEstimatorTrainer):
             classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuilder` protocol. The callable will
+                `ConditionalEstimatorBuildFn` protocol. The callable will
                 be called with the first batch of simulations (theta, x), which can
                 thus be used for shape inference and potentially for z-scoring. It
                 returns a `RatioEstimator`.

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -12,7 +12,7 @@ from sbi.inference.trainers._contracts import LossArgsNRE
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -63,7 +63,7 @@ class NRE_B(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuilder[RatioEstimator]] = "resnet",
+        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -79,7 +79,7 @@ class NRE_B(RatioEstimatorTrainer):
             classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuilder` protocol. The callable will
+                `ConditionalEstimatorBuildFn` protocol. The callable will
                 be called with the first batch of simulations (theta, x), which can thus
                 be used for shape inference and potentially for z-scoring. It returns a
                 `RatioEstimator`.

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -31,7 +31,7 @@ from sbi.inference.trainers.base import (
     NeuralInference,
 )
 from sbi.neural_nets import classifier_nn
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
@@ -45,7 +45,7 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuilder[RatioEstimator]] = "resnet",
+        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -73,7 +73,7 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuilder` protocol. The callable will
+                `ConditionalEstimatorBuildFn` protocol. The callable will
                 be called with the first batch of simulations (theta, x), which can thus
                 be used for shape inference and potentially for z-scoring. It returns a
                 `RatioEstimator`.

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -12,7 +12,7 @@ from sbi.inference.trainers._contracts import LossArgs, LossArgsNRE_C
 from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -60,7 +60,7 @@ class NRE_C(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuilder[RatioEstimator]] = "resnet",
+        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -76,7 +76,7 @@ class NRE_C(RatioEstimatorTrainer):
             classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuilder` protocol. The callable will
+                `ConditionalEstimatorBuildFn` protocol. The callable will
                 be called with the first batch of simulations (theta, x), which can thus
                 be used for shape inference and potentially for z-scoring. It returns a
                 `RatioEstimator`.

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -23,7 +23,7 @@ from sbi.inference.potentials.vector_field_potential import (
 from sbi.inference.trainers._contracts import LossArgsVF, StartIndexContext, TrainConfig
 from sbi.inference.trainers.base import LossArgs
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
     check_estimator_arg,
@@ -43,7 +43,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         prior: Optional[Distribution] = None,
         vector_field_estimator_builder: Union[
             Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-            ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator],
+            ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
         ] = "mlp",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -62,7 +62,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             prior: Prior distribution.
             vector_field_estimator_builder: Neural network architecture for the
                 vector field estimator. Can be a string (e.g. 'mlp' or 'ada_mlp') or a
-                callable that implements the `ConditionalEstimatorBuilder` protocol
+                callable that implements the `ConditionalEstimatorBuildFn` protocol
                 with `__call__` that receives `theta` and `x` and returns a
                 `ConditionalVectorFieldEstimator`.
             device: Device to run the training on.
@@ -101,7 +101,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
     def _build_default_nn_fn(
         self,
         model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-    ) -> ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator]: ...
+    ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]: ...
 
     def append_simulations(
         self,

--- a/sbi/inference/trainers/vfpe/fmpe.py
+++ b/sbi/inference/trainers/vfpe/fmpe.py
@@ -15,7 +15,7 @@ from sbi.inference.trainers.vfpe.base_vf_inference import (
     VectorFieldTrainer,
 )
 from sbi.neural_nets.estimators.base import (
-    ConditionalEstimatorBuilder,
+    ConditionalEstimatorBuildFn,
     ConditionalVectorFieldEstimator,
 )
 from sbi.neural_nets.factory import posterior_flow_nn
@@ -70,10 +70,10 @@ class FMPE(VectorFieldTrainer):
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
             Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-            ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator],
+            ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
         ] = "mlp",
         density_estimator: Optional[
-            ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator]
+            ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]
         ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -88,7 +88,7 @@ class FMPE(VectorFieldTrainer):
             vf_estimator: Neural network architecture used to learn the
                 vector field estimator. Can be a string (e.g. 'mlp', 'ada_mlp',
                 'transformer' or 'transformer_cross_attn') or a callable that implements
-                the `ConditionalEstimatorBuilder` protocol with `__call__` that receives
+                the `ConditionalEstimatorBuildFn` protocol with `__call__` that receives
                 `theta` and `x` and returns a `ConditionalVectorFieldEstimator`.
                 To configure estimator-level options, use `posterior_flow_nn` to
                 build a custom callable and pass it here.
@@ -174,5 +174,5 @@ class FMPE(VectorFieldTrainer):
     def _build_default_nn_fn(
         self,
         model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-    ) -> ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator]:
+    ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]:
         return posterior_flow_nn(model=model)

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -13,7 +13,7 @@ from sbi.inference.trainers.vfpe.base_vf_inference import (
     VectorFieldTrainer,
 )
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
-from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.factory import posterior_score_nn
 from sbi.sbi_types import Tracker
 
@@ -66,16 +66,16 @@ class NPSE(VectorFieldTrainer):
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
             Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-            ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator],
+            ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
         ] = "mlp",
         score_estimator: Optional[
             Union[
                 Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-                ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator],
+                ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
             ]
         ] = None,
         density_estimator: Optional[
-            ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator]
+            ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]
         ] = None,
         sde_type: Literal["vp", "ve", "subvp"] = "ve",
         device: str = "cpu",
@@ -92,7 +92,7 @@ class NPSE(VectorFieldTrainer):
                 vector field estimator aiming to estimate the marginal scores of the
                 target diffusion process. Can be a string (e.g. 'mlp', 'ada_mlp',
                 'transformer' or 'transformer_cross_attn') or a callable that implements
-                the `ConditionalEstimatorBuilder` protocol with `__call__` that receives
+                the `ConditionalEstimatorBuildFn` protocol with `__call__` that receives
                 `theta` and `x` and returns a `ConditionalVectorFieldEstimator`.
                 To configure estimator-level options (e.g. noise schedules for VE),
                 use `posterior_score_nn` to build a custom callable and pass it here.
@@ -199,5 +199,5 @@ class NPSE(VectorFieldTrainer):
         self,
         model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
         sde_type: Literal["vp", "ve", "subvp"] = "ve",
-    ) -> ConditionalEstimatorBuilder[ConditionalVectorFieldEstimator]:
+    ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]:
         return posterior_score_nn(model=model, sde_type=sde_type)

--- a/sbi/neural_nets/build_context.py
+++ b/sbi/neural_nets/build_context.py
@@ -44,11 +44,18 @@ class ZScoreConfig:
                 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ZScoreStats:
     """Computed z-score statistics derived from training data.
 
     Fields are ``None`` when the corresponding axis was not z-scored.
+
+    .. note::
+        Equality and hashing use object identity (``a == b`` iff ``a is b``).
+        For *content* comparison of stats, compare each tensor field directly
+        with ``torch.equal`` or use ``torch.testing.assert_close`` in tests.
+        Custom value-equality may be added later if a concrete consumer
+        (e.g., a build cache) requires it.
     """
 
     theta_mean: Optional[Tensor] = None
@@ -57,7 +64,7 @@ class ZScoreStats:
     x_std: Optional[Tensor] = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class BuildContext:
     """All data-derived state needed to construct an estimator.
 
@@ -96,7 +103,15 @@ class BuildContext:
 
         Returns:
             A new ``BuildContext`` instance.
+
+        Raises:
+            ValueError: If ``theta`` and ``x`` are on different devices.
         """
+        if theta.device != x.device:
+            raise ValueError(
+                f"theta and x must be on the same device, got "
+                f"{theta.device} and {x.device}."
+            )
         return cls(
             theta_shape=torch.Size(theta.shape[1:]),
             x_shape=torch.Size(x.shape[1:]),
@@ -129,12 +144,12 @@ def compute_z_score_stats(
     x_mean, x_std = None, None
 
     if config.theta != "none":
-        structured = config.theta == "structured"
-        theta_mean, theta_std = z_standardization(theta, structured)
+        theta_mean, theta_std = z_standardization(
+            theta, structured_dims=(config.theta == "structured")
+        )
 
     if config.x != "none":
-        structured = config.x == "structured"
-        x_mean, x_std = z_standardization(x, structured)
+        x_mean, x_std = z_standardization(x, structured_dims=(config.x == "structured"))
 
     return ZScoreStats(
         theta_mean=theta_mean,

--- a/sbi/neural_nets/build_context.py
+++ b/sbi/neural_nets/build_context.py
@@ -50,7 +50,7 @@ class ZScoreStats:
 
     Fields are ``None`` when the corresponding axis was not z-scored.
 
-    .. note::
+    Note:
         Equality and hashing use object identity (``a == b`` iff ``a is b``).
         For *content* comparison of stats, compare each tensor field directly
         with ``torch.equal`` or use ``torch.testing.assert_close`` in tests.

--- a/sbi/neural_nets/build_context.py
+++ b/sbi/neural_nets/build_context.py
@@ -1,0 +1,144 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+"""Supporting types for the Builder pattern: configuration, data-derived state,
+and z-score computation.
+
+``ZScoreConfig`` captures the user's preprocessing choice (per-axis z-score mode).
+``ZScoreStats`` holds the computed statistics. ``BuildContext`` bundles all
+data-derived state needed by ``_EstimatorBuilderBase.build()``.
+
+``compute_z_score_stats`` is a pure helper that bridges config + data → stats.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+import torch
+from torch import Tensor
+
+from sbi.utils.sbiutils import z_standardization
+
+
+@dataclass(frozen=True)
+class ZScoreConfig:
+    """User-facing choice for z-score preprocessing per axis.
+
+    Attributes:
+        theta: Z-score mode for parameters. One of ``"none"``,
+            ``"independent"`` (per-dimension), ``"structured"`` (single
+            mean/std across all dimensions).
+        x: Z-score mode for simulation outputs, same options as ``theta``.
+    """
+
+    theta: Literal["none", "independent", "structured"] = "independent"
+    x: Literal["none", "independent", "structured"] = "independent"
+
+    def __post_init__(self):
+        allowed = ("none", "independent", "structured")
+        for name in ("theta", "x"):
+            val = getattr(self, name)
+            if val not in allowed:
+                raise ValueError(
+                    f"ZScoreConfig.{name} must be one of {allowed}, got '{val}'"
+                )
+
+
+@dataclass(frozen=True)
+class ZScoreStats:
+    """Computed z-score statistics derived from training data.
+
+    Fields are ``None`` when the corresponding axis was not z-scored.
+    """
+
+    theta_mean: Optional[Tensor] = None
+    theta_std: Optional[Tensor] = None
+    x_mean: Optional[Tensor] = None
+    x_std: Optional[Tensor] = None
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    """All data-derived state needed to construct an estimator.
+
+    Carries shape / device / dtype and computed z-score stats.  Does NOT carry
+    trainer lifecycle state (round index, retrain flags, etc.) — that stays in
+    the trainer.
+
+    Attributes:
+        theta_shape: Event shape of parameters (excluding batch dimension).
+        x_shape: Event shape of simulation outputs (excluding batch dimension).
+        z_score_stats: Pre-computed z-score statistics.
+        device: Target device for the estimator.
+        dtype: Target dtype for the estimator.
+    """
+
+    theta_shape: torch.Size
+    x_shape: torch.Size
+    z_score_stats: ZScoreStats = field(default_factory=ZScoreStats)
+    device: torch.device = field(default_factory=lambda: torch.device("cpu"))
+    dtype: torch.dtype = torch.float32
+
+    @classmethod
+    def from_data(
+        cls,
+        theta: Tensor,
+        x: Tensor,
+        z_score_stats: Optional[ZScoreStats] = None,
+    ) -> "BuildContext":
+        """Construct a ``BuildContext`` by inferring shapes from training data.
+
+        Args:
+            theta: Parameter batch of shape ``(batch_size, *event_shape)``.
+            x: Simulation output batch of shape ``(batch_size, *event_shape)``.
+            z_score_stats: Pre-computed z-score statistics, or ``None`` for
+                defaults (no stats).
+
+        Returns:
+            A new ``BuildContext`` instance.
+        """
+        return cls(
+            theta_shape=torch.Size(theta.shape[1:]),
+            x_shape=torch.Size(x.shape[1:]),
+            z_score_stats=z_score_stats or ZScoreStats(),
+            device=theta.device,
+            dtype=theta.dtype,
+        )
+
+
+def compute_z_score_stats(
+    theta: Tensor,
+    x: Tensor,
+    config: ZScoreConfig,
+) -> ZScoreStats:
+    """Compute z-score statistics from training data.
+
+    Delegates to the existing ``z_standardization`` function for the actual
+    mean/std computation.
+
+    Args:
+        theta: Parameter batch of shape ``(batch_size, *event_shape)``.
+        x: Simulation output batch of shape ``(batch_size, *event_shape)``.
+        config: Per-axis z-score mode.
+
+    Returns:
+        A ``ZScoreStats`` instance with computed means and standard deviations
+        for the requested axes.
+    """
+    theta_mean, theta_std = None, None
+    x_mean, x_std = None, None
+
+    if config.theta != "none":
+        structured = config.theta == "structured"
+        theta_mean, theta_std = z_standardization(theta, structured)
+
+    if config.x != "none":
+        structured = config.x == "structured"
+        x_mean, x_std = z_standardization(x, structured)
+
+    return ZScoreStats(
+        theta_mean=theta_mean,
+        theta_std=theta_std,
+        x_mean=x_mean,
+        x_std=x_std,
+    )

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -698,3 +698,21 @@ class UnconditionalDensityEstimator(UnconditionalEstimator):
         samples = self.sample(sample_shape)
         log_probs = self.log_prob(samples)
         return samples, log_probs
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ (PEP 562) for deprecated import names."""
+    if name == "ConditionalEstimatorBuilder":
+        import warnings
+
+        warnings.warn(
+            "`ConditionalEstimatorBuilder` has been renamed to "
+            "`ConditionalEstimatorBuildFn`. The old name still works but will be "
+            "removed in a future release. Update your import to: "
+            "`from sbi.neural_nets.estimators.base import "
+            "ConditionalEstimatorBuildFn`.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return ConditionalEstimatorBuildFn
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -14,22 +14,20 @@ ConditionalEstimatorType = TypeVar(
 )
 
 
-class ConditionalEstimatorBuilder(Protocol[ConditionalEstimatorType]):
-    """Protocol for building a neural network from the data for the density
-    estimator."""
+class ConditionalEstimatorBuildFn(Protocol[ConditionalEstimatorType]):
+    """Protocol for a callable that builds a conditional estimator from data."""
 
     def __call__(self, theta: Tensor, x: Tensor) -> ConditionalEstimatorType:
-        """Build a density estimator from theta and x, which is mainly used for infering
-        shape and z-scoring. The density estimator should have the methods `.sample()`
-        and `.log_prob()`. The function should return an inheritance
-        of `ConditionalEstimator`.
+        """Build an estimator from theta and x, used for shape inference and
+        z-scoring. The returned object should be a ``ConditionalEstimator``
+        subclass.
 
         Args:
             theta: Parameter sets.
             x: Simulation outputs.
 
         Returns:
-            Density Estimator.
+            A conditional estimator.
         """
         ...
 

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -80,9 +80,7 @@ class _EstimatorBuilderBase:
         Returns:
             A ``ConditionalEstimator`` subclass instance.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not implement build()."
-        )
+        raise NotImplementedError(f"{type(self).__name__} does not implement build().")
 
     def to_dict(self) -> dict:
         """Return only explicitly-set (non-``None``) fields as a dict.

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -23,10 +23,13 @@ preserving typed field annotations.
 from dataclasses import dataclass, fields
 from typing import Any, Optional
 
+from sbi.neural_nets.build_context import BuildContext
+
 
 @dataclass
-class _EstimatorConfigBase:
-    """Shared base providing ``from_kwargs()`` and ``to_dict()`` for all configs."""
+class _EstimatorBuilderBase:
+    """Shared base providing ``from_kwargs()``, ``to_dict()``, and the abstract
+    ``build()`` contract for all estimator builders."""
 
     extra_kwargs: dict = None  # type: ignore
 
@@ -35,7 +38,7 @@ class _EstimatorConfigBase:
             self.extra_kwargs = {}
 
     @classmethod
-    def from_kwargs(cls, **kwargs) -> "_EstimatorConfigBase":
+    def from_kwargs(cls, **kwargs) -> "_EstimatorBuilderBase":
         """Create a config, forwarding unknown kwargs into ``extra_kwargs``.
 
         Known fields are set directly on the dataclass; any remaining kwargs
@@ -65,6 +68,22 @@ class _EstimatorConfigBase:
 
         return cls(**known, extra_kwargs=extra)
 
+    def build(self, context: BuildContext) -> Any:
+        """Build an estimator from a ``BuildContext``.
+
+        Subclasses must override this method to construct the appropriate
+        estimator using the shapes, device, and z-score stats in *context*.
+
+        Args:
+            context: Data-derived state (shapes, device, z-score stats).
+
+        Returns:
+            A ``ConditionalEstimator`` subclass instance.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement build()."
+        )
+
     def to_dict(self) -> dict:
         """Return only explicitly-set (non-``None``) fields as a dict.
 
@@ -82,7 +101,7 @@ class _EstimatorConfigBase:
 
 
 @dataclass
-class ConditionalFlowConfig(_EstimatorConfigBase):
+class ConditionalFlowConfig(_EstimatorBuilderBase):
     """Configuration for conditional normalizing-flow density estimator builders.
 
     Used by ``posterior_nn`` and ``likelihood_nn``.  Fields cover all parameters
@@ -142,7 +161,7 @@ class ConditionalFlowConfig(_EstimatorConfigBase):
 
 
 @dataclass
-class ClassifierConfig(_EstimatorConfigBase):
+class ClassifierConfig(_EstimatorBuilderBase):
     """Configuration for classifier builders (NRE).
 
     Covers parameters accepted by ``build_linear_classifier``,
@@ -162,7 +181,7 @@ class ClassifierConfig(_EstimatorConfigBase):
 
 
 @dataclass
-class MarginalFlowConfig(_EstimatorConfigBase):
+class MarginalFlowConfig(_EstimatorBuilderBase):
     """Configuration for marginal density estimator builders.
 
     Used by ``marginal_nn``.  Covers parameters accepted by

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -16,7 +16,7 @@ from sbi.neural_nets.estimators.score_estimator import (
     VEScoreEstimator,
     VPScoreEstimator,
 )
-from sbi.neural_nets.net_builders.estimator_configs import _EstimatorConfigBase
+from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
     standardizing_net,
@@ -28,10 +28,10 @@ from sbi.utils.vector_field_utils import VectorFieldNet
 
 
 @dataclass
-class _VectorFieldBaseConfig(_EstimatorConfigBase):
+class _VectorFieldBaseConfig(_EstimatorBuilderBase):
     """Shared configuration fields for all vector field estimator builders.
 
-    Inherits ``to_dict()`` from ``_EstimatorConfigBase``.
+    Inherits ``to_dict()`` from ``_EstimatorBuilderBase``.
     Defaults are ``None`` so that only explicitly-set fields are forwarded — the
     actual default values live in the estimator / network constructors.
     """

--- a/tests/build_context_test.py
+++ b/tests/build_context_test.py
@@ -140,9 +140,7 @@ class TestComputeZScoreStats:
     def test_none_returns_none(self):
         theta = torch.randn(100, 5)
         x = torch.randn(100, 3)
-        stats = compute_z_score_stats(
-            theta, x, ZScoreConfig(theta="none", x="none")
-        )
+        stats = compute_z_score_stats(theta, x, ZScoreConfig(theta="none", x="none"))
         assert stats.theta_mean is None
         assert stats.theta_std is None
         assert stats.x_mean is None
@@ -222,7 +220,7 @@ class TestProtocolRename:
 
     def test_protocol_exists(self):
         # The protocol should be importable under the new name.
-        assert hasattr(ConditionalEstimatorBuildFn, "__call__")
+        assert callable(ConditionalEstimatorBuildFn)
 
     def test_callable_satisfies_protocol(self):
         """A simple callable with the right signature satisfies the protocol."""

--- a/tests/build_context_test.py
+++ b/tests/build_context_test.py
@@ -10,7 +10,6 @@ Covers ``ZScoreConfig``, ``ZScoreStats``, ``BuildContext``,
 
 import pytest
 import torch
-from torch import Tensor
 
 from sbi.neural_nets.build_context import (
     BuildContext,
@@ -19,215 +18,153 @@ from sbi.neural_nets.build_context import (
     compute_z_score_stats,
 )
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
-from sbi.neural_nets.net_builders.estimator_configs import (
-    ClassifierConfig,
-    ConditionalFlowConfig,
-    MarginalFlowConfig,
-    _EstimatorBuilderBase,
+from sbi.neural_nets.net_builders.estimator_configs import ConditionalFlowConfig
+
+
+def test_zscore_config_defaults():
+    cfg = ZScoreConfig()
+    assert cfg.theta == "independent"
+    assert cfg.x == "independent"
+
+
+@pytest.mark.parametrize(
+    "theta, x",
+    [
+        ("none", "none"),
+        ("independent", "structured"),
+        ("structured", "independent"),
+    ],
 )
+def test_zscore_config_valid_combinations(theta, x):
+    cfg = ZScoreConfig(theta=theta, x=x)
+    assert cfg.theta == theta
+    assert cfg.x == x
 
 
-class TestZScoreConfig:
-    """Validation and immutability of ZScoreConfig."""
-
-    def test_defaults(self):
-        cfg = ZScoreConfig()
-        assert cfg.theta == "independent"
-        assert cfg.x == "independent"
-
-    @pytest.mark.parametrize(
-        "theta, x",
-        [
-            ("none", "none"),
-            ("independent", "structured"),
-            ("structured", "independent"),
-        ],
-    )
-    def test_valid_combinations(self, theta, x):
-        cfg = ZScoreConfig(theta=theta, x=x)
-        assert cfg.theta == theta
-        assert cfg.x == x
-
-    @pytest.mark.parametrize("field", ["theta", "x"])
-    def test_invalid_value_raises(self, field):
-        with pytest.raises(ValueError, match="must be one of"):
-            ZScoreConfig(**{field: "invalid"})
-
-    def test_frozen(self):
-        cfg = ZScoreConfig()
-        with pytest.raises(AttributeError):
-            cfg.theta = "none"
+@pytest.mark.parametrize("field", ["theta", "x"])
+def test_zscore_config_invalid_value_raises(field):
+    with pytest.raises(ValueError, match="must be one of"):
+        ZScoreConfig(**{field: "invalid"})
 
 
-class TestZScoreStats:
-    """Default construction and immutability of ZScoreStats."""
+@pytest.mark.parametrize("device", ["cpu", pytest.param("cuda", marks=pytest.mark.gpu)])
+@pytest.mark.parametrize(
+    "theta_shape, x_shape",
+    [
+        ((100, 5), (100, 3)),
+        ((50, 4), (50, 8, 8)),
+    ],
+)
+def test_build_context_from_data(device, theta_shape, x_shape):
+    """BuildContext.from_data infers shapes, device, and dtype correctly."""
+    theta = torch.randn(*theta_shape, device=device)
+    x = torch.randn(*x_shape, device=device)
+    ctx = BuildContext.from_data(theta, x)
+    assert ctx.theta_shape == torch.Size(theta_shape[1:])
+    assert ctx.x_shape == torch.Size(x_shape[1:])
+    assert ctx.device.type == device
+    assert ctx.dtype == torch.float32
 
-    def test_defaults_are_none(self):
-        stats = ZScoreStats()
+
+def test_build_context_from_data_with_stats():
+    theta = torch.randn(100, 5)
+    x = torch.randn(100, 3)
+    stats = ZScoreStats(theta_mean=torch.zeros(5), theta_std=torch.ones(5))
+    ctx = BuildContext.from_data(theta, x, z_score_stats=stats)
+    assert ctx.z_score_stats is stats
+
+
+@pytest.mark.gpu
+def test_build_context_device_mismatch_raises():
+    """Mismatched cpu/cuda devices raise ValueError."""
+    theta_cpu = torch.randn(10, 3, device="cpu")
+    x_cuda = torch.randn(10, 3, device="cuda")
+    with pytest.raises(ValueError, match="same device"):
+        BuildContext.from_data(theta_cpu, x_cuda)
+
+    with pytest.raises(ValueError, match="same device"):
+        BuildContext.from_data(x_cuda, theta_cpu)
+
+
+@pytest.mark.parametrize("device", ["cpu", pytest.param("cuda", marks=pytest.mark.gpu)])
+@pytest.mark.parametrize(
+    "theta_mode, x_mode",
+    [
+        ("independent", "independent"),
+        ("structured", "structured"),
+        ("independent", "none"),
+        ("none", "none"),
+    ],
+)
+def test_compute_z_score_stats(device, theta_mode, x_mode):
+    """Z-score stats have correct shape, type, and device for all mode combos."""
+    theta = torch.randn(200, 5, device=device)
+    x = torch.randn(200, 3, device=device)
+    stats = compute_z_score_stats(theta, x, ZScoreConfig(theta=theta_mode, x=x_mode))
+
+    if theta_mode == "none":
         assert stats.theta_mean is None
-        assert stats.theta_std is None
-        assert stats.x_mean is None
-        assert stats.x_std is None
-
-    def test_with_tensors(self):
-        m = torch.zeros(5)
-        s = torch.ones(5)
-        stats = ZScoreStats(theta_mean=m, theta_std=s)
-        assert torch.equal(stats.theta_mean, m)
-        assert stats.x_mean is None
-
-    def test_frozen(self):
-        stats = ZScoreStats()
-        with pytest.raises(AttributeError):
-            stats.theta_mean = torch.zeros(3)
-
-
-class TestBuildContext:
-    """Construction and factory method of BuildContext."""
-
-    def test_from_data(self):
-        theta = torch.randn(100, 5)
-        x = torch.randn(100, 3)
-        ctx = BuildContext.from_data(theta, x)
-        assert ctx.theta_shape == torch.Size([5])
-        assert ctx.x_shape == torch.Size([3])
-        assert ctx.device == torch.device("cpu")
-        assert ctx.dtype == torch.float32
-
-    def test_from_data_multidim(self):
-        theta = torch.randn(50, 4)
-        x = torch.randn(50, 8, 8)
-        ctx = BuildContext.from_data(theta, x)
-        assert ctx.theta_shape == torch.Size([4])
-        assert ctx.x_shape == torch.Size([8, 8])
-
-    def test_from_data_with_stats(self):
-        theta = torch.randn(100, 5)
-        x = torch.randn(100, 3)
-        stats = ZScoreStats(theta_mean=torch.zeros(5), theta_std=torch.ones(5))
-        ctx = BuildContext.from_data(theta, x, z_score_stats=stats)
-        assert ctx.z_score_stats is stats
-
-    def test_from_data_default_stats(self):
-        ctx = BuildContext.from_data(torch.randn(10, 2), torch.randn(10, 3))
-        assert ctx.z_score_stats.theta_mean is None
-
-    def test_frozen(self):
-        ctx = BuildContext(
-            theta_shape=torch.Size([5]),
-            x_shape=torch.Size([3]),
-        )
-        with pytest.raises(AttributeError):
-            ctx.theta_shape = torch.Size([10])
-
-
-class TestComputeZScoreStats:
-    """Correctness of the pure z-score stats computation."""
-
-    def test_independent_computes_per_dim(self):
-        torch.manual_seed(42)
-        theta = torch.randn(1000, 5)
-        x = torch.randn(1000, 3)
-        stats = compute_z_score_stats(theta, x, ZScoreConfig())
-
-        assert stats.theta_mean is not None
-        assert stats.theta_std is not None
+    elif theta_mode == "independent":
         assert stats.theta_mean.shape == (5,)
-        assert stats.theta_std.shape == (5,)
-        assert stats.x_mean.shape == (3,)
-        assert stats.x_std.shape == (3,)
-
-    def test_none_returns_none(self):
-        theta = torch.randn(100, 5)
-        x = torch.randn(100, 3)
-        stats = compute_z_score_stats(theta, x, ZScoreConfig(theta="none", x="none"))
-        assert stats.theta_mean is None
-        assert stats.theta_std is None
-        assert stats.x_mean is None
-        assert stats.x_std is None
-
-    def test_structured_returns_scalar(self):
-        theta = torch.randn(100, 5)
-        x = torch.randn(100, 3)
-        stats = compute_z_score_stats(
-            theta, x, ZScoreConfig(theta="structured", x="structured")
-        )
-        # Structured mode computes a single mean/std scalar.
+        assert stats.theta_mean.device.type == device
+    else:
         assert stats.theta_mean.dim() == 0
-        assert stats.x_mean.dim() == 0
+        assert stats.theta_mean.device.type == device
 
-    def test_mixed_modes(self):
-        theta = torch.randn(100, 5)
-        x = torch.randn(100, 3)
-        stats = compute_z_score_stats(
-            theta, x, ZScoreConfig(theta="independent", x="none")
-        )
-        assert stats.theta_mean is not None
-        assert stats.theta_mean.shape == (5,)
+    if x_mode == "none":
         assert stats.x_mean is None
-
-    def test_matches_z_standardization(self):
-        """Output must match the existing z_standardization function."""
-        from sbi.utils.sbiutils import z_standardization
-
-        torch.manual_seed(0)
-        theta = torch.randn(200, 4)
-        x = torch.randn(200, 6)
-
-        stats = compute_z_score_stats(theta, x, ZScoreConfig())
-        expected_t_mean, expected_t_std = z_standardization(theta, False)
-        expected_x_mean, expected_x_std = z_standardization(x, False)
-
-        torch.testing.assert_close(stats.theta_mean, expected_t_mean)
-        torch.testing.assert_close(stats.theta_std, expected_t_std)
-        torch.testing.assert_close(stats.x_mean, expected_x_mean)
-        torch.testing.assert_close(stats.x_std, expected_x_std)
+    elif x_mode == "independent":
+        assert stats.x_mean.shape == (3,)
+        assert stats.x_mean.device.type == device
+    else:
+        assert stats.x_mean.dim() == 0
+        assert stats.x_mean.device.type == device
 
 
-class TestEstimatorBuilderBase:
-    """The renamed base class retains existing functionality and adds build()."""
+def test_compute_z_score_stats_matches_z_standardization():
+    """Output must match the existing z_standardization function."""
+    from sbi.utils.sbiutils import z_standardization
 
-    def test_build_raises_not_implemented(self):
-        """Subclasses that don't override build() raise NotImplementedError."""
-        cfg = ConditionalFlowConfig(hidden_features=64)
-        ctx = BuildContext(theta_shape=torch.Size([5]), x_shape=torch.Size([3]))
-        with pytest.raises(NotImplementedError, match="does not implement build"):
-            cfg.build(ctx)
+    torch.manual_seed(0)
+    theta = torch.randn(200, 4)
+    x = torch.randn(200, 6)
 
-    def test_from_kwargs_still_works(self):
-        """The existing from_kwargs() + to_dict() contract is preserved."""
-        cfg = ConditionalFlowConfig(hidden_features=64)
-        d = cfg.to_dict()
-        assert d == {"hidden_features": 64}
+    stats = compute_z_score_stats(theta, x, ZScoreConfig())
+    expected_t_mean, expected_t_std = z_standardization(theta, False)
+    expected_x_mean, expected_x_std = z_standardization(x, False)
 
-    def test_from_kwargs_extra_warns(self):
-        with pytest.warns(UserWarning, match="Unknown kwargs"):
-            cfg = ConditionalFlowConfig.from_kwargs(
-                hidden_features=64, some_zuko_param=True
-            )
-        d = cfg.to_dict()
-        assert d == {"hidden_features": 64, "some_zuko_param": True}
-
-    def test_subclasses_inherit(self):
-        """All existing config subclasses now inherit from _EstimatorBuilderBase."""
-        assert issubclass(ConditionalFlowConfig, _EstimatorBuilderBase)
-        assert issubclass(ClassifierConfig, _EstimatorBuilderBase)
-        assert issubclass(MarginalFlowConfig, _EstimatorBuilderBase)
+    torch.testing.assert_close(stats.theta_mean, expected_t_mean)
+    torch.testing.assert_close(stats.theta_std, expected_t_std)
+    torch.testing.assert_close(stats.x_mean, expected_x_mean)
+    torch.testing.assert_close(stats.x_std, expected_x_std)
 
 
-class TestProtocolRename:
-    """ConditionalEstimatorBuildFn exists and has the expected signature."""
+def test_estimator_builder_base_build_raises():
+    """Subclasses that don't override build() raise NotImplementedError."""
+    cfg = ConditionalFlowConfig(hidden_features=64)
+    ctx = BuildContext(theta_shape=torch.Size([5]), x_shape=torch.Size([3]))
+    with pytest.raises(NotImplementedError, match="does not implement build"):
+        cfg.build(ctx)
 
-    def test_protocol_exists(self):
-        # The protocol should be importable under the new name.
-        assert callable(ConditionalEstimatorBuildFn)
 
-    def test_callable_satisfies_protocol(self):
-        """A simple callable with the right signature satisfies the protocol."""
+def test_estimator_builder_base_from_kwargs():
+    """The existing from_kwargs() + to_dict() contract is preserved."""
+    cfg = ConditionalFlowConfig(hidden_features=64)
+    d = cfg.to_dict()
+    assert d == {"hidden_features": 64}
 
-        def dummy_build_fn(theta: Tensor, x: Tensor):
-            return None
 
-        # Runtime isinstance checks don't work with Protocol, but we can verify
-        # the callable has the right signature shape.
-        assert callable(dummy_build_fn)
+def test_estimator_builder_base_extra_warns():
+    with pytest.warns(UserWarning, match="Unknown kwargs"):
+        cfg = ConditionalFlowConfig.from_kwargs(
+            hidden_features=64, some_zuko_param=True
+        )
+    d = cfg.to_dict()
+    assert d == {"hidden_features": 64, "some_zuko_param": True}
+
+
+def test_deprecated_alias_works_with_future_warning():
+    with pytest.warns(FutureWarning, match="renamed to.*ConditionalEstimatorBuildFn"):
+        from sbi.neural_nets.estimators.base import ConditionalEstimatorBuilder
+
+    assert ConditionalEstimatorBuilder is ConditionalEstimatorBuildFn

--- a/tests/build_context_test.py
+++ b/tests/build_context_test.py
@@ -1,0 +1,235 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+"""Tests for the builder-pattern foundation types.
+
+Covers ``ZScoreConfig``, ``ZScoreStats``, ``BuildContext``,
+``compute_z_score_stats``, the ``_EstimatorBuilderBase`` base class, and the
+``ConditionalEstimatorBuildFn`` protocol rename.
+"""
+
+import pytest
+import torch
+from torch import Tensor
+
+from sbi.neural_nets.build_context import (
+    BuildContext,
+    ZScoreConfig,
+    ZScoreStats,
+    compute_z_score_stats,
+)
+from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    ClassifierConfig,
+    ConditionalFlowConfig,
+    MarginalFlowConfig,
+    _EstimatorBuilderBase,
+)
+
+
+class TestZScoreConfig:
+    """Validation and immutability of ZScoreConfig."""
+
+    def test_defaults(self):
+        cfg = ZScoreConfig()
+        assert cfg.theta == "independent"
+        assert cfg.x == "independent"
+
+    @pytest.mark.parametrize(
+        "theta, x",
+        [
+            ("none", "none"),
+            ("independent", "structured"),
+            ("structured", "independent"),
+        ],
+    )
+    def test_valid_combinations(self, theta, x):
+        cfg = ZScoreConfig(theta=theta, x=x)
+        assert cfg.theta == theta
+        assert cfg.x == x
+
+    @pytest.mark.parametrize("field", ["theta", "x"])
+    def test_invalid_value_raises(self, field):
+        with pytest.raises(ValueError, match="must be one of"):
+            ZScoreConfig(**{field: "invalid"})
+
+    def test_frozen(self):
+        cfg = ZScoreConfig()
+        with pytest.raises(AttributeError):
+            cfg.theta = "none"
+
+
+class TestZScoreStats:
+    """Default construction and immutability of ZScoreStats."""
+
+    def test_defaults_are_none(self):
+        stats = ZScoreStats()
+        assert stats.theta_mean is None
+        assert stats.theta_std is None
+        assert stats.x_mean is None
+        assert stats.x_std is None
+
+    def test_with_tensors(self):
+        m = torch.zeros(5)
+        s = torch.ones(5)
+        stats = ZScoreStats(theta_mean=m, theta_std=s)
+        assert torch.equal(stats.theta_mean, m)
+        assert stats.x_mean is None
+
+    def test_frozen(self):
+        stats = ZScoreStats()
+        with pytest.raises(AttributeError):
+            stats.theta_mean = torch.zeros(3)
+
+
+class TestBuildContext:
+    """Construction and factory method of BuildContext."""
+
+    def test_from_data(self):
+        theta = torch.randn(100, 5)
+        x = torch.randn(100, 3)
+        ctx = BuildContext.from_data(theta, x)
+        assert ctx.theta_shape == torch.Size([5])
+        assert ctx.x_shape == torch.Size([3])
+        assert ctx.device == torch.device("cpu")
+        assert ctx.dtype == torch.float32
+
+    def test_from_data_multidim(self):
+        theta = torch.randn(50, 4)
+        x = torch.randn(50, 8, 8)
+        ctx = BuildContext.from_data(theta, x)
+        assert ctx.theta_shape == torch.Size([4])
+        assert ctx.x_shape == torch.Size([8, 8])
+
+    def test_from_data_with_stats(self):
+        theta = torch.randn(100, 5)
+        x = torch.randn(100, 3)
+        stats = ZScoreStats(theta_mean=torch.zeros(5), theta_std=torch.ones(5))
+        ctx = BuildContext.from_data(theta, x, z_score_stats=stats)
+        assert ctx.z_score_stats is stats
+
+    def test_from_data_default_stats(self):
+        ctx = BuildContext.from_data(torch.randn(10, 2), torch.randn(10, 3))
+        assert ctx.z_score_stats.theta_mean is None
+
+    def test_frozen(self):
+        ctx = BuildContext(
+            theta_shape=torch.Size([5]),
+            x_shape=torch.Size([3]),
+        )
+        with pytest.raises(AttributeError):
+            ctx.theta_shape = torch.Size([10])
+
+
+class TestComputeZScoreStats:
+    """Correctness of the pure z-score stats computation."""
+
+    def test_independent_computes_per_dim(self):
+        torch.manual_seed(42)
+        theta = torch.randn(1000, 5)
+        x = torch.randn(1000, 3)
+        stats = compute_z_score_stats(theta, x, ZScoreConfig())
+
+        assert stats.theta_mean is not None
+        assert stats.theta_std is not None
+        assert stats.theta_mean.shape == (5,)
+        assert stats.theta_std.shape == (5,)
+        assert stats.x_mean.shape == (3,)
+        assert stats.x_std.shape == (3,)
+
+    def test_none_returns_none(self):
+        theta = torch.randn(100, 5)
+        x = torch.randn(100, 3)
+        stats = compute_z_score_stats(
+            theta, x, ZScoreConfig(theta="none", x="none")
+        )
+        assert stats.theta_mean is None
+        assert stats.theta_std is None
+        assert stats.x_mean is None
+        assert stats.x_std is None
+
+    def test_structured_returns_scalar(self):
+        theta = torch.randn(100, 5)
+        x = torch.randn(100, 3)
+        stats = compute_z_score_stats(
+            theta, x, ZScoreConfig(theta="structured", x="structured")
+        )
+        # Structured mode computes a single mean/std scalar.
+        assert stats.theta_mean.dim() == 0
+        assert stats.x_mean.dim() == 0
+
+    def test_mixed_modes(self):
+        theta = torch.randn(100, 5)
+        x = torch.randn(100, 3)
+        stats = compute_z_score_stats(
+            theta, x, ZScoreConfig(theta="independent", x="none")
+        )
+        assert stats.theta_mean is not None
+        assert stats.theta_mean.shape == (5,)
+        assert stats.x_mean is None
+
+    def test_matches_z_standardization(self):
+        """Output must match the existing z_standardization function."""
+        from sbi.utils.sbiutils import z_standardization
+
+        torch.manual_seed(0)
+        theta = torch.randn(200, 4)
+        x = torch.randn(200, 6)
+
+        stats = compute_z_score_stats(theta, x, ZScoreConfig())
+        expected_t_mean, expected_t_std = z_standardization(theta, False)
+        expected_x_mean, expected_x_std = z_standardization(x, False)
+
+        torch.testing.assert_close(stats.theta_mean, expected_t_mean)
+        torch.testing.assert_close(stats.theta_std, expected_t_std)
+        torch.testing.assert_close(stats.x_mean, expected_x_mean)
+        torch.testing.assert_close(stats.x_std, expected_x_std)
+
+
+class TestEstimatorBuilderBase:
+    """The renamed base class retains existing functionality and adds build()."""
+
+    def test_build_raises_not_implemented(self):
+        """Subclasses that don't override build() raise NotImplementedError."""
+        cfg = ConditionalFlowConfig(hidden_features=64)
+        ctx = BuildContext(theta_shape=torch.Size([5]), x_shape=torch.Size([3]))
+        with pytest.raises(NotImplementedError, match="does not implement build"):
+            cfg.build(ctx)
+
+    def test_from_kwargs_still_works(self):
+        """The existing from_kwargs() + to_dict() contract is preserved."""
+        cfg = ConditionalFlowConfig(hidden_features=64)
+        d = cfg.to_dict()
+        assert d == {"hidden_features": 64}
+
+    def test_from_kwargs_extra_warns(self):
+        with pytest.warns(UserWarning, match="Unknown kwargs"):
+            cfg = ConditionalFlowConfig.from_kwargs(
+                hidden_features=64, some_zuko_param=True
+            )
+        d = cfg.to_dict()
+        assert d == {"hidden_features": 64, "some_zuko_param": True}
+
+    def test_subclasses_inherit(self):
+        """All existing config subclasses now inherit from _EstimatorBuilderBase."""
+        assert issubclass(ConditionalFlowConfig, _EstimatorBuilderBase)
+        assert issubclass(ClassifierConfig, _EstimatorBuilderBase)
+        assert issubclass(MarginalFlowConfig, _EstimatorBuilderBase)
+
+
+class TestProtocolRename:
+    """ConditionalEstimatorBuildFn exists and has the expected signature."""
+
+    def test_protocol_exists(self):
+        # The protocol should be importable under the new name.
+        assert hasattr(ConditionalEstimatorBuildFn, "__call__")
+
+    def test_callable_satisfies_protocol(self):
+        """A simple callable with the right signature satisfies the protocol."""
+
+        def dummy_build_fn(theta: Tensor, x: Tensor):
+            return None
+
+        # Runtime isinstance checks don't work with Protocol, but we can verify
+        # the callable has the right signature shape.
+        assert callable(dummy_build_fn)


### PR DESCRIPTION
## What does this PR do?

This PR sets up the groundwork for the Neural Network (NN) Builder refactor project under GSoC 2026. It doesn't add the final builders yet, but it provides a clean, reviewable foundation for the upcoming PRs. 

Here are the main changes:

1. **New `build_context.py` File:**
   Adds the core pieces needed to set up a neural network:
   * **`ZScoreConfig`**: Tracks how the user wants to preprocess data (e.g., "none", "independent", "structured").
   * **`ZScoreStats`**: Holds the calculated mean and standard deviation.
   * **`BuildContext`**: Bundles everything needed to build network (shapes, device, dtype, and z-score stats) into one place.
   * **`compute_z_score_stats()`**: A simple helper function to calculate the z-score stats from the data.

2. **Renamed `ConditionalEstimatorBuilder` to `ConditionalEstimatorBuildFn`:**
   * This clarifies that this protocol is actually a *function*, not an object.
   * It also frees up the "Builder" name for the new classes coming in the next PR.
   * This was a simple find-and-replace across 16 trainer files.

3. **Renamed `_EstimatorConfigBase` to `_EstimatorBuilderBase`:**
   * Renamed the base class and added an empty `build()` method to it.
   * The old `from_kwargs()` and `to_dict()` methods are untouched and work as usual.

## Files Changed

* **`sbi/neural_nets/build_context.py` (NEW):** Added `ZScoreConfig`, `ZScoreStats`, `BuildContext`, and `compute_z_score_stats` as suggested in updated plan.md
* **`sbi/neural_nets/estimators/base.py`:** Renamed `ConditionalEstimatorBuilder` to `ConditionalEstimatorBuildFn`
* **`sbi/neural_nets/net_builders/estimator_configs.py`:** Renamed `_EstimatorConfigBase` to `_EstimatorBuilderBase` and added an empty `build()` method
* **`sbi/neural_nets/net_builders/vector_field_nets.py`:** Updated imports and docstrings
* **Trainer files (`npe/`, `nle/`, `nre/`, `vfpe/`):** Updated Protocol imports across 16 files
* **`tests/build_context_test.py` (NEW):** Added 26 passing tests to fully cover the new types, much of these codes in this file is suggested by AI, we can trim out if any tests are unnecessary

## AI Usage

* **Claude Opus 4.6 (via Antigravity 2.0):** Used to improve code docstrings and comments, suggest additional docstring changes, and write additional tests for `build_context_test.py`.
* **Grammarly:** Used to refine and improve the grammar of this PR description.
* **VS Code auto-complete:** Used some suggested docstrings and comments.

## Does this close any issues?

N/A

## Any relevant code examples, logs, or error messages?

N/A