### PR TITLE
Integrate DensityEstimatorBuilder into NPE trainers

### DIFF
--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -17,6 +17,7 @@ from sbi.inference.posteriors.posterior_parameters import (
 from sbi.inference.trainers.npe.npe_c import NPE_C
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
 
@@ -68,6 +69,7 @@ class MNPE(NPE_C):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["mnpe"],
+            _EstimatorBuilderBase,
             ConditionalEstimatorBuildFn[MixedDensityEstimator],
         ] = "mnpe",
         device: str = "cpu",

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -15,6 +15,7 @@ from sbi.inference.posteriors.posterior_parameters import (
     VIPosteriorParameters,
 )
 from sbi.inference.trainers.npe.npe_c import NPE_C
+from sbi.neural_nets import posterior_nn
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
@@ -69,7 +70,6 @@ class MNPE(NPE_C):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["mnpe"],
-            _EstimatorBuilderBase,
             ConditionalEstimatorBuildFn[MixedDensityEstimator],
         ] = "mnpe",
         device: str = "cpu",
@@ -103,11 +103,17 @@ class MNPE(NPE_C):
                 sampling.
         """
 
+        if isinstance(density_estimator, _EstimatorBuilderBase):
+            raise NotImplementedError(
+                "Builder support for MNPE is not yet implemented; pass 'mnpe'."
+            )
         if isinstance(density_estimator, str):
-            assert (
-                density_estimator == "mnpe"
-            ), f"""MNPE can be used with preconfigured 'mnpe' density estimator only,
-                not with {density_estimator}."""
+            if density_estimator != "mnpe":
+                raise ValueError(
+                    "MNPE supports only the preconfigured 'mnpe' density estimator, "
+                    f"not {density_estimator!r}."
+                )
+            density_estimator = posterior_nn(model="mnpe")
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
 

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -17,7 +17,7 @@ from sbi.neural_nets.estimators.base import (
     ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.shape_handling import reshape_to_sample_batch_event
-from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
+from sbi.neural_nets.net_builders.estimator_configs import DensityEstimatorBuilder
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
 
@@ -74,9 +74,10 @@ class NPE_B(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            _EstimatorBuilderBase,
+            DensityEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
-        ] = "maf",
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -90,10 +91,10 @@ class NPE_B(PosteriorEstimatorTrainer):
                 parameters, e.g. which ranges are meaningful for them.
             density_estimator: If it is a string (deprecated), use a pre-configured
                 network of the provided type (one of nsf, maf, mdn, made). If it is
-                a ``_EstimatorBuilderBase`` (e.g. ``DensityEstimatorBuilder``), the
-                builder's ``build()`` method will be called with the first batch
-                of simulations. Alternatively, a function that builds a custom
-                neural network can be provided.
+                a ``DensityEstimatorBuilder``, the builder's ``build()`` method will be
+                called with the first batch of simulations. Alternatively, a function
+                that builds a custom neural network can be provided. If None, it
+                uses a default ``DensityEstimatorBuilder`` with ``"maf"``.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -17,6 +17,7 @@ from sbi.neural_nets.estimators.base import (
     ConditionalEstimatorBuildFn,
 )
 from sbi.neural_nets.estimators.shape_handling import reshape_to_sample_batch_event
+from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
 
@@ -73,6 +74,7 @@ class NPE_B(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
+            _EstimatorBuilderBase,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",

--- a/sbi/inference/trainers/npe/npe_b.py
+++ b/sbi/inference/trainers/npe/npe_b.py
@@ -86,14 +86,12 @@ class NPE_B(PosteriorEstimatorTrainer):
         Args:
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them.
-            density_estimator: If it is a string, use a pre-configured network of the
-                provided type (one of nsf, maf, mdn, made). Alternatively, a function
-                that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuildFn` protocol can be provided. The function
-                will be called with the first batch of simulations (theta, x), which can
-                thus be used for shape inference and potentially for z-scoring. The
-                density estimator needs to provide the methods `.log_prob` and
-                `.sample()` and must return a `ConditionalDensityEstimator`.
+            density_estimator: If it is a string (deprecated), use a pre-configured
+                network of the provided type (one of nsf, maf, mdn, made). If it is
+                a ``_EstimatorBuilderBase`` (e.g. ``DensityEstimatorBuilder``), the
+                builder's ``build()`` method will be called with the first batch
+                of simulations. Alternatively, a function that builds a custom
+                neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -101,14 +101,22 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
             show_progress_bars=show_progress_bars,
         )
 
-        # As detailed in the docstring, `density_estimator` is either a string or
-        # a callable. The function creating the neural network is attached to
+        # `density_estimator` is either a string, a builder, or a callable.
+        # The function creating the neural network is attached to
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
         # potentially for z-scoring.
         check_estimator_arg(density_estimator)
         if isinstance(density_estimator, str):
+            warnings.warn(
+                "Passing a string for `density_estimator` is deprecated. "
+                "Use DensityEstimatorBuilder(model=...) instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
             self._build_neural_net = posterior_nn(model=density_estimator)
+        elif isinstance(density_estimator, _EstimatorBuilderBase):
+            self._build_neural_net = self._wrap_builder(density_estimator)
         else:
             self._build_neural_net = density_estimator
 

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -39,7 +39,10 @@ from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
-from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+    _EstimatorBuilderBase,
+)
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
     RestrictedPrior,
@@ -64,9 +67,10 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            _EstimatorBuilderBase,
+            DensityEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
-        ] = "maf",
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -82,11 +86,11 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         Args:
             density_estimator: If it is a string (deprecated), use a pre-configured
                 network of the provided type (one of nsf, maf, mdn, made). If it is
-                a `_EstimatorBuilderBase` (e.g. `DensityEstimatorBuilder`), the
-                builder's `build()` method will be called with the first batch
-                of simulations. Alternatively, a function that builds a custom
-                neural network, which adheres to `ConditionalEstimatorBuildFn`
-                protocol can be provided.
+                a ``DensityEstimatorBuilder``, the builder's ``build()`` method will be
+                called with the first batch of simulations. Alternatively, a function
+                that builds a custom neural network, which adheres to
+                ``ConditionalEstimatorBuildFn`` protocol can be provided. If None,
+                it uses a default ``DensityEstimatorBuilder`` with ``"maf"``.
 
         See docstring of `NeuralInference` class for all other arguments.
         """
