### PR TITLE
Add DensityEstimatorBuilder with build() dispatch

### DIFF
--- a/sbi/neural_nets/net_builders/__init__.py
+++ b/sbi/neural_nets/net_builders/__init__.py
@@ -7,9 +7,7 @@ from sbi.neural_nets.net_builders.classifier import (
     build_mlp_classifier,
     build_resnet_classifier,
 )
-from sbi.neural_nets.net_builders.estimator_configs import (
-    DensityEstimatorBuilder,
-)
+from sbi.neural_nets.net_builders.estimator_configs import DensityEstimatorBuilder
 from sbi.neural_nets.net_builders.flow import (
     build_made,
     build_maf,

--- a/sbi/neural_nets/net_builders/__init__.py
+++ b/sbi/neural_nets/net_builders/__init__.py
@@ -7,6 +7,9 @@ from sbi.neural_nets.net_builders.classifier import (
     build_mlp_classifier,
     build_resnet_classifier,
 )
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+)
 from sbi.neural_nets.net_builders.flow import (
     build_made,
     build_maf,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -300,7 +300,8 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
                 z-scoring.
 
         Returns:
-            A ``ConditionalDensityEstimator`` (e.g., ``NFlowsFlow``, ``ZukoFlow``, or MDN).
+            A ``ConditionalDensityEstimator`` (e.g., ``NFlowsFlow``,
+            ``ZukoFlow``, or MDN).
         """
         from sbi.neural_nets.net_builders.flow import (
             build_made,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -240,6 +240,13 @@ _VALID_DENSITY_MODELS = {
 
 @dataclass
 class DensityEstimatorBuilder(_EstimatorBuilderBase):
+    """Builder for continuous density estimators (NPE / NLE).
+
+    Covers NFlows (MAF, NSF, MAF-RQS, MADE), all Zuko flow variants, and MDN.
+    Mixed density estimators (MNLE / MNPE) are handled by a separate builder.
+    Fields mirror the parameters of the underlying ``build_*`` functions;
+    see ``ConditionalFlowConfig`` for the full set.
+    """
 
     model: DENSITY_MODELS = "maf"  # type: ignore[valid-type]
 
@@ -283,7 +290,23 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
             )
 
     def build(self, context: BuildContext, batch_theta: Tensor, batch_x: Tensor):
+        """Build the density estimator by dispatching to the appropriate
+        ``build_*`` function.
 
+        The naming follows the internal convention of ``posterior_nn``: the
+        caller passes ``batch_theta`` as the modeled variable and ``batch_x``
+        as the conditioning variable.
+
+        Args:
+            context: Data-derived build state (shapes, device, z-score stats).
+            batch_theta: Batch of parameters used for shape inference and
+                z-scoring.
+            batch_x: Batch of observations used for shape inference and
+                z-scoring.
+
+        Returns:
+            Neural network.
+        """
         from sbi.neural_nets.net_builders.flow import (
             build_made,
             build_maf,
@@ -323,7 +346,7 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
         return build_fn(batch_x=batch_theta, batch_y=batch_x, **kwargs)
 
     def _build_kwargs(self) -> dict:
-
+        """Return non-None fields as a dict, excluding ``model``."""
         d = {
             f.name: getattr(self, f.name)
             for f in fields(self)

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -21,7 +21,7 @@ preserving typed field annotations.
 """
 
 from dataclasses import dataclass, fields
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Sequence, Union, get_args
 
 from torch import Tensor
 
@@ -220,22 +220,7 @@ DENSITY_MODELS = Literal[
     "zuko_bpf",
 ]
 
-_VALID_DENSITY_MODELS = {
-    "mdn",
-    "made",
-    "maf",
-    "maf_rqs",
-    "nsf",
-    "zuko_nice",
-    "zuko_maf",
-    "zuko_nsf",
-    "zuko_ncsf",
-    "zuko_sospf",
-    "zuko_naf",
-    "zuko_unaf",
-    "zuko_gf",
-    "zuko_bpf",
-}
+_VALID_DENSITY_MODELS = frozenset(get_args(DENSITY_MODELS))
 
 
 @dataclass
@@ -343,6 +328,8 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
 
         build_fn = builders[self.model]
         kwargs = self._build_kwargs()
+        # For NPE: batch_theta is the modeled variable (batch_x in the builder)
+        # and batch_x is the conditioning variable (batch_y in the builder).
         return build_fn(batch_x=batch_theta, batch_y=batch_x, **kwargs)
 
     def _build_kwargs(self) -> dict:

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -25,6 +25,11 @@ from typing import Any, Literal, Optional, Sequence, Union, get_args
 
 from torch import Tensor
 
+from sbi.neural_nets.estimators.base import (
+    ConditionalDensityEstimator,
+    ConditionalEstimator,
+)
+
 
 @dataclass
 class _EstimatorBuilderBase:
@@ -68,7 +73,7 @@ class _EstimatorBuilderBase:
 
         return cls(**known, extra_kwargs=extra)
 
-    def build(self, batch_theta: Tensor, batch_x: Tensor) -> Any:
+    def build(self, batch_theta: Tensor, batch_x: Tensor) -> ConditionalEstimator:
         """Build an estimator from training batches.
 
         Subclasses must override this method to construct the appropriate
@@ -278,7 +283,9 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
                 f"Must be one of {sorted(_VALID_DENSITY_MODELS)}."
             )
 
-    def build(self, batch_theta: Tensor, batch_x: Tensor):
+    def build(
+        self, batch_theta: Tensor, batch_x: Tensor
+    ) -> ConditionalDensityEstimator:
         """Build the density estimator by dispatching to the appropriate
         ``build_*`` function.
 

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -300,7 +300,7 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
                 z-scoring.
 
         Returns:
-            Neural network.
+            A ``ConditionalDensityEstimator`` (e.g., ``NFlowsFlow``, ``ZukoFlow``, or MDN).
         """
         from sbi.neural_nets.net_builders.flow import (
             build_made,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -21,7 +21,9 @@ preserving typed field annotations.
 """
 
 from dataclasses import dataclass, fields
-from typing import Any, Optional
+from typing import Any, Literal, Optional
+
+from torch import Tensor
 
 from sbi.neural_nets.build_context import BuildContext
 
@@ -235,3 +237,98 @@ _VALID_DENSITY_MODELS = {
     "zuko_bpf",
 }
 
+
+@dataclass
+class DensityEstimatorBuilder(_EstimatorBuilderBase):
+
+    model: DENSITY_MODELS = "maf"  # type: ignore[valid-type]
+
+    # --- Shared across most builders ---
+    z_score_x: Optional[str] = None
+    z_score_y: Optional[str] = None
+    hidden_features: Optional[Any] = None
+    num_transforms: Optional[int] = None
+    num_bins: Optional[int] = None
+    embedding_net: Optional[Any] = None
+    num_components: Optional[int] = None
+
+    # --- NFlows-specific (MAF, NSF, MAF-RQS) ---
+    num_blocks: Optional[int] = None
+    dropout_probability: Optional[float] = None
+    use_batch_norm: Optional[bool] = None
+    tail_bound: Optional[float] = None
+    hidden_layers_spline_context: Optional[int] = None
+    tails: Optional[str] = None
+    min_bin_width: Optional[float] = None
+    min_bin_height: Optional[float] = None
+    min_derivative: Optional[float] = None
+
+    # --- MADE-specific ---
+    num_mixture_components: Optional[int] = None
+
+    # --- Zuko per-model kwargs (model-specific; ignored by models that don't use them)
+    randperm: Optional[bool] = None  # zuko_maf, zuko_naf, zuko_unaf
+    randmask: Optional[bool] = None  # zuko_nice
+    signal: Optional[int] = None  # zuko_naf, zuko_unaf
+    degree: Optional[int] = None  # zuko_sospf, zuko_bpf
+    polynomials: Optional[int] = None  # zuko_sospf
+    components: Optional[int] = None  # zuko_gf
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.model not in _VALID_DENSITY_MODELS:
+            raise ValueError(
+                f"Unknown model {self.model!r}. "
+                f"Must be one of {sorted(_VALID_DENSITY_MODELS)}."
+            )
+
+    def build(self, context: BuildContext, batch_theta: Tensor, batch_x: Tensor):
+
+        from sbi.neural_nets.net_builders.flow import (
+            build_made,
+            build_maf,
+            build_maf_rqs,
+            build_nsf,
+            build_zuko_bpf,
+            build_zuko_gf,
+            build_zuko_maf,
+            build_zuko_naf,
+            build_zuko_ncsf,
+            build_zuko_nice,
+            build_zuko_nsf,
+            build_zuko_sospf,
+            build_zuko_unaf,
+        )
+        from sbi.neural_nets.net_builders.mdn import build_mdn
+
+        builders = {
+            "mdn": build_mdn,
+            "made": build_made,
+            "maf": build_maf,
+            "maf_rqs": build_maf_rqs,
+            "nsf": build_nsf,
+            "zuko_nice": build_zuko_nice,
+            "zuko_maf": build_zuko_maf,
+            "zuko_nsf": build_zuko_nsf,
+            "zuko_ncsf": build_zuko_ncsf,
+            "zuko_sospf": build_zuko_sospf,
+            "zuko_naf": build_zuko_naf,
+            "zuko_unaf": build_zuko_unaf,
+            "zuko_gf": build_zuko_gf,
+            "zuko_bpf": build_zuko_bpf,
+        }
+
+        build_fn = builders[self.model]
+        kwargs = self._build_kwargs()
+        return build_fn(batch_x=batch_theta, batch_y=batch_x, **kwargs)
+
+    def _build_kwargs(self) -> dict:
+
+        d = {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in ("model", "extra_kwargs")
+            and getattr(self, f.name) is not None
+        }
+        d.update(self.extra_kwargs)
+        return d

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -199,3 +199,39 @@ class MarginalFlowConfig(_EstimatorBuilderBase):
     degree: Optional[int] = None  # zuko_sospf, zuko_bpf
     polynomials: Optional[int] = None  # zuko_sospf
     components: Optional[int] = None  # zuko_gf
+
+
+DENSITY_MODELS = Literal[
+    "mdn",
+    "made",
+    "maf",
+    "maf_rqs",
+    "nsf",
+    "zuko_nice",
+    "zuko_maf",
+    "zuko_nsf",
+    "zuko_ncsf",
+    "zuko_sospf",
+    "zuko_naf",
+    "zuko_unaf",
+    "zuko_gf",
+    "zuko_bpf",
+]
+
+_VALID_DENSITY_MODELS = {
+    "mdn",
+    "made",
+    "maf",
+    "maf_rqs",
+    "nsf",
+    "zuko_nice",
+    "zuko_maf",
+    "zuko_nsf",
+    "zuko_ncsf",
+    "zuko_sospf",
+    "zuko_naf",
+    "zuko_unaf",
+    "zuko_gf",
+    "zuko_bpf",
+}
+

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -236,9 +236,13 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
     model: DENSITY_MODELS = "maf"  # type: ignore[valid-type]
 
     # --- Shared across most builders ---
-    z_score_x: Optional[str] = None
-    z_score_y: Optional[str] = None
-    hidden_features: Optional[Any] = None
+    z_score_x: Optional[
+        Literal["none", "independent", "structured", "transform_to_unconstrained"]
+    ] = None
+    z_score_y: Optional[
+        Literal["none", "independent", "structured", "transform_to_unconstrained"]
+    ] = None
+    hidden_features: Optional[Union[int, Sequence[int]]] = None
     num_transforms: Optional[int] = None
     num_bins: Optional[int] = None
     embedding_net: Optional[Any] = None

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -25,8 +25,6 @@ from typing import Any, Literal, Optional, Sequence, Union, get_args
 
 from torch import Tensor
 
-from sbi.neural_nets.build_context import BuildContext
-
 
 @dataclass
 class _EstimatorBuilderBase:
@@ -70,14 +68,16 @@ class _EstimatorBuilderBase:
 
         return cls(**known, extra_kwargs=extra)
 
-    def build(self, context: BuildContext) -> Any:
-        """Build an estimator from a ``BuildContext``.
+    def build(self, batch_theta: Tensor, batch_x: Tensor) -> Any:
+        """Build an estimator from training batches.
 
         Subclasses must override this method to construct the appropriate
-        estimator using the shapes, device, and z-score stats in *context*.
+        estimator.  Shape inference and z-scoring are derived from the
+        supplied batches by the downstream ``build_*`` functions.
 
         Args:
-            context: Data-derived state (shapes, device, z-score stats).
+            batch_theta: Batch of parameters.
+            batch_x: Batch of observations.
 
         Returns:
             A ``ConditionalEstimator`` subclass instance.
@@ -278,7 +278,7 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
                 f"Must be one of {sorted(_VALID_DENSITY_MODELS)}."
             )
 
