### PR TITLE
feat(mdn): implement transform_to_unconstrained z-scoring for MDN

### DIFF
--- a/sbi/inference/posteriors/npe_a_posterior.py
+++ b/sbi/inference/posteriors/npe_a_posterior.py
@@ -171,7 +171,7 @@ class NPE_A_Posterior(DirectPosterior):
 
         # Add log det jacobian for z-score transform
         log_probs = log_probs + self.posterior_estimator._log_det_jacobian_forward(
-            theta
+            theta, theta_transformed
         )
 
         return log_probs

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -354,7 +354,13 @@ class NPE_A(PosteriorEstimatorTrainer):
         prior_cov = self._prior.covariance_matrix
 
         # Apply z-score transform if enabled
-        if density_estimator.has_affine_z_score:
+        if getattr(density_estimator, "_prior_transform", None) is not None:
+            raise NotImplementedError(
+                "NPE-A's analytic leakage correction does not support "
+                "z_score_theta='transform_to_unconstrained' (it assumes an affine "
+                "z-score). Use 'independent'/'structured', or a different method."
+            )
+        if density_estimator.has_input_transform:
             shift = density_estimator._transform_shift
             scale = density_estimator._transform_scale
 
@@ -364,11 +370,6 @@ class NPE_A(PosteriorEstimatorTrainer):
             # Z-scored covariance: Sigma_z[i,j] = Sigma[i,j] / (scale_i * scale_j)
             scale_outer = scale.unsqueeze(-1) * scale.unsqueeze(-2)
             z_cov = prior_cov / scale_outer
-        elif density_estimator.has_input_transform:
-            raise NotImplementedError(
-                "Analytic SNPE correction is not supported for "
-                "nonlinear prior_transform."
-            )
         else:
             z_mean = prior_mean
             z_cov = prior_cov

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -354,7 +354,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         prior_cov = self._prior.covariance_matrix
 
         # Apply z-score transform if enabled
-        if density_estimator.has_input_transform:
+        if density_estimator.has_affine_z_score:
             shift = density_estimator._transform_shift
             scale = density_estimator._transform_scale
 
@@ -364,6 +364,11 @@ class NPE_A(PosteriorEstimatorTrainer):
             # Z-scored covariance: Sigma_z[i,j] = Sigma[i,j] / (scale_i * scale_j)
             scale_outer = scale.unsqueeze(-1) * scale.unsqueeze(-2)
             z_cov = prior_cov / scale_outer
+        elif density_estimator.has_input_transform:
+            raise NotImplementedError(
+                "Analytic SNPE correction is not supported for "
+                "nonlinear prior_transform."
+            )
         else:
             z_mean = prior_mean
             z_cov = prior_cov

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -239,13 +239,13 @@ class NPE_C(PosteriorEstimatorTrainer):
         """
         # Check if z-scoring is enabled on the MixtureDensityEstimator
         assert isinstance(self._neural_net, MixtureDensityEstimator)
-        if self._neural_net.has_input_transform and not self._neural_net.has_affine_z_score:
+        if getattr(self._neural_net, "_prior_transform", None) is not None:
             raise NotImplementedError(
-                "Analytic SNPE-C correction is not supported for "
-                "nonlinear prior_transform. Use single-round NPE or "
-                "affine z-scoring instead."
+                "NPE-C's analytic proposal correction does not support "
+                "z_score_theta='transform_to_unconstrained' (it assumes an affine "
+                "z-score). Use 'independent'/'structured', or single-round NPE."
             )
-        self.z_score_theta = self._neural_net.has_affine_z_score
+        self.z_score_theta = self._neural_net.has_input_transform
 
         self._set_maybe_z_scored_prior()
 

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -239,7 +239,13 @@ class NPE_C(PosteriorEstimatorTrainer):
         """
         # Check if z-scoring is enabled on the MixtureDensityEstimator
         assert isinstance(self._neural_net, MixtureDensityEstimator)
-        self.z_score_theta = self._neural_net.has_input_transform
+        if self._neural_net.has_input_transform and not self._neural_net.has_affine_z_score:
+            raise NotImplementedError(
+                "Analytic SNPE-C correction is not supported for "
+                "nonlinear prior_transform. Use single-round NPE or "
+                "affine z-scoring instead."
+            )
+        self.z_score_theta = self._neural_net.has_affine_z_score
 
         self._set_maybe_z_scored_prior()
 

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -497,8 +497,10 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         # Get MoG from network
         mog = self.get_uncorrected_mog(condition)
 
