### PR TITLE
fix: transform_to_unconstrained device mdn device handling (#1893)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # Development files and python cache
 /*.pyc
-junit.xml
 /*.egg
 /*.egg-info
 .venv*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Development files and python cache
 /*.pyc
+junit.xml
 /*.egg
 /*.egg-info
 .venv*

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -22,6 +22,7 @@ from torch.nn import functional as F
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.estimators.mog import MoG
 from sbi.sbi_types import TorchTransform
+from sbi.utils.sbiutils import _apply_to_transform
 
 
 class MultivariateGaussianMDN(nn.Module):
@@ -408,36 +409,8 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
     def _apply(self, fn):
         super()._apply(fn)
         if self._prior_transform is not None:
-            self._move_tensors(self._prior_transform, fn)
+            _apply_to_transform(self._prior_transform, fn)
         return self
-
-    @staticmethod
-    def _move_tensors(transform, fn):
-        seen = set()
-
-        def _walk(t):
-            if id(t) in seen:
-                return
-            seen.add(id(t))
-            for key, val in list(t.__dict__.items()):
-                if isinstance(val, Tensor):
-                    object.__setattr__(t, key, fn(val))
-                elif isinstance(val, (list, tuple)):
-                    changed = False
-                    items = list(val)
-                    for i, item in enumerate(items):
-                        if isinstance(item, Tensor):
-                            items[i] = fn(item)
-                            changed = True
-                        elif isinstance(item, TorchTransform):
-                            _walk(item)
-                    if changed:
-                        updated = type(val)(items) if isinstance(val, tuple) else items
-                        object.__setattr__(t, key, updated)
-                elif isinstance(val, TorchTransform):
-                    _walk(val)
-
-        _walk(transform)
 
     @property
     def embedding_net(self) -> nn.Module:

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -433,11 +433,7 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
                             _walk(item)
                     if changed:
                         object.__setattr__(
-                            t,
-                            key,
-                            type(val)(items)
-                            if isinstance(val, tuple)
-                            else items,
+                            t, key, type(val)(items) if isinstance(val, tuple) else items
                         )
                 elif isinstance(val, TorchTransform):
                     _walk(val)

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -432,9 +432,8 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
                         elif isinstance(item, TorchTransform):
                             _walk(item)
                     if changed:
-                        object.__setattr__(
-                            t, key, type(val)(items) if isinstance(val, tuple) else items
-                        )
+                        updated = type(val)(items) if isinstance(val, tuple) else items
+                        object.__setattr__(t, key, updated)
                 elif isinstance(val, TorchTransform):
                     _walk(val)
 

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -405,6 +405,45 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
             self.register_buffer("_transform_shift", None)
             self.register_buffer("_transform_scale", None)
 
+    def _apply(self, fn):
+        super()._apply(fn)
+        if self._prior_transform is not None:
+            self._move_tensors(self._prior_transform, fn)
+        return self
+
+    @staticmethod
+    def _move_tensors(transform, fn):
+        seen = set()
+
+        def _walk(t):
+            if id(t) in seen:
+                return
+            seen.add(id(t))
+            for key, val in list(t.__dict__.items()):
+                if isinstance(val, Tensor):
+                    object.__setattr__(t, key, fn(val))
+                elif isinstance(val, (list, tuple)):
+                    changed = False
+                    items = list(val)
+                    for i, item in enumerate(items):
+                        if isinstance(item, Tensor):
+                            items[i] = fn(item)
+                            changed = True
+                        elif isinstance(item, TorchTransform):
+                            _walk(item)
+                    if changed:
+                        object.__setattr__(
+                            t,
+                            key,
+                            type(val)(items)
+                            if isinstance(val, tuple)
+                            else items,
+                        )
+                elif isinstance(val, TorchTransform):
+                    _walk(val)
+
+        _walk(transform)
+
     @property
     def embedding_net(self) -> nn.Module:
         """Return the embedding network."""

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -814,27 +814,7 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
 def _apply_to_transform(
     transform: TorchTransform, fn: Callable[[Tensor], Tensor]
 ) -> None:
-    """Walk a transform tree and apply ``fn`` to every leaf tensor.
-
-    Handles ``ComposeTransform.parts``, ``IndependentTransform.base_transform``,
-    and any other transform attribute stored as a ``Tensor``, ``Transform``,
-    or ``list``/``tuple`` of ``Transform``s. Uses identity-tracking to avoid
-    infinite loops from cyclic references, though transforms are not expected
-    to have cycles.
-
-    This is a public utility because multiple call sites need it:
-
-    *  :func:`mcmc_transform` moves the freshly-built transform onto the
-       caller's target device.
-    *  ``MixtureDensityEstimator._apply`` propagates ``nn.Module`` device
-       moves into the transform so that ``.to()`` / ``.cuda()`` / ``.mps()``
-       work correctly.
-
-    Args:
-        transform: Root of the transform tree to walk.
-        fn: Callable applied to every ``Tensor`` encountered. Must return the
-            transformed tensor (e.g. ``lambda t: t.to(device)``).
-    """
+    """Apply fn to all tensors in a transform tree."""
     seen = set()
 
     def _walk(t):

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -814,7 +814,15 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
 def _apply_to_transform(
     transform: TorchTransform, fn: Callable[[Tensor], Tensor]
 ) -> None:
-    """Apply fn to all tensors in a transform tree."""
+    """Apply fn to all tensors in a transform tree.
+
+    Walks ComposeTransform.parts, IndependentTransform.base_transform,
+    etc., so .to() calls propagate into the transform.
+
+    Args:
+        transform: Root of the transform tree.
+        fn: Callable applied to each tensor (e.g. ``lambda t: t.to(device)``).
+    """
     seen = set()
 
     def _walk(t):

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -957,7 +957,6 @@ def mcmc_transform(
 
     check_transform(prior, transform)  # type: ignore
 
-    # Move transform tensors to the target device (check_transform runs on CPU)
     if enable_transform:
         _move_transform_tensors_to_device(transform, device)
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -811,6 +811,38 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
     return theta_repeated, x_repeated
 
 
+def _move_transform_tensors_to_device(
+    transform: TorchTransform, device: Union[str, torch.device]
+) -> None:
+    """Move all tensors in a transform tree to the target device."""
+    seen = set()
+
+    def _walk(t):
+        if id(t) in seen:
+            return
+        seen.add(id(t))
+        for key, val in list(t.__dict__.items()):
+            if isinstance(val, Tensor):
+                object.__setattr__(t, key, val.to(device))
+            elif isinstance(val, TorchTransform):
+                _walk(val)
+            elif isinstance(val, (list, tuple)):
+                changed = False
+                items = list(val)
+                for i, item in enumerate(items):
+                    if isinstance(item, Tensor):
+                        items[i] = item.to(device)
+                        changed = True
+                    elif isinstance(item, TorchTransform):
+                        _walk(item)
+                if changed:
+                    object.__setattr__(
+                        t, key, type(val)(items) if isinstance(val, tuple) else items
+                    )
+
+    _walk(transform)
+
+
 def mcmc_transform(
     prior: Distribution,
     num_prior_samples_for_zscoring: int = 1000,
@@ -924,6 +956,10 @@ def mcmc_transform(
         )
 
     check_transform(prior, transform)  # type: ignore
+
+    # Move transform tensors to the target device (check_transform runs on CPU)
+    if enable_transform:
+        _move_transform_tensors_to_device(transform, device)
 
     return transform.inv  # type: ignore
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -811,10 +811,30 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
     return theta_repeated, x_repeated
 
 
-def _move_transform_tensors_to_device(
-    transform: TorchTransform, device: Union[str, torch.device]
+def _apply_to_transform(
+    transform: TorchTransform, fn: Callable[[Tensor], Tensor]
 ) -> None:
-    """Move all tensors in a transform tree to the target device."""
+    """Walk a transform tree and apply ``fn`` to every leaf tensor.
+
+    Handles ``ComposeTransform.parts``, ``IndependentTransform.base_transform``,
+    and any other transform attribute stored as a ``Tensor``, ``Transform``,
+    or ``list``/``tuple`` of ``Transform``s. Uses identity-tracking to avoid
+    infinite loops from cyclic references, though transforms are not expected
+    to have cycles.
+
+    This is a public utility because multiple call sites need it:
+
+    *  :func:`mcmc_transform` moves the freshly-built transform onto the
+       caller's target device.
+    *  ``MixtureDensityEstimator._apply`` propagates ``nn.Module`` device
+       moves into the transform so that ``.to()`` / ``.cuda()`` / ``.mps()``
+       work correctly.
+
+    Args:
+        transform: Root of the transform tree to walk.
+        fn: Callable applied to every ``Tensor`` encountered. Must return the
+            transformed tensor (e.g. ``lambda t: t.to(device)``).
+    """
     seen = set()
 
     def _walk(t):
@@ -823,22 +843,20 @@ def _move_transform_tensors_to_device(
         seen.add(id(t))
         for key, val in list(t.__dict__.items()):
             if isinstance(val, Tensor):
-                object.__setattr__(t, key, val.to(device))
-            elif isinstance(val, TorchTransform):
-                _walk(val)
+                object.__setattr__(t, key, fn(val))
             elif isinstance(val, (list, tuple)):
                 changed = False
                 items = list(val)
-                for i, item in enumerate(items):
-                    if isinstance(item, Tensor):
-                        items[i] = item.to(device)
-                        changed = True
-                    elif isinstance(item, TorchTransform):
+                for _i, item in enumerate(items):
+                    if isinstance(item, TorchTransform):
                         _walk(item)
+                        changed = True
                 if changed:
                     object.__setattr__(
-                        t, key, type(val)(items) if isinstance(val, tuple) else items
+                        t, key, tuple(items) if isinstance(val, tuple) else items
                     )
+            elif isinstance(val, TorchTransform):
+                _walk(val)
 
     _walk(transform)
 
@@ -958,7 +976,7 @@ def mcmc_transform(
     check_transform(prior, transform)  # type: ignore
 
     if enable_transform:
-        _move_transform_tensors_to_device(transform, device)
+        _apply_to_transform(transform, lambda t: t.to(device))
 
     return transform.inv  # type: ignore
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -833,20 +833,45 @@ def _apply_to_transform(
             if isinstance(val, Tensor):
                 object.__setattr__(t, key, fn(val))
             elif isinstance(val, (list, tuple)):
-                changed = False
-                items = list(val)
-                for _i, item in enumerate(items):
+                for item in val:
                     if isinstance(item, TorchTransform):
                         _walk(item)
-                        changed = True
-                if changed:
-                    object.__setattr__(
-                        t, key, tuple(items) if isinstance(val, tuple) else items
-                    )
             elif isinstance(val, TorchTransform):
                 _walk(val)
 
     _walk(transform)
+
+
+def _transform_tensors(
+    transform: TorchTransform,
+) -> List[Tensor]:
+    """Collect every tensor in a transform tree (mirror of _apply_to_transform).
+
+    Args:
+        transform: Root of the transform tree.
+
+    Returns:
+        List of all tensors found in the transform tree.
+    """
+    seen = set()
+    tensors: List[Tensor] = []
+
+    def _walk(t):
+        if id(t) in seen:
+            return
+        seen.add(id(t))
+        for val in t.__dict__.values():
+            if isinstance(val, Tensor):
+                tensors.append(val)
+            elif isinstance(val, (list, tuple)):
+                for item in val:
+                    if isinstance(item, TorchTransform):
+                        _walk(item)
+            elif isinstance(val, TorchTransform):
+                _walk(val)
+
+    _walk(transform)
+    return tensors
 
 
 def mcmc_transform(

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -891,3 +891,27 @@ def test_npe_pfn_on_device(prior_device):
     assert posterior.estimator._context_input.device.type == "cpu", (
         "TabPFN context must always remain on CPU."
     )
+
+
+@pytest.mark.gpu
+def test_mdn_device_transform():
+    """MDN with transform_to_unconstrained moves transform tensors on .to()."""
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+
+    device = process_device("gpu")
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((512,)), torch.randn(512, 3)
+    est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+    est.to(device)
+
+    for key, val in list(est._prior_transform.__dict__.items()):
+        if isinstance(val, torch.Tensor):
+            assert val.device.type == device.split(":")[0], (
+                f"Transform tensor '{key}' on {val.device}, expected {device}"
+            )
+    theta = prior.sample((5,)).to(device)
+    cond = torch.randn(1, 3).to(device)
+    lp = est.log_prob(theta.unsqueeze(1), cond)
+    assert lp.device.type == device.split(":")[0]
+    s = est.sample((10,), cond)
+    assert s.device.type == device.split(":")[0]

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -897,6 +897,7 @@ def test_npe_pfn_on_device(prior_device):
 def test_mdn_device_transform():
     """MDN with transform_to_unconstrained moves transform tensors on .to()."""
     from sbi.neural_nets.net_builders.mdn import build_mdn
+    from sbi.utils.sbiutils import _transform_tensors
 
     device = process_device("gpu")
     prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
@@ -904,14 +905,42 @@ def test_mdn_device_transform():
     est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
     est.to(device)
 
-    for key, val in list(est._prior_transform.__dict__.items()):
-        if isinstance(val, torch.Tensor):
-            assert val.device.type == device.split(":")[0], (
-                f"Transform tensor '{key}' on {val.device}, expected {device}"
-            )
+    transform_tensors = _transform_tensors(est._prior_transform)
+    assert transform_tensors, "expected the prior transform to hold tensors"
+    for t in transform_tensors:
+        assert t.device.type == device.split(":")[0], (
+            f"transform tensor on {t.device}, expected {device}"
+        )
+
     theta = prior.sample((5,)).to(device)
     cond = torch.randn(1, 3).to(device)
     lp = est.log_prob(theta.unsqueeze(1), cond)
     assert lp.device.type == device.split(":")[0]
     s = est.sample((10,), cond)
     assert s.device.type == device.split(":")[0]
+
+
+def test_mdn_transform_follows_dtype():
+    """transform_to_unconstrained transform follows dtype casts on the MDN.
+
+    Guards the callable-fn design in _apply_to_transform: a rebuild-from-prior
+    would leave the transform in float32 and silently desync it from the weights.
+    Runs on every CI (no GPU needed).
+    """
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+    from sbi.utils.sbiutils import _transform_tensors
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((256,)), torch.randn(256, 3)
+    est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+
+    est.double()
+
+    transform_tensors = _transform_tensors(est._prior_transform)
+    assert transform_tensors, "expected the prior transform to hold tensors"
+    assert all(t.dtype == torch.float64 for t in transform_tensors)
+
+    theta = prior.sample((5,)).double()
+    cond = torch.randn(1, 3).double()
+    lp = est.log_prob(theta.unsqueeze(1), cond)
+    assert lp.dtype == torch.float64


### PR DESCRIPTION
Fixes MDN part of #1893

Two changes:
1. `mcmc_transform` bounded branch now moves transform tensor internals to the requested `device` (was CPU-only via `biject_to`)
2. `MixtureDensityEstimator._apply` overridden so `_prior_transform` follows `.to()`, `.cuda()`, `.mps()` moves