-    def build(self, context: BuildContext, batch_theta: Tensor, batch_x: Tensor):
+    def build(self, batch_theta: Tensor, batch_x: Tensor):
         """Build the density estimator by dispatching to the appropriate
         ``build_*`` function.
 
@@ -287,7 +287,6 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
         as the conditioning variable.
 
         Args:
-            context: Data-derived build state (shapes, device, z-score stats).
             batch_theta: Batch of parameters used for shape inference and
                 z-scoring.
             batch_x: Batch of observations used for shape inference and

--- a/tests/build_context_test.py
+++ b/tests/build_context_test.py
@@ -142,9 +142,10 @@ def test_compute_z_score_stats_matches_z_standardization():
 def test_estimator_builder_base_build_raises():
     """Subclasses that don't override build() raise NotImplementedError."""
     cfg = ConditionalFlowConfig(hidden_features=64)
-    ctx = BuildContext(theta_shape=torch.Size([5]), x_shape=torch.Size([3]))
+    theta = torch.randn(10, 5)
+    x = torch.randn(10, 3)
     with pytest.raises(NotImplementedError, match="does not implement build"):
-        cfg.build(ctx)
+        cfg.build(theta, x)
 
 
 def test_estimator_builder_base_from_kwargs():

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -105,3 +105,32 @@ def test_density_estimator_builder_build_with_embedding_net(model):
     ctx = BuildContext.from_data(theta, x)
     estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