+        # MoG.log_prob handles (sample_dim, batch_dim, dim) input
         # Change of variables: log p(x) = log p(z) + log|det(dz/dx)|
-        log_probs = mog.log_prob(transformed_input)
+        # where z = (x - shift) / scale and log|det(dz/dx)| = -sum(log(scale))
+        log_probs = mog.log_prob(transformed_input)  # (sample_dim, batch_dim)
         log_probs = log_probs + self._log_det_jacobian_forward(input, transformed_input)
 
         if not has_sample_dim:

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -19,10 +19,9 @@ import torch
 from torch import Tensor, nn
 from torch.nn import functional as F
 
-from sbi.sbi_types import TorchTransform
-
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.mog import MoG
+from sbi.sbi_types import TorchTransform
 
 
 class MultivariateGaussianMDN(nn.Module):

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -413,11 +413,6 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
     @property
     def has_input_transform(self) -> bool:
         """Whether input z-score transform is enabled."""
-        return self._prior_transform is not None or self._transform_shift is not None
-
-    @property
-    def has_affine_z_score(self) -> bool:
-        """Whether the affine z-score transform (shift/scale) is enabled."""
         return self._transform_shift is not None
 
     def _transform_input(self, input: Tensor) -> Tensor:

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -415,6 +415,11 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         """Whether input z-score transform is enabled."""
         return self._prior_transform is not None or self._transform_shift is not None
 
+    @property
+    def has_affine_z_score(self) -> bool:
+        """Whether the affine z-score transform (shift/scale) is enabled."""
+        return self._transform_shift is not None
+
     def _transform_input(self, input: Tensor) -> Tensor:
         """Apply z-score transform to input: z = (x - shift) / scale."""
         if self._prior_transform is not None:

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -485,14 +485,18 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         self._check_condition_shape(condition)
         self._check_input_shape(input)
 
+        # Handle input with or without sample dimension
         has_sample_dim = input.dim() > len(self.input_shape) + 1
         if not has_sample_dim:
             input = input.unsqueeze(0)
 
+        # Apply z-score transform to input if enabled
         transformed_input = self._transform_input(input)
 
+        # Get MoG from network
         mog = self.get_uncorrected_mog(condition)
 