@@ -105,13 +109,18 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
         # potentially for z-scoring.
-        check_estimator_arg(density_estimator)
-        if isinstance(density_estimator, str):
+        if density_estimator is not None:
+            check_estimator_arg(density_estimator)
+        if density_estimator is None:
+            self._build_neural_net = self._wrap_builder(
+                DensityEstimatorBuilder(model="maf")
+            )
+        elif isinstance(density_estimator, str):
             warnings.warn(
                 "Passing a string for `density_estimator` is deprecated. "
                 "Use DensityEstimatorBuilder(model=...) instead.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
             self._build_neural_net = posterior_nn(model=density_estimator)
         elif isinstance(density_estimator, _EstimatorBuilderBase):
@@ -531,8 +540,8 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         """Wrap a builder object as a legacy-compatible build function.
 
         This allows the existing ``_initialize_neural_network`` flow to work
-        unchanged: the returned callable has the same ``(theta, x)`` signature
-        as the functions produced by ``posterior_nn``.
+        unchanged: the returned callable has the same ``(batch_theta, batch_x)``
+        signature as the functions produced by ``posterior_nn``.
         """
 
         def build_fn(batch_theta, batch_x):

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -33,12 +33,14 @@ from sbi.inference.trainers.base import (
     check_if_proposal_has_default_x,
 )
 from sbi.neural_nets import posterior_nn
+from sbi.neural_nets.build_context import BuildContext
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
+from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
     RestrictedPrior,
@@ -63,6 +65,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
+            _EstimatorBuilderBase,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -33,7 +33,6 @@ from sbi.inference.trainers.base import (
     check_if_proposal_has_default_x,
 )
 from sbi.neural_nets import posterior_nn
-from sbi.neural_nets.build_context import BuildContext
 from sbi.neural_nets.estimators import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.estimators.shape_handling import (

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -78,14 +78,13 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         a sequential scheme.
 
         Args:
-            density_estimator: If it is a string, use a pre-configured network of the
-                provided type (one of nsf, maf, mdn, made). Alternatively, a function
-                that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuildFn` protocol can be provided. The function
-                will be called with the first batch of simulations (theta, x), which can
-                thus be used for shape inference and potentially for z-scoring. The
-                density estimator needs to provide the methods `.log_prob` and
-                `.sample()` and must return a `ConditionalDensityEstimator`.
+            density_estimator: If it is a string (deprecated), use a pre-configured
+                network of the provided type (one of nsf, maf, mdn, made). If it is
+                a `_EstimatorBuilderBase` (e.g. `DensityEstimatorBuilder`), the
+                builder's `build()` method will be called with the first batch
+                of simulations. Alternatively, a function that builds a custom
+                neural network, which adheres to `ConditionalEstimatorBuildFn`
+                protocol can be provided.
 
         See docstring of `NeuralInference` class for all other arguments.
         """
@@ -514,6 +513,22 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
 
         assert_all_finite(loss, "NPE loss")
         return calibration_kernel(x) * loss
+
+    @staticmethod
+    def _wrap_builder(
+        builder: _EstimatorBuilderBase,
+    ) -> Callable:
+        """Wrap a builder object as a legacy-compatible build function.
+
+        This allows the existing ``_initialize_neural_network`` flow to work
+        unchanged: the returned callable has the same ``(theta, x)`` signature
+        as the functions produced by ``posterior_nn``.
+        """
+
+        def build_fn(batch_theta, batch_x):
+            return builder.build(batch_theta=batch_theta, batch_x=batch_x)
+
+        return build_fn
 
     def _check_proposal(self, proposal):
         """

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -24,7 +24,7 @@ from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
-from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
+from sbi.neural_nets.net_builders.estimator_configs import DensityEstimatorBuilder
 from sbi.sbi_types import Tracker
 from sbi.utils import (
     batched_mixture_mv,
@@ -91,9 +91,10 @@ class NPE_C(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
-            _EstimatorBuilderBase,
+            DensityEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
-        ] = "maf",
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -107,10 +108,10 @@ class NPE_C(PosteriorEstimatorTrainer):
                 parameters, e.g. which ranges are meaningful for them.
             density_estimator: If it is a string (deprecated), use a pre-configured
                 network of the provided type (one of nsf, maf, mdn, made). If it is
-                a ``_EstimatorBuilderBase`` (e.g. ``DensityEstimatorBuilder``), the
-                builder's ``build()`` method will be called with the first batch
-                of simulations. Alternatively, a function that builds a custom
-                neural network can be provided.
+                a ``DensityEstimatorBuilder``, the builder's ``build()`` method will be
+                called with the first batch of simulations. Alternatively, a function
+                that builds a custom neural network can be provided. If None, it
+                uses a default ``DensityEstimatorBuilder`` with ``"maf"``.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -103,14 +103,12 @@ class NPE_C(PosteriorEstimatorTrainer):
         Args:
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them.
-            density_estimator: If it is a string, use a pre-configured network of the
-                provided type (one of nsf, maf, mdn, made). Alternatively, a function
-                that builds a custom neural network, which adheres to
-                `ConditionalEstimatorBuildFn` protocol can be provided. The function
-                will be called with the first batch of simulations (theta, x), which can
-                thus be used for shape inference and potentially for z-scoring. The
-                density estimator needs to provide the methods `.log_prob` and
-                `.sample()` and must return a `ConditionalDensityEstimator`.
+            density_estimator: If it is a string (deprecated), use a pre-configured
+                network of the provided type (one of nsf, maf, mdn, made). If it is
+                a ``_EstimatorBuilderBase`` (e.g. ``DensityEstimatorBuilder``), the
+                builder's ``build()`` method will be called with the first batch
+                of simulations. Alternatively, a function that builds a custom
+                neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -24,6 +24,7 @@ from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
     reshape_to_sample_batch_event,
 )
+from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 from sbi.sbi_types import Tracker
 from sbi.utils import (
     batched_mixture_mv,
@@ -90,6 +91,7 @@ class NPE_C(PosteriorEstimatorTrainer):
         prior: Optional[Distribution] = None,
         density_estimator: Union[
             Literal["nsf", "maf", "mdn", "made"],
+            _EstimatorBuilderBase,
             ConditionalEstimatorBuildFn[ConditionalDensityEstimator],
         ] = "maf",
         device: str = "cpu",

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -713,13 +713,15 @@ def check_estimator_arg(estimator: Union[str, Callable]) -> None:
     """Check (density or ratio) estimator argument passed by the user."""
     from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 
-    assert isinstance(estimator, (str, _EstimatorBuilderBase)) or (
-        isinstance(estimator, Callable) and not isinstance(estimator, nn.Module)
-    ), (
-        "The passed density estimator / classifier must be a string, "
-        "an _EstimatorBuilderBase, or a function "
-        f"returning a nn.Module, but is {type(estimator)}"
-    )
+    if not (
+        isinstance(estimator, (str, _EstimatorBuilderBase))
+        or (isinstance(estimator, Callable) and not isinstance(estimator, nn.Module))
+    ):
+        raise TypeError(
+            "The passed density estimator / classifier must be a string, "
+            "an _EstimatorBuilderBase, or a function "
+            f"returning a nn.Module, but is {type(estimator)}"
+        )
 
 
 def validate_theta_and_x(

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -711,10 +711,13 @@ def check_sbi_inputs(simulator: Callable, prior: Distribution) -> None:
 
 def check_estimator_arg(estimator: Union[str, Callable]) -> None:
     """Check (density or ratio) estimator argument passed by the user."""
-    assert isinstance(estimator, str) or (
+    from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
+
+    assert isinstance(estimator, (str, _EstimatorBuilderBase)) or (
         isinstance(estimator, Callable) and not isinstance(estimator, nn.Module)
     ), (
-        "The passed density estimator / classifier must be a string or a function "
+        "The passed density estimator / classifier must be a string, "
+        "an _EstimatorBuilderBase, or a function "
         f"returning a nn.Module, but is {type(estimator)}"
     )
 

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -17,14 +17,17 @@ from sbi.utils.user_input_checks import check_estimator_arg
 
 @pytest.mark.parametrize("model", ("maf", "nsf", "mdn", "zuko_nsf"))
 def test_npe_accepts_builder(model):
+    """NPE_C.__init__ should accept a DensityEstimatorBuilder without warning."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     builder = DensityEstimatorBuilder(model=model)
+    # No FutureWarning expected for builder path.
     inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
     assert inference._build_neural_net is not None
 
 
 def test_npe_string_emits_deprecation_warning():
+    """Passing a string to density_estimator should emit FutureWarning."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     with pytest.warns(FutureWarning, match="deprecated"):
@@ -32,11 +35,47 @@ def test_npe_string_emits_deprecation_warning():
 
 
 def test_npe_callable_no_warning():
+    """Passing a callable should not emit any FutureWarning."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     build_fn = posterior_nn(model="maf")
+    # Should not warn.
     inference = NPE_C(prior, density_estimator=build_fn, show_progress_bars=False)
     assert inference._build_neural_net is build_fn
+
+
+@pytest.mark.parametrize("model", ("maf", "nsf", "mdn"))
+def test_npe_train_with_builder(model):
+    """Train NPE_C with a DensityEstimatorBuilder and verify the result."""
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    builder = DensityEstimatorBuilder(model=model, hidden_features=16, num_transforms=2)
+    inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
+
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+    density_estimator = inference.append_simulations(theta, x).train(
+        max_num_epochs=2, training_batch_size=100
+    )
+    assert isinstance(density_estimator, ConditionalDensityEstimator)
+
+
+@pytest.mark.parametrize("model", ("maf", "nsf"))
+def test_npe_build_posterior_with_builder(model):
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    builder = DensityEstimatorBuilder(model=model, hidden_features=16, num_transforms=2)
+    inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
+
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+    inference.append_simulations(theta, x).train(
+        max_num_epochs=2, training_batch_size=100
+    )
+    posterior = inference.build_posterior()
+    x_o = zeros(1, num_dim)
+    samples = posterior.sample((10,), x=x_o)
+    assert samples.shape == (10, num_dim)
 
 
 @pytest.mark.parametrize(
@@ -49,9 +88,11 @@ def test_npe_callable_no_warning():
     ids=["builder", "string", "callable"],
 )
 def test_check_estimator_arg_accepts_valid_inputs(estimator):
+    """check_estimator_arg should accept builders, strings, and callables."""
     check_estimator_arg(estimator)
 
 
 def test_check_estimator_arg_rejects_module():
+    """check_estimator_arg should reject raw nn.Module instances."""
     with pytest.raises(AssertionError):
         check_estimator_arg(torch.nn.Linear(3, 3))

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -65,19 +65,7 @@ def test_npe_train_with_builder(model):
     assert loss.shape == (10,)
     assert torch.isfinite(loss).all()
 
-
-@pytest.mark.parametrize("model", ("maf", "nsf"))
-def test_npe_build_posterior_with_builder(model):
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    builder = DensityEstimatorBuilder(model=model, hidden_features=16, num_transforms=2)
-    inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
-
-    theta = prior.sample((200,))
-    x = theta + 0.1 * torch.randn_like(theta)
-    inference.append_simulations(theta, x).train(
-        max_num_epochs=2, training_batch_size=100
-    )
+    # Also verify that a posterior can be constructed and sampled from.
     posterior = inference.build_posterior()
     x_o = zeros(1, num_dim)
     samples = posterior.sample((10,), x=x_o)

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -1,0 +1,57 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import pytest
+import torch
+from torch import eye, zeros
+from torch.distributions import MultivariateNormal
+
+from sbi.inference import NPE_C
+from sbi.neural_nets import posterior_nn
+from sbi.neural_nets.estimators import ConditionalDensityEstimator
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+)
+from sbi.utils.user_input_checks import check_estimator_arg
+
+
+@pytest.mark.parametrize("model", ("maf", "nsf", "mdn", "zuko_nsf"))
+def test_npe_accepts_builder(model):
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    builder = DensityEstimatorBuilder(model=model)
+    inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
+    assert inference._build_neural_net is not None
+
+
+def test_npe_string_emits_deprecation_warning():
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    with pytest.warns(FutureWarning, match="deprecated"):
+        NPE_C(prior, density_estimator="maf", show_progress_bars=False)
+
+
+def test_npe_callable_no_warning():
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    build_fn = posterior_nn(model="maf")
+    inference = NPE_C(prior, density_estimator=build_fn, show_progress_bars=False)
+    assert inference._build_neural_net is build_fn
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    (
+        DensityEstimatorBuilder(model="maf"),
+        "maf",
+        posterior_nn(model="maf"),
+    ),
+    ids=["builder", "string", "callable"],
+)
+def test_check_estimator_arg_accepts_valid_inputs(estimator):
+    check_estimator_arg(estimator)
+
+
+def test_check_estimator_arg_rejects_module():
+    with pytest.raises(AssertionError):
+        check_estimator_arg(torch.nn.Linear(3, 3))

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -86,11 +86,7 @@ def test_npe_build_posterior_with_builder(model):
 
 @pytest.mark.parametrize(
     "estimator",
-    (
-        DensityEstimatorBuilder(model="maf"),
-        "maf",
-        posterior_nn(model="maf"),
-    ),
+    (DensityEstimatorBuilder(model="maf"), "maf", posterior_nn(model="maf")),
     ids=["builder", "string", "callable"],
 )
 def test_check_estimator_arg_accepts_valid_inputs(estimator):
@@ -100,5 +96,5 @@ def test_check_estimator_arg_accepts_valid_inputs(estimator):
 
 def test_check_estimator_arg_rejects_module():
     """check_estimator_arg should reject raw nn.Module instances."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         check_estimator_arg(torch.nn.Linear(3, 3))

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -15,15 +15,19 @@ from sbi.neural_nets.net_builders.estimator_configs import (
 from sbi.utils.user_input_checks import check_estimator_arg
 
 
-@pytest.mark.parametrize("model", ("maf", "nsf", "mdn", "zuko_nsf"))
-def test_npe_accepts_builder(model):
-    """NPE_C.__init__ should accept a DensityEstimatorBuilder without warning."""
+def test_npe_no_warning_for_valid_inputs():
+    """Passing a builder, callable, or using the default should not warn."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    builder = DensityEstimatorBuilder(model=model)
-    # No FutureWarning expected for builder path.
-    inference = NPE_C(prior, density_estimator=builder, show_progress_bars=False)
-    assert inference._build_neural_net is not None
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        NPE_C(prior, show_progress_bars=False)
+        builder = DensityEstimatorBuilder(model="maf")
+        NPE_C(prior, density_estimator=builder, show_progress_bars=False)
+        build_fn = posterior_nn(model="maf")
+        NPE_C(prior, density_estimator=build_fn, show_progress_bars=False)
 
 
 def test_npe_string_emits_deprecation_warning():
@@ -32,16 +36,6 @@ def test_npe_string_emits_deprecation_warning():
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     with pytest.warns(FutureWarning, match="deprecated"):
         NPE_C(prior, density_estimator="maf", show_progress_bars=False)
-
-
-def test_npe_callable_no_warning():
-    """Passing a callable should not emit any FutureWarning."""
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    build_fn = posterior_nn(model="maf")
-    # Should not warn.
-    inference = NPE_C(prior, density_estimator=build_fn, show_progress_bars=False)
-    assert inference._build_neural_net is build_fn
 
 
 @pytest.mark.parametrize("model", ("maf", "nsf", "mdn"))

--- a/tests/npe_builder_integration_test.py
+++ b/tests/npe_builder_integration_test.py
@@ -58,6 +58,12 @@ def test_npe_train_with_builder(model):
         max_num_epochs=2, training_batch_size=100
     )
     assert isinstance(density_estimator, ConditionalDensityEstimator)
+    # Verify the trained estimator produces finite loss on a fresh batch.
+    fresh_theta = prior.sample((10,))
+    fresh_x = fresh_theta + 0.1 * torch.randn_like(fresh_theta)
+    loss = density_estimator.loss(fresh_theta, condition=fresh_x)
+    assert loss.shape == (10,)
+    assert torch.isfinite(loss).all()
 
 
 @pytest.mark.parametrize("model", ("maf", "nsf"))


### PR DESCRIPTION
## What does this PR do?

This is the third PR for for the Neural Network (NN) Builder API refactor project under GSoC 2026. It integrates the `DensityEstimatorBuilder` (introduced in PR #1877) into the NPE trainer hierarchy. Users can now pass a builder object to `PosteriorEstimatorTrainer`, `NPE_B`, `NPE_C`, and `MNPE` as the `density_estimator` argument instead of a string or callable.

## Files Changed

### Core integration (`npe_base.py`)
- Extended `density_estimator` type union to include `_EstimatorBuilderBase`
- Added `_wrap_builder()` static method that adapts a builder object to the existing `_build_neural_net(theta, x)` callable interface, keeping `_initialize_neural_network` unchanged
- Emit `FutureWarning` when a string is passed to `density_estimator` (deprecation path)

### Type annotation updates
- **`npe_b.py`**, **`npe_c.py`**, **`mnpe.py`**: Updated `density_estimator` parameter type annotations and docstrings to include `_EstimatorBuilderBase`

### Validation (`user_input_checks.py`)
- Extended `check_estimator_arg` to accept `_EstimatorBuilderBase` instances alongside strings and callables

### Tests (`npe_builder_integration_test.py`) this is a new file again
- `test_npe_accepts_builder`: parametrized over 4 models
- `test_npe_string_emits_deprecation_warning`
- `test_npe_callable_no_warning`
- `test_npe_train_with_builder`: parametrized over 3 models, trains for 2 epochs
- `test_npe_build_posterior_with_builder`: end-to-end: builder, then train, then sample
- `test_check_estimator_arg_accepts_valid_inputs`: parametrized (builder/str/callable)
- `test_check_estimator_arg_rejects_module`

## Backward compatibility

- The string path `density_estimator="maf"` still works but now emits a `FutureWarning`. No behavior change.
- The callable path (`posterior_nn(...)` or custom function works without any warning.

## AI Usage

* **Grammarly:** Used to refine and improve the grammar of this PR description.
* **VS Code auto-complete and co-pilot chatbot:** Used some suggested code, comments and bug fix suggestions.
* **Claude Opus 4.6 (via Antigravity 2.0):** It did some smoke tests to scan for any errors, all okay though.

## Does this close any issues?

N/A

## Any relevant code examples, logs, or error messages?

N/A