+
+
+@pytest.mark.parametrize("model", ["maf", "zuko_maf"])
+def test_density_estimator_builder_loss_computable(model):
+    """Test that the built estimator can compute a finite loss."""
+    builder = DensityEstimatorBuilder(model=model, hidden_features=16, num_transforms=2)
+    theta = torch.randn(100, 3)
+    x = torch.randn(100, 2)
+    ctx = BuildContext.from_data(theta, x)
+    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+
+    # Evaluate on a fresh batch.
+    batch_theta_eval = torch.randn(10, 3)
+    batch_x_eval = torch.randn(10, 2)
+    loss = estimator.loss(batch_theta_eval, condition=batch_x_eval)
+    assert loss.shape == (10,)
+    assert torch.isfinite(loss).all()
+
+
+def test_density_estimator_builder_z_score_none():
+    """Test that z_score_x='none' disables z-scoring."""
+    builder = DensityEstimatorBuilder(
+        model="maf", z_score_x="none", z_score_y="none", num_transforms=2
+    )
+    theta = torch.randn(100, 3)
+    x = torch.randn(100, 2)
+    ctx = BuildContext.from_data(theta, x)
+    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    assert isinstance(estimator, ConditionalDensityEstimator)

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -14,19 +14,6 @@ from sbi.neural_nets.net_builders.estimator_configs import (
 )
 
 