+        # Change of variables: log p(x) = log p(z) + log|det(dz/dx)|
         log_probs = mog.log_prob(transformed_input)
         log_probs = log_probs + self._log_det_jacobian_forward(
             input, transformed_input
@@ -513,6 +517,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         Returns:
             Loss per batch element, shape (batch_dim,).
         """
+        # Add sample dimension, compute log_prob, remove sample dimension
         log_prob = self.log_prob(input.unsqueeze(0), condition)
         return -log_prob.squeeze(0)
 
@@ -530,10 +535,13 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         """
         self._check_condition_shape(condition)
 
+        # Get MoG from network
         mog = self.get_uncorrected_mog(condition)
 
+        # MoG.sample returns (*sample_shape, batch_dim, dim) - matches sbi convention
         samples = mog.sample(sample_shape)
 
+        # Apply inverse transform to get samples in original space
         samples = self._inverse_transform_input(samples)
 
         return samples

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -412,7 +412,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
 
     @property
     def has_input_transform(self) -> bool:
-        """Whether input z-score transform or prior transform is enabled."""
+        """Whether input z-score transform is enabled."""
         return self._prior_transform is not None or self._transform_shift is not None
 
     def _transform_input(self, input: Tensor) -> Tensor:
@@ -431,10 +431,34 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
             return z
         return z * self._transform_scale + self._transform_shift
 
-    def _log_det_jacobian_forward(
-        self, input: Tensor, transformed_input: Tensor
-    ) -> Tensor:
-        """Compute log|det J| for the forward transform."""
+    def _log_det_jacobian_forward(self, input: Tensor, transformed_input: Tensor) -> Tensor:
+        """Compute log determinant of Jacobian for the forward z-score transform.
+
+        For the forward affine transform z = (x - shift) / scale:
+            - The Jacobian matrix is: dz/dx = diag(1/scale)
+            - The determinant is: |det(dz/dx)| = prod(1/scale)
+            - The log determinant is: log|det(dz/dx)| = -sum(log(scale))
+
+        Change of Variables Formula:
+            When we have a density p_z(z) and want p_x(x), we use:
+            p_x(x) = p_z(z(x)) * |det(dz/dx)|
+
+            In log space:
+            log p_x(x) = log p_z(z(x)) + log|det(dz/dx)|
+
+            Since log|det(dz/dx)| = -sum(log(scale)), we have:
+            log p_x(x) = log p_z(z) - sum(log(scale))
+
+        This method returns log|det(dz/dx)| = -sum(log(scale)), which should
+        be ADDED to log p_z(z) to get log p_x(x).
+
+        Args:
+            input: Input tensor, used to determine device and dtype.
+            transformed_input: Transformed input tensor (for prior_transform path).
+
+        Returns:
+            Log determinant of forward Jacobian (scalar for affine, same shape as input for prior_transform).
+        """
         if self._prior_transform is not None:
             return self._prior_transform.log_abs_det_jacobian(
                 input, transformed_input

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -17,6 +17,7 @@ from typing import Optional
 import numpy as np
 import torch
 from torch import Tensor, nn
+from sbi.sbi_types import TorchTransform
 from torch.nn import functional as F
 
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
@@ -337,6 +338,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         condition_shape: torch.Size,
         embedding_net: Optional[nn.Module] = None,
         transform_input: Optional[Tensor] = None,
+        prior_transform: Optional[TorchTransform] = None,
     ) -> None:
         """Initialize the mixture density estimator.
 
@@ -354,11 +356,20 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
                 evaluation, and samples are inverse transformed as:
                 x = z * scale + shift.
                 This is used for z-scoring inputs to improve numerical stability.
+            prior_transform: Optional Transform mapping constrained -> unconstrained
+                space. Mutually exclusive with transform_input. When set, log_prob
+                applies this transform (with log-det correction) and sample applies
+                its inverse.
         """
         super().__init__(net, input_shape, condition_shape)
         self._embedding_net = (
             embedding_net if embedding_net is not None else nn.Identity()
         )
+
+        if transform_input is not None and prior_transform is not None:
+            raise ValueError(
+                "Only one of transform_input and prior_transform can be provided."
+            )
 
         # Validate that embedding_net output matches MDN input if embedding is provided
         if embedding_net is not None:
@@ -371,6 +382,8 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
                     f"embedding_net output dimension ({embedded_dim}) does not match "
                     f"MDN context_features ({net.context_features})"
                 )
+
+        self._prior_transform = prior_transform
 
         # Store z-score transform parameters as buffers (not trained, moved with model)
         if transform_input is not None:
@@ -399,49 +412,49 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
 
     @property
     def has_input_transform(self) -> bool:
-        """Whether input z-score transform is enabled."""
-        return self._transform_shift is not None
+        """Whether input z-score transform or prior transform is enabled."""
+        return self._prior_transform is not None or self._transform_shift is not None
 
     def _transform_input(self, input: Tensor) -> Tensor:
         """Apply z-score transform to input: z = (x - shift) / scale."""
-        if not self.has_input_transform:
+        if self._prior_transform is not None:
+            return self._prior_transform(input)
+        if self._transform_shift is None:
             return input
         return (input - self._transform_shift) / self._transform_scale
 
     def _inverse_transform_input(self, z: Tensor) -> Tensor:
         """Apply inverse z-score transform: x = z * scale + shift."""
-        if not self.has_input_transform:
+        if self._prior_transform is not None:
+            return self._prior_transform.inv(z)
+        if self._transform_shift is None:
             return z
         return z * self._transform_scale + self._transform_shift
 
-    def _log_det_jacobian_forward(self, input: Tensor) -> Tensor:
-        """Compute log determinant of Jacobian for the forward z-score transform.
+    def _log_det_jacobian_forward(
+        self, input: Tensor, transformed_input: Tensor
+    ) -> Tensor:
+        """Compute log determinant of Jacobian for the forward transform.
 
         For the forward affine transform z = (x - shift) / scale:
-            - The Jacobian matrix is: dz/dx = diag(1/scale)
-            - The determinant is: |det(dz/dx)| = prod(1/scale)
-            - The log determinant is: log|det(dz/dx)| = -sum(log(scale))
+            log|det(dz/dx)| = -sum(log(scale))
 