-def test_density_estimator_builder_defaults():
-    builder = DensityEstimatorBuilder()
-    assert builder.model == "maf"
-    assert builder.hidden_features is None
-    assert builder.embedding_net is None
-
-
-@pytest.mark.parametrize("model", sorted(_VALID_DENSITY_MODELS))
-def test_density_estimator_builder_accepts_valid_models(model):
-    builder = DensityEstimatorBuilder(model=model)
-    assert builder.model == model
-
-
 def test_density_estimator_builder_invalid_model_raises():
     with pytest.raises(ValueError, match="Unknown model"):
         DensityEstimatorBuilder(model="invalid_model")
@@ -56,27 +43,9 @@ def test_density_estimator_builder_build_kwargs_excludes_model():
     assert kwargs["hidden_features"] == 64
 
 
-_QUICK_MODELS = [
-    "mdn",
-    "made",
-    "maf",
-    "maf_rqs",
-    "nsf",
-    "zuko_nice",
-    "zuko_maf",
-    "zuko_nsf",
-    "zuko_ncsf",
-    "zuko_sospf",
-    "zuko_naf",
-    "zuko_unaf",
-    "zuko_gf",
-    "zuko_bpf",
-]
-
-
-@pytest.mark.parametrize("model", _QUICK_MODELS)
+@pytest.mark.parametrize("model", sorted(_VALID_DENSITY_MODELS))
 def test_density_estimator_builder_build(model):
-    """Test that build() returns a ConditionalDensityEstimator."""
+    """Test that build() returns a ConditionalDensityEstimator for every supported model."""
     builder = DensityEstimatorBuilder(model=model)
     theta = torch.randn(100, 5)
     x = torch.randn(100, 3)

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -56,17 +56,24 @@ def test_density_estimator_builder_build(model):
 
 @pytest.mark.parametrize("model", ["maf", "nsf", "zuko_maf", "zuko_nsf", "mdn"])
 def test_density_estimator_builder_build_with_custom_features(model):
-    """Test that custom hidden_features are forwarded to the build function."""
-    builder = DensityEstimatorBuilder(model=model, hidden_features=32)
+    """Test that custom hidden_features are forwarded and wired into the estimator."""
+    custom_features = 32
+    builder = DensityEstimatorBuilder(model=model, hidden_features=custom_features)
     theta = torch.randn(100, 4)
     x = torch.randn(100, 2)
     ctx = BuildContext.from_data(theta, x)
     estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
+    # Verify that at least one layer has the requested hidden size.
+    param_shapes = [p.shape for p in estimator.parameters()]
+    assert any(custom_features in s for s in param_shapes), (
+        f"No parameter with hidden_features={custom_features} found in {param_shapes}"
+    )
 
 
 @pytest.mark.parametrize("model", ["maf", "zuko_nsf"])
 def test_density_estimator_builder_build_with_embedding_net(model):
+    """Test that a custom embedding_net is wired into the built estimator."""
     emb = nn.Linear(3, 10)
     builder = DensityEstimatorBuilder(model=model, embedding_net=emb)
     theta = torch.randn(100, 5)
@@ -74,6 +81,8 @@ def test_density_estimator_builder_build_with_embedding_net(model):
     ctx = BuildContext.from_data(theta, x)
     estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
+    # The embedding net must not be a plain Identity.
+    assert not isinstance(estimator.embedding_net, nn.Identity)
 
 
 @pytest.mark.parametrize("model", ["maf", "zuko_maf"])
@@ -93,13 +102,25 @@ def test_density_estimator_builder_loss_computable(model):
     assert torch.isfinite(loss).all()
 
 
-def test_density_estimator_builder_z_score_none():
-    """Test that z_score_x='none' disables z-scoring."""
+@pytest.mark.parametrize(
+    "z_score_x, z_score_y",
+    [
+        ("none", "none"),
+        ("independent", "independent"),
+        ("none", "independent"),
+    ],
+)
+def test_density_estimator_builder_z_score_modes(z_score_x, z_score_y):
+    """Test that z_score fields are forwarded and the estimator builds successfully."""
     builder = DensityEstimatorBuilder(
-        model="maf", z_score_x="none", z_score_y="none", num_transforms=2
+        model="maf", z_score_x=z_score_x, z_score_y=z_score_y, num_transforms=2
     )
     theta = torch.randn(100, 3)
     x = torch.randn(100, 2)
     ctx = BuildContext.from_data(theta, x)
     estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
+    # When z_score is "none" for both, the estimator should still produce
+    # a finite loss (just without standardization).
+    loss = estimator.loss(theta[:10], condition=x[:10])
+    assert torch.isfinite(loss).all()

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 from torch import nn
 