-        Change of Variables Formula:
-            When we have a density p_z(z) and want p_x(x), we use:
-            p_x(x) = p_z(z(x)) * |det(dz/dx)|
-
-            In log space:
-            log p_x(x) = log p_z(z(x)) + log|det(dz/dx)|
-
-            Since log|det(dz/dx)| = -sum(log(scale)), we have:
-            log p_x(x) = log p_z(z) - sum(log(scale))
-
-        This method returns log|det(dz/dx)| = -sum(log(scale)), which should
-        be ADDED to log p_z(z) to get log p_x(x).
+        For prior_transform (e.g., mcmc_transform), delegates to the transform's
+        log_abs_det_jacobian, which already sums over the event dimension.
 
         Args:
-            input: Input tensor, used to determine device and dtype.
+            input: Input tensor in original space.
+            transformed_input: Input tensor in transformed space.
 
         Returns:
-            Log determinant of forward Jacobian (scalar), on the same device as input.
+            Log determinant of forward Jacobian, shape (sample_dim, batch_dim)
+            or scalar for the affine z-score path.
         """
-        if not self.has_input_transform:
+        if self._prior_transform is not None:
+            return self._prior_transform.log_abs_det_jacobian(
+                input, transformed_input
+            )
+        if self._transform_shift is None:
             return torch.zeros(1, device=input.device, dtype=input.dtype).squeeze()
         return -torch.log(self._transform_scale).sum()
 
@@ -476,9 +489,10 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
 
         # MoG.log_prob handles (sample_dim, batch_dim, dim) input
         # Change of variables: log p(x) = log p(z) + log|det(dz/dx)|
-        # where z = (x - shift) / scale and log|det(dz/dx)| = -sum(log(scale))
         log_probs = mog.log_prob(transformed_input)  # (sample_dim, batch_dim)
-        log_probs = log_probs + self._log_det_jacobian_forward(input)
+        log_probs = log_probs + self._log_det_jacobian_forward(
+            input, transformed_input
+        )
 
         if not has_sample_dim:
             log_probs = log_probs.squeeze(0)

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -17,8 +17,9 @@ from typing import Optional
 import numpy as np
 import torch
 from torch import Tensor, nn
-from sbi.sbi_types import TorchTransform
 from torch.nn import functional as F
+
+from sbi.sbi_types import TorchTransform
 
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.mog import MoG
@@ -431,7 +432,9 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
             return z
         return z * self._transform_scale + self._transform_shift
 
-    def _log_det_jacobian_forward(self, input: Tensor, transformed_input: Tensor) -> Tensor:
+    def _log_det_jacobian_forward(
+        self, input: Tensor, transformed_input: Tensor
+    ) -> Tensor:
         """Compute log determinant of Jacobian for the forward z-score transform.
 
         For the forward affine transform z = (x - shift) / scale:
@@ -457,12 +460,11 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
             transformed_input: Transformed input tensor (for prior_transform path).
 
         Returns:
-            Log determinant of forward Jacobian (scalar for affine, same shape as input for prior_transform).
+            Log determinant of forward Jacobian (scalar for affine, same shape as
+            input for prior_transform).
         """
         if self._prior_transform is not None:
-            return self._prior_transform.log_abs_det_jacobian(
-                input, transformed_input
-            )
+            return self._prior_transform.log_abs_det_jacobian(input, transformed_input)
         if self._transform_shift is None:
             return torch.zeros(1, device=input.device, dtype=input.dtype).squeeze()
         return -torch.log(self._transform_scale).sum()
@@ -498,9 +500,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
 
         # Change of variables: log p(x) = log p(z) + log|det(dz/dx)|
         log_probs = mog.log_prob(transformed_input)
-        log_probs = log_probs + self._log_det_jacobian_forward(
-            input, transformed_input
-        )
+        log_probs = log_probs + self._log_det_jacobian_forward(input, transformed_input)
 
         if not has_sample_dim:
             log_probs = log_probs.squeeze(0)

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -434,22 +434,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
     def _log_det_jacobian_forward(
         self, input: Tensor, transformed_input: Tensor
     ) -> Tensor:
-        """Compute log determinant of Jacobian for the forward transform.
-
-        For the forward affine transform z = (x - shift) / scale:
-            log|det(dz/dx)| = -sum(log(scale))
-
-        For prior_transform (e.g., mcmc_transform), delegates to the transform's
-        log_abs_det_jacobian, which already sums over the event dimension.
-
-        Args:
-            input: Input tensor in original space.
-            transformed_input: Input tensor in transformed space.
-
-        Returns:
-            Log determinant of forward Jacobian, shape (sample_dim, batch_dim)
-            or scalar for the affine z-score path.
-        """
+        """Compute log|det J| for the forward transform."""
         if self._prior_transform is not None:
             return self._prior_transform.log_abs_det_jacobian(
                 input, transformed_input
@@ -476,20 +461,15 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         self._check_condition_shape(condition)
         self._check_input_shape(input)
 
-        # Handle input with or without sample dimension
         has_sample_dim = input.dim() > len(self.input_shape) + 1
         if not has_sample_dim:
             input = input.unsqueeze(0)
 
-        # Apply z-score transform to input if enabled
         transformed_input = self._transform_input(input)
 
-        # Get MoG from network
         mog = self.get_uncorrected_mog(condition)
 
-        # MoG.log_prob handles (sample_dim, batch_dim, dim) input
-        # Change of variables: log p(x) = log p(z) + log|det(dz/dx)|
-        log_probs = mog.log_prob(transformed_input)  # (sample_dim, batch_dim)
+        log_probs = mog.log_prob(transformed_input)
         log_probs = log_probs + self._log_det_jacobian_forward(
             input, transformed_input
         )
@@ -509,7 +489,6 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         Returns:
             Loss per batch element, shape (batch_dim,).
         """
-        # Add sample dimension, compute log_prob, remove sample dimension
         log_prob = self.log_prob(input.unsqueeze(0), condition)
         return -log_prob.squeeze(0)
 
@@ -527,13 +506,10 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         """
         self._check_condition_shape(condition)
 
-        # Get MoG from network
         mog = self.get_uncorrected_mog(condition)
 
-        # MoG.sample returns (*sample_shape, batch_dim, dim) - matches sbi convention
         samples = mog.sample(sample_shape)
 
-        # Apply inverse transform to get samples in original space
         samples = self._inverse_transform_input(samples)
 
         return samples

--- a/sbi/neural_nets/net_builders/mdn.py
+++ b/sbi/neural_nets/net_builders/mdn.py
@@ -85,7 +85,6 @@ def build_mdn(
             standardizing_net(batch_y, structured_y), embedding_net
         )
 
-    # Create the MDN network
     mdn_net = MultivariateGaussianMDN(
         features=x_numel,
         context_features=y_numel,
@@ -94,7 +93,6 @@ def build_mdn(
         custom_initialization=True,
     )
 
-    # Wrap in MixtureDensityEstimator
     estimator = MixtureDensityEstimator(
         net=mdn_net,
         input_shape=batch_x[0].shape,

--- a/sbi/neural_nets/net_builders/mdn.py
+++ b/sbi/neural_nets/net_builders/mdn.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import torch
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.neural_nets.estimators.mixture_density_estimator import (
     MixtureDensityEstimator,
@@ -12,7 +13,7 @@ from sbi.neural_nets.estimators.mixture_density_estimator import (
 )
 from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
-    assert_transform_to_unconstrained_supported,
+    mcmc_transform,
     standardizing_net,
     z_score_parser,
     z_standardization,
@@ -28,6 +29,7 @@ def build_mdn(
     hidden_features: int = 50,
     num_components: int = 10,
     embedding_net: nn.Module = nn.Identity(),
+    x_dist: Optional[Distribution] = None,
     **kwargs,
 ) -> MixtureDensityEstimator:
     """Builds MDN p(x|y).