-from sbi.neural_nets.build_context import BuildContext
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.net_builders.estimator_configs import (
     _VALID_DENSITY_MODELS,
@@ -49,8 +48,7 @@ def test_density_estimator_builder_build(model):
     builder = DensityEstimatorBuilder(model=model)
     theta = torch.randn(100, 5)
     x = torch.randn(100, 3)
-    ctx = BuildContext.from_data(theta, x)
-    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    estimator = builder.build(batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
 
 
@@ -61,8 +59,7 @@ def test_density_estimator_builder_build_with_custom_features(model):
     builder = DensityEstimatorBuilder(model=model, hidden_features=custom_features)
     theta = torch.randn(100, 4)
     x = torch.randn(100, 2)
-    ctx = BuildContext.from_data(theta, x)
-    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    estimator = builder.build(batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
     # Verify that at least one layer has the requested hidden size.
     param_shapes = [p.shape for p in estimator.parameters()]
@@ -78,8 +75,7 @@ def test_density_estimator_builder_build_with_embedding_net(model):
     builder = DensityEstimatorBuilder(model=model, embedding_net=emb)
     theta = torch.randn(100, 5)
     x = torch.randn(100, 3)
-    ctx = BuildContext.from_data(theta, x)
-    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    estimator = builder.build(batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
     # The embedding net must not be a plain Identity.
     assert not isinstance(estimator.embedding_net, nn.Identity)
@@ -91,8 +87,7 @@ def test_density_estimator_builder_loss_computable(model):
     builder = DensityEstimatorBuilder(model=model, hidden_features=16, num_transforms=2)
     theta = torch.randn(100, 3)
     x = torch.randn(100, 2)
-    ctx = BuildContext.from_data(theta, x)
-    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    estimator = builder.build(batch_theta=theta, batch_x=x)
 
     # Evaluate on a fresh batch.
     batch_theta_eval = torch.randn(10, 3)
@@ -117,8 +112,7 @@ def test_density_estimator_builder_z_score_modes(z_score_x, z_score_y):
     )
     theta = torch.randn(100, 3)
     x = torch.randn(100, 2)
-    ctx = BuildContext.from_data(theta, x)
-    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    estimator = builder.build(batch_theta=theta, batch_x=x)
     assert isinstance(estimator, ConditionalDensityEstimator)
     # When z_score is "none" for both, the estimator should still produce
     # a finite loss (just without standardization).

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -45,7 +45,7 @@ def test_density_estimator_builder_build_kwargs_excludes_model():
 
 @pytest.mark.parametrize("model", sorted(_VALID_DENSITY_MODELS))
 def test_density_estimator_builder_build(model):
-    """Test that build() returns a ConditionalDensityEstimator for every supported model."""
+    """Test that build() returns correct estimator type for every supported model."""
     builder = DensityEstimatorBuilder(model=model)
     theta = torch.randn(100, 5)
     x = torch.randn(100, 3)

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -1,0 +1,107 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+
+import pytest
+import torch
+from torch import nn
+
+from sbi.neural_nets.build_context import BuildContext
+from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
+from sbi.neural_nets.net_builders.estimator_configs import (
+    _VALID_DENSITY_MODELS,
+    DensityEstimatorBuilder,
+)
+
+
+def test_density_estimator_builder_defaults():
+    builder = DensityEstimatorBuilder()
+    assert builder.model == "maf"
+    assert builder.hidden_features is None
+    assert builder.embedding_net is None
+
+
+@pytest.mark.parametrize("model", sorted(_VALID_DENSITY_MODELS))
+def test_density_estimator_builder_accepts_valid_models(model):
+    builder = DensityEstimatorBuilder(model=model)
+    assert builder.model == model
+
+
+def test_density_estimator_builder_invalid_model_raises():
+    with pytest.raises(ValueError, match="Unknown model"):
+        DensityEstimatorBuilder(model="invalid_model")
+
+
+def test_density_estimator_builder_to_dict_only_set_fields():
+    builder = DensityEstimatorBuilder(model="nsf", hidden_features=64)
+    d = builder.to_dict()
+    assert d == {"model": "nsf", "hidden_features": 64}
+    assert "num_transforms" not in d
+
+
+def test_density_estimator_builder_to_dict_with_extra_kwargs():
+    with pytest.warns(UserWarning, match="Unknown kwargs"):
+        builder = DensityEstimatorBuilder.from_kwargs(
+            model="zuko_maf", hidden_features=64, some_library_param=True
+        )
+    d = builder.to_dict()
+    assert d["some_library_param"] is True
+    assert d["hidden_features"] == 64
+
+
+def test_density_estimator_builder_build_kwargs_excludes_model():
+    builder = DensityEstimatorBuilder(model="maf", hidden_features=64)
+    kwargs = builder._build_kwargs()
+    assert "model" not in kwargs
+    assert kwargs["hidden_features"] == 64
+
+
+_QUICK_MODELS = [
+    "mdn",
+    "made",
+    "maf",
+    "maf_rqs",
+    "nsf",
+    "zuko_nice",
+    "zuko_maf",
+    "zuko_nsf",
+    "zuko_ncsf",
+    "zuko_sospf",
+    "zuko_naf",
+    "zuko_unaf",
+    "zuko_gf",
+    "zuko_bpf",
+]
+
+
+@pytest.mark.parametrize("model", _QUICK_MODELS)
+def test_density_estimator_builder_build(model):
+    """Test that build() returns a ConditionalDensityEstimator."""
+    builder = DensityEstimatorBuilder(model=model)
+    theta = torch.randn(100, 5)
+    x = torch.randn(100, 3)
+    ctx = BuildContext.from_data(theta, x)
+    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    assert isinstance(estimator, ConditionalDensityEstimator)
+
+
+@pytest.mark.parametrize("model", ["maf", "nsf", "zuko_maf", "zuko_nsf", "mdn"])
+def test_density_estimator_builder_build_with_custom_features(model):
+    """Test that custom hidden_features are forwarded to the build function."""
+    builder = DensityEstimatorBuilder(model=model, hidden_features=32)
+    theta = torch.randn(100, 4)
+    x = torch.randn(100, 2)
+    ctx = BuildContext.from_data(theta, x)
+    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    assert isinstance(estimator, ConditionalDensityEstimator)
+
+
+@pytest.mark.parametrize("model", ["maf", "zuko_nsf"])
+def test_density_estimator_builder_build_with_embedding_net(model):
+    emb = nn.Linear(3, 10)
+    builder = DensityEstimatorBuilder(model=model, embedding_net=emb)
+    theta = torch.randn(100, 5)
+    x = torch.randn(100, 3)
+    ctx = BuildContext.from_data(theta, x)
+    estimator = builder.build(ctx, batch_theta=theta, batch_x=x)
+    assert isinstance(estimator, ConditionalDensityEstimator)


### PR DESCRIPTION
## What does this PR do?

This is the second PR for for the Neural Network (NN) Builder API refactor project under GSoC 2026. It adds `DensityEstimatorBuilder` which is the first concrete builder class in the NN builder refactor. It provides a typed, inspectable replacement for the `posterior_nn()`/`likelihood_nn()` factory closures, covering all 14 continuous density estimator model types.

Builds on PR #1872 which introduced `BuildContext`, `ZScoreConfig`, `ZScoreStats`, and the `_EstimatorBuilderBase` contract.

## Files Changed

**`sbi/neural_nets/net_builders/estimator_configs.py`**
- Added `DensityEstimatorBuilder(_EstimatorBuilderBase)` dataclass with:
  - `model: Literal[...]` field selecting the architecture (maf, nsf, mdn, made, maf_rqs, and all Zuko variants)
  - Typed fields for all shared and model-specific parameters (hidden_features, num_transforms, num_bins, embedding_net, etc.)
  - `__post_init__` validation: unknown model names fail immediately at construction
  - `build(context, batch_theta, batch_x)`: dispatches to the appropriate existing `build_*` function
  - `_build_kwargs()`: collects non-None fields + extra_kwargs, excluding `model` (used only for dispatch)
- Added `DENSITY_MODELS` type alias and `_VALID_DENSITY_MODELS` set for validation

**`sbi/neural_nets/net_builders/__init__.py`**
- Exported `DensityEstimatorBuilder`

**`tests/density_estimator_builder_test.py`** (created new file, or may be we can also add to existing test files ?)
- 43 tests covering construction, validation, to_dict, build dispatch for all 14 models, custom features, embedding nets, loss computation, and z-score options

## AI Usage

* **GPT-OSS 120B (via Antigravity 2.0):** Used to add docstrings and a few more tests.
* **Grammarly:** Used to refine and improve the grammar of this PR description.
* **VS Code auto-complete:** Used some suggested code and comments.
* **Gemini 3.1 Pro (via Antigravity 2.0):** Used to scan for any bugs or architectural errors, code review prior push.

## Does this close any issues?

N/A

## Any relevant code examples, logs, or error messages?

N/A