@@ -41,11 +43,15 @@ def build_mdn(
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension. Should be used when each
             sample is, for example, a time series or an image.
+            - `transform_to_unconstrained`: transform inputs to unconstrained space
+            using the prior's support. Requires `x_dist` to be provided.
         z_score_y: Whether to z-score ys passing into the network, same options as
             z_score_x.
         hidden_features: Number of hidden features.
         num_components: Number of components.
         embedding_net: Optional embedding network for y.
+        x_dist: Optional prior distribution. Required when
+            ``z_score_x="transform_to_unconstrained"``.
         kwargs: Additional arguments that are passed by the build function but are not
             relevant for MDNs and are therefore ignored.
 
@@ -53,19 +59,21 @@ def build_mdn(
         MixtureDensityEstimator for conditional density estimation.
     """
     check_data_device(batch_x, batch_y)
-    assert_transform_to_unconstrained_supported(
-        z_score_x,
-        "build_mdn",
-        "Use a `zuko_*` model (e.g. `zuko_maf`, `zuko_nsf`), which supports it, "
-        "or one of 'none', 'independent', 'structured'.",
-    )
+
     x_numel = get_numel(batch_x, embedding_net=None)
     y_numel = get_numel(batch_y, embedding_net=embedding_net)
 
     # Handle z-scoring for x (input)
     transform_input = None
+    prior_transform = None
     z_score_x_bool, structured_x = z_score_parser(z_score_x)
-    if z_score_x_bool:
+    if z_score_x == "transform_to_unconstrained":
+        if x_dist is None:
+            raise ValueError(
+                "x_dist must be provided when z_score_x='transform_to_unconstrained'."
+            )
+        prior_transform = mcmc_transform(x_dist, device=batch_x.device)
+    elif z_score_x_bool:
         x_mean, x_std = z_standardization(batch_x, structured_x)
         # Store as [shift, scale] tensor for the estimator
         transform_input = torch.stack([x_mean, x_std], dim=0)
@@ -93,6 +101,7 @@ def build_mdn(
         condition_shape=batch_y[0].shape,
         embedding_net=embedding_net,
         transform_input=transform_input,
+        prior_transform=prior_transform,
     )
 
     return estimator

--- a/sbi/neural_nets/net_builders/mdn.py
+++ b/sbi/neural_nets/net_builders/mdn.py
@@ -85,6 +85,7 @@ def build_mdn(
             standardizing_net(batch_y, structured_y), embedding_net
         )
 
+    # Create the MDN network
     mdn_net = MultivariateGaussianMDN(
         features=x_numel,
         context_features=y_numel,
@@ -93,6 +94,7 @@ def build_mdn(
         custom_initialization=True,
     )
 
+    # Wrap in MixtureDensityEstimator
     estimator = MixtureDensityEstimator(
         net=mdn_net,
         input_shape=batch_x[0].shape,

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -193,7 +193,13 @@ def extract_and_transform_mog(
     assert precfs is not None  # For type checker
 
     # Transform means and precision factors to original space if z-scoring is enabled
-    if estimator.has_affine_z_score:
+    if getattr(estimator, "_prior_transform", None) is not None:
+        raise NotImplementedError(
+            "Conditional density extraction is not supported for "
+            "z_score='transform_to_unconstrained' (it assumes an affine "
+            "z-score)."
+        )
+    if estimator.has_input_transform:
         # The z-score transform is: z = (theta - shift) / scale
         # To transform means: theta = z * scale + shift
         shift = estimator._transform_shift
@@ -201,11 +207,6 @@ def extract_and_transform_mog(
 
         # Transform means: mu_theta = mu_z * scale + shift
         means_transformed = means * scale + shift
-    elif estimator.has_input_transform:
-        raise NotImplementedError(
-            "Conditional density extraction is not supported for "
-            "nonlinear prior_transform."
-        )
 
         # Transform precision factors:
         # For z = (theta - shift) / scale:

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -193,7 +193,7 @@ def extract_and_transform_mog(
     assert precfs is not None  # For type checker
 
     # Transform means and precision factors to original space if z-scoring is enabled
-    if estimator.has_input_transform:
+    if estimator.has_affine_z_score:
         # The z-score transform is: z = (theta - shift) / scale
         # To transform means: theta = z * scale + shift
         shift = estimator._transform_shift
@@ -201,6 +201,11 @@ def extract_and_transform_mog(
 
         # Transform means: mu_theta = mu_z * scale + shift
         means_transformed = means * scale + shift
+    elif estimator.has_input_transform:
+        raise NotImplementedError(
+            "Conditional density extraction is not supported for "
+            "nonlinear prior_transform."
+        )
 
         # Transform precision factors:
         # For z = (theta - shift) / scale:

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -497,7 +497,6 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
 
         # Unsupported combination: the modeled variable requests the unconstrained
         # transform on a non-Zuko-conditional builder -> expect a clear ValueError.
-        # MDN supports it (via prior_transform), so it's excluded from this check.
         if (
             modeled_z == "transform_to_unconstrained"
             and not model.startswith("zuko")

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -497,7 +497,12 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
 
         # Unsupported combination: the modeled variable requests the unconstrained
         # transform on a non-Zuko-conditional builder -> expect a clear ValueError.
-        if modeled_z == "transform_to_unconstrained" and not model.startswith("zuko"):
+        # MDN supports it (via prior_transform), so it's excluded from this check.
+        if (
+            modeled_z == "transform_to_unconstrained"
+            and not model.startswith("zuko")
+            and model != "mdn"
+        ):
             with pytest.raises(ValueError, match="transform_to_unconstrained"):
                 build_fun = build_fn(**kwargs)
                 build_fun(theta, model_x)
@@ -549,30 +554,27 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
         "build_maf",
         "build_maf_rqs",
         "build_nsf",
-        "build_mdn",
         "build_linear_classifier",
         "build_mlp_classifier",
         "build_resnet_classifier",
     ],
 )
 def test_transform_to_unconstrained_raises_for_unsupported_builders(builder_name):
-    """nflows, MDN, and ratio-classifier builders raise a clear error for
+    """nflows and ratio-classifier builders raise a clear error for
     `transform_to_unconstrained` instead of silently building a model without the
-    reparametrization."""
+    reparametrization. MDN now supports it and is excluded."""
     from sbi.neural_nets.net_builders import flow as flow_builders
     from sbi.neural_nets.net_builders.classifier import (
         build_linear_classifier,
         build_mlp_classifier,
         build_resnet_classifier,
     )
-    from sbi.neural_nets.net_builders.mdn import build_mdn
 
     builders = {
         "build_made": flow_builders.build_made,
         "build_maf": flow_builders.build_maf,
         "build_maf_rqs": flow_builders.build_maf_rqs,
         "build_nsf": flow_builders.build_nsf,
-        "build_mdn": build_mdn,
         "build_linear_classifier": build_linear_classifier,
         "build_mlp_classifier": build_mlp_classifier,
         "build_resnet_classifier": build_resnet_classifier,
@@ -690,3 +692,21 @@ class TestWarnIfInvalidForZscoring:
         x_3d_outlier[0, 2, 3] = 10000.0  # Extreme outlier at position [2,3]
         with pytest.warns(UserWarning, match="extreme outliers"):
             warn_if_invalid_for_zscoring(x_3d_outlier)
+
+
+def test_mdn_transform_to_unconstrained():
+    """MDN with transform_to_unconstrained produces valid log_probs and samples."""
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((512,)), torch.randn(512, 3)
+    est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+    theta, cond = prior.sample((5,)), torch.randn(1, 3)
+    lp = est.log_prob(theta.unsqueeze(1), cond)
+    assert lp.shape == (5, 1)
+    z = est._prior_transform(theta.unsqueeze(1))
+    mog = est.get_uncorrected_mog(cond)
+    ldj = est._prior_transform.log_abs_det_jacobian(theta.unsqueeze(1), z)
+    assert torch.allclose(lp, mog.log_prob(z) + ldj, atol=1e-5)
+    s = est.sample((10,), cond)
+    assert s.shape[0] == 10 and torch.isfinite(s).all()


### PR DESCRIPTION
## Summary

Remove all vector field estimator changes from this PR. Keep only the `transform_to_unconstrained` z-scoring for MDN.

## Changes

- **`MixtureDensityEstimator`**: Added `prior_transform` parameter for change-of-variables via `mcmc_transform`. `log_prob` includes the Jacobian correction (`log_prob(z) + log|det J⁻¹|`). `sample` applies the inverse transform to map back to constrained space. The mutual-exclusion guard `transform_input` ↔ `prior_transform` ensures only one is active.
- **`build_mdn`**: Wires `prior_transform = mcmc_transform(x_dist)` when `z_score_x="transform_to_unconstrained"`. Added `x_dist` as explicit parameter.
- **Bugfix**: Fixed double-sum in `_log_det_jacobian` — the `IndependentTransform(reinterpreted_batch_ndims=1)` already sums over the event dimension, so the explicit `.sum(dim=-1)` was duplicating the sum.
- **Naming**: Renamed from `input_transform` → `prior_transform` to avoid confusion with the existing `transform_input` parameter.
- **Docs**: Restored omitted docstrings for `has_input_transform`, `_transform_input`, `_inverse_transform_input`, `_log_det_jacobian_forward`.
- **Type hints**: Uses `TorchTransform` from `sbi.sbi_types`.
- **Tests**: Added `test_mdn_transform_to_unconstrained` that tests the change-of-variables formula directly against the underlying MoG.

Closes #1885

---

The VF estimator changes will be pursued in a separate PR by @janfb 