### PR TITLE
fix: correct biased pymc HMC sampling (target_accept)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug Fixes
 
+* **Improve PyMC HMC sampling** ([#1908](https://github.com/sbi-dev/sbi/pull/1908)): Use a target acceptance probability of `0.9` by default for `hmc_pymc`, avoiding poor finite-chain mixing observed with PyMC's `0.65` default. The value can be customized with `MCMCPosteriorParameters.target_accept` or `MCMCPosterior.sample(target_accept=...)`.
 * **Fix TARP z-scoring bug** ([#1832](https://github.com/sbi-dev/sbi/issues/1832)): Reference points are now z-scored alongside `thetas` and `posterior_samples` when `z_score_theta=True`, fixing incorrect distance calculations that masked bias detection.
 * **Fix broken `biased_toy_gaussian` test helper**: Rewrote to create actual location bias (posterior mean shifted from truth) instead of the previous NaN-producing formula.
 * **Raise on unsupported `transform_to_unconstrained` z-scoring**: `z_score_x="transform_to_unconstrained"` was silently ignored by the nflows builders (`maf`, `nsf`, `maf_rqs`, `made`), the MDN builder, the unconditional Zuko builder, the ratio-based classifier builders (`linear`, `mlp`, `resnet`), and the vector field builders (FMPE / NPSE), producing a model with no reparametrization. These builders now raise a clear `ValueError`. The mixed builders (MNLE / MNPE) raise transitively when their continuous flow is a non-Zuko model. The option remains supported by the conditional `zuko_*` models.

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -64,6 +64,7 @@ class MCMCPosterior(NeuralPosterior):
         mp_context: Literal["fork", "spawn"] = "spawn",
         device: Optional[Union[str, torch.device]] = None,
         x_shape: Optional[torch.Size] = None,
+        target_accept: Optional[float] = None,
     ):
         """
         Args:
@@ -107,6 +108,9 @@ class MCMCPosterior(NeuralPosterior):
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
             x_shape: Deprecated, should not be passed.
+            target_accept: Target acceptance probability for the gradient-based
+                samplers (HMC/NUTS). See `MCMCPosteriorParameters` for details. If
+                `None`, HMC uses `0.9` and NUTS/Pyro keep their backend defaults.
         """
         if method == "slice":
             warn(
@@ -136,6 +140,7 @@ class MCMCPosterior(NeuralPosterior):
         self.init_strategy_parameters = init_strategy_parameters or {}
         self.num_workers = num_workers
         self.mp_context = mp_context
+        self.target_accept = target_accept
         self._posterior_sampler = None
 
         # Hardcode parameter name to reduce clutter kwargs.
@@ -257,6 +262,7 @@ class MCMCPosterior(NeuralPosterior):
         num_workers: Optional[int] = None,
         mp_context: Optional[str] = None,
         show_progress_bars: bool = True,
+        target_accept: Optional[float] = None,
     ) -> Tensor:
         r"""Draw samples from the approximate posterior distribution $p(\theta|x)$.
 
@@ -285,6 +291,9 @@ class MCMCPosterior(NeuralPosterior):
             mp_context: Multiprocessing context (`fork` or `spawn`). If not provided,
                 uses the value specified at initialization.
             show_progress_bars: Whether to show sampling progress monitor.
+            target_accept: Target acceptance probability for the gradient-based
+                samplers (HMC/NUTS). If not provided, uses the value specified at
+                initialization.
 
         Returns:
             Samples from posterior.
@@ -301,6 +310,7 @@ class MCMCPosterior(NeuralPosterior):
         init_strategy = self.init_strategy if init_strategy is None else init_strategy
         num_workers = self.num_workers if num_workers is None else num_workers
         mp_context = self.mp_context if mp_context is None else mp_context
+        target_accept = self.target_accept if target_accept is None else target_accept
         init_strategy_parameters = (
             self.init_strategy_parameters
             if init_strategy_parameters is None
@@ -342,6 +352,7 @@ class MCMCPosterior(NeuralPosterior):
                     num_chains=num_chains,
                     show_progress_bars=show_progress_bars,
                     mp_context=mp_context,
+                    target_accept=target_accept,
                 )
             elif method in ("hmc_pymc", "nuts_pymc", "slice_pymc"):
                 transformed_samples = self._pymc_mcmc(
@@ -354,6 +365,7 @@ class MCMCPosterior(NeuralPosterior):
                     num_chains=num_chains,
                     show_progress_bars=show_progress_bars,
                     mp_context=mp_context,
+                    target_accept=target_accept,
                 )
             else:
                 raise NameError(f"The sampling method {method} is not implemented!")
@@ -794,6 +806,7 @@ class MCMCPosterior(NeuralPosterior):
         num_chains: Optional[int] = 1,
         show_progress_bars: bool = True,
         mp_context: str = "spawn",
+        target_accept: Optional[float] = None,
     ) -> Tensor:
         r"""Return samples obtained using Pyro's HMC or NUTS sampler.
 
@@ -809,6 +822,8 @@ class MCMCPosterior(NeuralPosterior):
             warmup_steps: Initial number of samples to discard.
             num_chains: Whether to sample in parallel. If None, use all but one CPU.
             show_progress_bars: Whether to show a progressbar during sampling.
+            target_accept: Target acceptance probability for step-size adaptation.
+                If None, Pyro's default is used.
 
         Returns:
             Tensor of shape (num_samples, shape_of_single_theta).
@@ -827,9 +842,12 @@ class MCMCPosterior(NeuralPosterior):
         thin = _process_thin_default(thin)
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         kernels = dict(hmc_pyro=HMC, nuts_pyro=NUTS)
+        kernel_kwargs = {"potential_fn": potential_function}
+        if target_accept is not None:
+            kernel_kwargs["target_accept_prob"] = target_accept
 
         sampler = MCMC(
-            kernel=kernels[mcmc_method](potential_fn=potential_function),
+            kernel=kernels[mcmc_method](**kernel_kwargs),
             num_samples=ceil((thin * num_samples) / num_chains),
             warmup_steps=warmup_steps,
             initial_params={self.param_name: initial_params},
@@ -862,6 +880,7 @@ class MCMCPosterior(NeuralPosterior):
         num_chains: Optional[int] = 1,
         show_progress_bars: bool = True,
         mp_context: str = "spawn",
+        target_accept: Optional[float] = None,
     ) -> Tensor:
         r"""Return samples obtained using PyMC's HMC, NUTS or slice samplers.
 
@@ -877,6 +896,9 @@ class MCMCPosterior(NeuralPosterior):
             warmup_steps: Initial number of samples to discard.
             num_chains: Whether to sample in parallel. If None, use all but one CPU.
             show_progress_bars: Whether to show a progressbar during sampling.
+            target_accept: Target acceptance probability for HMC/NUTS. If None,
+                HMC uses 0.9 and NUTS keeps PyMC's default. Ignored by the slice
+                sampler.
 
         Returns:
             Tensor of shape (num_samples, shape_of_single_theta).
@@ -896,10 +918,8 @@ class MCMCPosterior(NeuralPosterior):
         steps = dict(slice_pymc="slice", hmc_pymc="hmc", nuts_pymc="nuts")
         step = steps[mcmc_method]
 
-        # PyMC's HamiltonianMC default (target_accept=0.65) mixes poorly on
-        # peaked targets and yields biased samples. Use a higher value for HMC;
-        # NUTS keeps PyMC's default (0.8), which already samples well.
-        target_accept = 0.9 if step == "hmc" else None
+        if target_accept is None and step == "hmc":
+            target_accept = 0.9
 
         sampler = PyMCSampler(
             potential_fn=potential_function,

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -894,10 +894,16 @@ class MCMCPosterior(NeuralPosterior):
         thin = _process_thin_default(thin)
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         steps = dict(slice_pymc="slice", hmc_pymc="hmc", nuts_pymc="nuts")
+        step = steps[mcmc_method]
+
+        # PyMC's HamiltonianMC default (target_accept=0.65) mixes poorly on
+        # peaked targets and yields biased samples. Use a higher value for HMC;
+        # NUTS keeps PyMC's default (0.8), which already samples well.
+        target_accept = 0.9 if step == "hmc" else None
 
         sampler = PyMCSampler(
             potential_fn=potential_function,
-            step=steps[mcmc_method],
+            step=step,
             initvals=tensor2numpy(initial_params),
             draws=ceil((thin * num_samples) / num_chains),
             tune=warmup_steps,
@@ -906,6 +912,7 @@ class MCMCPosterior(NeuralPosterior):
             progressbar=show_progress_bars,
             param_name=self.param_name,
             device=self._device,
+            target_accept=target_accept,
         )
         samples = sampler.run()
         samples = torch.from_numpy(samples).to(dtype=torch.float32, device=self._device)

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -31,7 +31,7 @@ from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched, tensor2numpy
-from sbi.utils.typechecks import validate_float_range
+from sbi.utils.typechecks import validate_target_accept
 
 
 class MCMCPosterior(NeuralPosterior):
@@ -109,10 +109,11 @@ class MCMCPosterior(NeuralPosterior):
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
             x_shape: Deprecated, should not be passed.
-            target_accept: Target acceptance probability for PyMC's HMC and NUTS
-                samplers. See `MCMCPosteriorParameters` for details. If `None`, PyMC
-                HMC uses `0.9` and PyMC NUTS keeps its backend default. Ignored by
-                other samplers.
+            target_accept: Target acceptance probability used only by the PyMC
+                samplers `hmc_pymc` and `nuts_pymc`; it is ignored by `slice_pymc`,
+                the Pyro samplers (`hmc_pyro`, `nuts_pyro`) and the numpy slice
+                samplers. If `None`, `hmc_pymc` uses `0.9` and `nuts_pymc` keeps
+                PyMC's backend default. See `MCMCPosteriorParameters` for details.
         """
         if method == "slice":
             warn(
@@ -142,14 +143,7 @@ class MCMCPosterior(NeuralPosterior):
         self.init_strategy_parameters = init_strategy_parameters or {}
         self.num_workers = num_workers
         self.mp_context = mp_context
-        if target_accept is not None:
-            validate_float_range(
-                target_accept,
-                "target_accept",
-                min_val=0.0,
-                max_val=1.0,
-                range_inclusive=False,
-            )
+        validate_target_accept(target_accept)
         self.target_accept = target_accept
         self._posterior_sampler = None
 
@@ -301,9 +295,10 @@ class MCMCPosterior(NeuralPosterior):
             mp_context: Multiprocessing context (`fork` or `spawn`). If not provided,
                 uses the value specified at initialization.
             show_progress_bars: Whether to show sampling progress monitor.
-            target_accept: Target acceptance probability for PyMC's HMC and NUTS
+            target_accept: Target acceptance probability used only by the PyMC
+                samplers `hmc_pymc` and `nuts_pymc`; it is ignored by `slice_pymc`,
+                the Pyro samplers (`hmc_pyro`, `nuts_pyro`) and the numpy slice
                 samplers. If not provided, uses the value specified at initialization.
-                Ignored by other samplers.
 
         Returns:
             Samples from posterior.
@@ -320,15 +315,10 @@ class MCMCPosterior(NeuralPosterior):
         init_strategy = self.init_strategy if init_strategy is None else init_strategy
         num_workers = self.num_workers if num_workers is None else num_workers
         mp_context = self.mp_context if mp_context is None else mp_context
-        target_accept = self.target_accept if target_accept is None else target_accept
-        if target_accept is not None:
-            validate_float_range(
-                target_accept,
-                "target_accept",
-                min_val=0.0,
-                max_val=1.0,
-                range_inclusive=False,
-            )
+        if target_accept is None:
+            target_accept = self.target_accept  # already validated in `__init__`.
+        else:
+            validate_target_accept(target_accept)
         init_strategy_parameters = (
             self.init_strategy_parameters
             if init_strategy_parameters is None
@@ -856,6 +846,7 @@ class MCMCPosterior(NeuralPosterior):
         thin = _process_thin_default(thin)
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         kernels = dict(hmc_pyro=HMC, nuts_pyro=NUTS)
+
         sampler = MCMC(
             kernel=kernels[mcmc_method](potential_fn=potential_function),
             num_samples=ceil((thin * num_samples) / num_chains),
@@ -926,11 +917,10 @@ class MCMCPosterior(NeuralPosterior):
         thin = _process_thin_default(thin)
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         steps = dict(slice_pymc="slice", hmc_pymc="hmc", nuts_pymc="nuts")
-        step = steps[mcmc_method]
 
         sampler = PyMCSampler(
             potential_fn=potential_function,
-            step=step,
+            step=steps[mcmc_method],
             initvals=tensor2numpy(initial_params),
             draws=ceil((thin * num_samples) / num_chains),
             tune=warmup_steps,

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -31,6 +31,7 @@ from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched, tensor2numpy
+from sbi.utils.typechecks import validate_float_range
 
 
 class MCMCPosterior(NeuralPosterior):
@@ -108,9 +109,10 @@ class MCMCPosterior(NeuralPosterior):
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
             x_shape: Deprecated, should not be passed.
-            target_accept: Target acceptance probability for the gradient-based
-                samplers (HMC/NUTS). See `MCMCPosteriorParameters` for details. If
-                `None`, HMC uses `0.9` and NUTS/Pyro keep their backend defaults.
+            target_accept: Target acceptance probability for PyMC's HMC and NUTS
+                samplers. See `MCMCPosteriorParameters` for details. If `None`, PyMC
+                HMC uses `0.9` and PyMC NUTS keeps its backend default. Ignored by
+                other samplers.
         """
         if method == "slice":
             warn(
@@ -140,6 +142,14 @@ class MCMCPosterior(NeuralPosterior):
         self.init_strategy_parameters = init_strategy_parameters or {}
         self.num_workers = num_workers
         self.mp_context = mp_context
+        if target_accept is not None:
+            validate_float_range(
+                target_accept,
+                "target_accept",
+                min_val=0.0,
+                max_val=1.0,
+                range_inclusive=False,
+            )
         self.target_accept = target_accept
         self._posterior_sampler = None
 
@@ -291,9 +301,9 @@ class MCMCPosterior(NeuralPosterior):
             mp_context: Multiprocessing context (`fork` or `spawn`). If not provided,
                 uses the value specified at initialization.
             show_progress_bars: Whether to show sampling progress monitor.
-            target_accept: Target acceptance probability for the gradient-based
-                samplers (HMC/NUTS). If not provided, uses the value specified at
-                initialization.
+            target_accept: Target acceptance probability for PyMC's HMC and NUTS
+                samplers. If not provided, uses the value specified at initialization.
+                Ignored by other samplers.
 
         Returns:
             Samples from posterior.
@@ -311,6 +321,14 @@ class MCMCPosterior(NeuralPosterior):
         num_workers = self.num_workers if num_workers is None else num_workers
         mp_context = self.mp_context if mp_context is None else mp_context
         target_accept = self.target_accept if target_accept is None else target_accept
+        if target_accept is not None:
+            validate_float_range(
+                target_accept,
+                "target_accept",
+                min_val=0.0,
+                max_val=1.0,
+                range_inclusive=False,
+            )
         init_strategy_parameters = (
             self.init_strategy_parameters
             if init_strategy_parameters is None
@@ -352,7 +370,6 @@ class MCMCPosterior(NeuralPosterior):
                     num_chains=num_chains,
                     show_progress_bars=show_progress_bars,
                     mp_context=mp_context,
-                    target_accept=target_accept,
                 )
             elif method in ("hmc_pymc", "nuts_pymc", "slice_pymc"):
                 transformed_samples = self._pymc_mcmc(
@@ -806,7 +823,6 @@ class MCMCPosterior(NeuralPosterior):
         num_chains: Optional[int] = 1,
         show_progress_bars: bool = True,
         mp_context: str = "spawn",
-        target_accept: Optional[float] = None,
     ) -> Tensor:
         r"""Return samples obtained using Pyro's HMC or NUTS sampler.
 
@@ -822,8 +838,6 @@ class MCMCPosterior(NeuralPosterior):
             warmup_steps: Initial number of samples to discard.
             num_chains: Whether to sample in parallel. If None, use all but one CPU.
             show_progress_bars: Whether to show a progressbar during sampling.
-            target_accept: Target acceptance probability for step-size adaptation.
-                If None, Pyro's default is used.
 
         Returns:
             Tensor of shape (num_samples, shape_of_single_theta).
@@ -842,12 +856,8 @@ class MCMCPosterior(NeuralPosterior):
         thin = _process_thin_default(thin)
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         kernels = dict(hmc_pyro=HMC, nuts_pyro=NUTS)
-        kernel_kwargs = {"potential_fn": potential_function}
-        if target_accept is not None:
-            kernel_kwargs["target_accept_prob"] = target_accept
-
         sampler = MCMC(
-            kernel=kernels[mcmc_method](**kernel_kwargs),
+            kernel=kernels[mcmc_method](potential_fn=potential_function),
             num_samples=ceil((thin * num_samples) / num_chains),
             warmup_steps=warmup_steps,
             initial_params={self.param_name: initial_params},
@@ -896,8 +906,8 @@ class MCMCPosterior(NeuralPosterior):
             warmup_steps: Initial number of samples to discard.
             num_chains: Whether to sample in parallel. If None, use all but one CPU.
             show_progress_bars: Whether to show a progressbar during sampling.
-            target_accept: Target acceptance probability for HMC/NUTS. If None,
-                HMC uses 0.9 and NUTS keeps PyMC's default. Ignored by the slice
+            target_accept: Target acceptance probability for HMC/NUTS. If `None`,
+                HMC uses `0.9` and NUTS keeps PyMC's default. Ignored by the slice
                 sampler.
 
         Returns:
@@ -917,9 +927,6 @@ class MCMCPosterior(NeuralPosterior):
         num_chains = mp.cpu_count() - 1 if num_chains is None else num_chains
         steps = dict(slice_pymc="slice", hmc_pymc="hmc", nuts_pymc="nuts")
         step = steps[mcmc_method]
-
-        if target_accept is None and step == "hmc":
-            target_accept = 0.9
 
         sampler = PyMCSampler(
             potential_fn=potential_function,

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -244,6 +244,13 @@ class MCMCPosteriorParameters(PosteriorParameters):
             (default), used by Pyro and PyMC samplers. `"fork"` can be significantly
             faster than `"spawn"` but is only supported on POSIX-based systems
             (e.g. Linux and macOS, not Windows).
+        target_accept: Target acceptance probability for the gradient-based
+            samplers (`hmc_pymc`, `nuts_pymc`, `hmc_pyro`, `nuts_pyro`), controlling
+            the step-size adaptation during warmup. Higher values take smaller,
+            more accurate steps at the cost of speed. Ignored by the slice samplers.
+            If `None`, HMC uses `0.9` (PyMC's default of `0.65` mixes poorly on
+            peaked targets and yields biased samples), while NUTS and the Pyro
+            samplers keep their respective backend defaults.
     """
 
     method: Literal[
@@ -262,9 +269,13 @@ class MCMCPosteriorParameters(PosteriorParameters):
     init_strategy_parameters: Optional[Dict[str, Any]] = None
     num_workers: int = 1
     mp_context: Literal["fork", "spawn"] = "spawn"
+    target_accept: Optional[float] = None
 
     def validate(self):
         """Validate MCMCPosteriorParameters fields."""
+
+        if self.target_accept is not None and not (0.0 < self.target_accept < 1.0):
+            raise ValueError("target_accept must be between 0 and 1, or None.")
 
         if not (
             self.init_strategy_parameters is None

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -23,6 +23,7 @@ from sbi.utils.typechecks import (
     is_nonnegative_int,
     is_positive_float,
     is_positive_int,
+    validate_float_range,
 )
 
 
@@ -244,13 +245,12 @@ class MCMCPosteriorParameters(PosteriorParameters):
             (default), used by Pyro and PyMC samplers. `"fork"` can be significantly
             faster than `"spawn"` but is only supported on POSIX-based systems
             (e.g. Linux and macOS, not Windows).
-        target_accept: Target acceptance probability for the gradient-based
-            samplers (`hmc_pymc`, `nuts_pymc`, `hmc_pyro`, `nuts_pyro`), controlling
-            the step-size adaptation during warmup. Higher values take smaller,
-            more accurate steps at the cost of speed. Ignored by the slice samplers.
-            If `None`, HMC uses `0.9` (PyMC's default of `0.65` mixes poorly on
-            peaked targets and yields biased samples), while NUTS and the Pyro
-            samplers keep their respective backend defaults.
+        target_accept: Target acceptance probability for `hmc_pymc` and `nuts_pymc`,
+            controlling step-size adaptation during warmup. Higher values generally
+            result in smaller steps and fewer rejections, at the cost of speed. If
+            `None`, HMC uses `0.9` because PyMC's `0.65` default mixed poorly in sbi's
+            Gaussian regression test; NUTS keeps PyMC's backend default. Ignored by
+            other samplers.
     """
 
     method: Literal[
@@ -274,8 +274,14 @@ class MCMCPosteriorParameters(PosteriorParameters):
     def validate(self):
         """Validate MCMCPosteriorParameters fields."""
 
-        if self.target_accept is not None and not (0.0 < self.target_accept < 1.0):
-            raise ValueError("target_accept must be between 0 and 1, or None.")
+        if self.target_accept is not None:
+            validate_float_range(
+                self.target_accept,
+                "target_accept",
+                min_val=0.0,
+                max_val=1.0,
+                range_inclusive=False,
+            )
 
         if not (
             self.init_strategy_parameters is None

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -23,7 +23,7 @@ from sbi.utils.typechecks import (
     is_nonnegative_int,
     is_positive_float,
     is_positive_int,
-    validate_float_range,
+    validate_target_accept,
 )
 
 
@@ -245,12 +245,14 @@ class MCMCPosteriorParameters(PosteriorParameters):
             (default), used by Pyro and PyMC samplers. `"fork"` can be significantly
             faster than `"spawn"` but is only supported on POSIX-based systems
             (e.g. Linux and macOS, not Windows).
-        target_accept: Target acceptance probability for `hmc_pymc` and `nuts_pymc`,
-            controlling step-size adaptation during warmup. Higher values generally
-            result in smaller steps and fewer rejections, at the cost of speed. If
-            `None`, HMC uses `0.9` because PyMC's `0.65` default mixed poorly in sbi's
-            Gaussian regression test; NUTS keeps PyMC's backend default. Ignored by
-            other samplers.
+        target_accept: Target acceptance probability used only by the PyMC samplers
+            `hmc_pymc` and `nuts_pymc`, controlling step-size adaptation during
+            warmup. Higher values generally result in smaller steps and fewer
+            rejections, at the cost of speed. If `None`, `hmc_pymc` uses `0.9`
+            because PyMC's `0.65` default mixed poorly in sbi's Gaussian regression
+            test, and `nuts_pymc` keeps PyMC's backend default. Ignored by
+            `slice_pymc`, the Pyro samplers (`hmc_pyro`, `nuts_pyro`) and the numpy
+            slice samplers.
     """
 
     method: Literal[
@@ -274,14 +276,7 @@ class MCMCPosteriorParameters(PosteriorParameters):
     def validate(self):
         """Validate MCMCPosteriorParameters fields."""
 
-        if self.target_accept is not None:
-            validate_float_range(
-                self.target_accept,
-                "target_accept",
-                min_val=0.0,
-                max_val=1.0,
-                range_inclusive=False,
-            )
+        validate_target_accept(self.target_accept)
 
         if not (
             self.init_strategy_parameters is None

--- a/sbi/samplers/mcmc/pymc_wrapper.py
+++ b/sbi/samplers/mcmc/pymc_wrapper.py
@@ -114,6 +114,8 @@ class PyMCSampler:
         progressbar: bool = True,
         param_name: str = "theta",
         device: str = "cpu",
+        seed: Optional[int] = None,
+        target_accept: Optional[float] = None,
     ):
         """Interface for PyMC samplers
 
@@ -128,6 +130,13 @@ class PyMCSampler:
             progressbar: Whether to show/hide progress bars.
             param_name: Name for parameter variable, for PyMC and ArviZ structures
             device: The device to which to move the parameters for potential_fn.
+            seed: Random seed passed to `pymc.sample` for reproducible sampling.
+                If None (default), PyMC seeds from system entropy.
+            target_accept: Target acceptance probability for the `"hmc"` and
+                `"nuts"` step methods. If None (default), PyMC's own default is
+                used. PyMC's HMC default (0.65) mixes poorly on peaked targets;
+                a higher value (e.g. 0.9-0.95) gives markedly less biased samples.
+                Ignored for the `"slice"` step.
         """
         self.param_name = param_name
         self._step = step
@@ -138,6 +147,8 @@ class PyMCSampler:
         self._mp_ctx = mp_ctx
         self._progressbar = progressbar
         self._device = device
+        self._seed = seed
+        self._target_accept = target_accept
 
         # create PyMC model object
         track_gradients = step in ("nuts", "hmc")
@@ -157,15 +168,21 @@ class PyMCSampler:
             MCMC samples
         """
         step_class = dict(slice=pymc.Slice, hmc=pymc.HamiltonianMC, nuts=pymc.NUTS)
+        # target_accept only applies to the gradient-based samplers; Slice
+        # does not take it.
+        step_kwargs = {}
+        if self._target_accept is not None and self._step in ("hmc", "nuts"):
+            step_kwargs["target_accept"] = self._target_accept
         with self._model:
             inference_data = pymc.sample(
-                step=step_class[self._step](),
+                step=step_class[self._step](**step_kwargs),
                 tune=self._tune,
                 draws=self._draws,
                 initvals=self._initvals,  # type: ignore
                 chains=self._chains,
                 progressbar=self._progressbar,
                 mp_ctx=self._mp_ctx,
+                random_seed=self._seed,
             )
         self._inference_data = inference_data
         traces = inference_data.posterior  # type: ignore

--- a/sbi/samplers/mcmc/pymc_wrapper.py
+++ b/sbi/samplers/mcmc/pymc_wrapper.py
@@ -9,6 +9,7 @@ import pytensor.tensor as pt
 import torch
 
 from sbi.utils.torchutils import tensor2numpy
+from sbi.utils.typechecks import validate_float_range
 
 
 class PyMCPotential(pt.Op):  # type: ignore
@@ -133,10 +134,10 @@ class PyMCSampler:
             seed: Random seed passed to `pymc.sample` for reproducible sampling.
                 If None (default), PyMC seeds from system entropy.
             target_accept: Target acceptance probability for the `"hmc"` and
-                `"nuts"` step methods. If None (default), PyMC's own default is
-                used. PyMC's HMC default (0.65) mixes poorly on peaked targets;
-                a higher value (e.g. 0.9-0.95) gives markedly less biased samples.
-                Ignored for the `"slice"` step.
+                `"nuts"` step methods. If `None`, HMC uses sbi's default of `0.9`,
+                while NUTS keeps PyMC's backend default. The HMC default avoids poor
+                finite-chain mixing observed with PyMC's `0.65` default in sbi's
+                Gaussian regression test. Ignored for the `"slice"` step.
         """
         self.param_name = param_name
         self._step = step
@@ -148,7 +149,17 @@ class PyMCSampler:
         self._progressbar = progressbar
         self._device = device
         self._seed = seed
-        self._target_accept = target_accept
+        if target_accept is not None:
+            validate_float_range(
+                target_accept,
+                "target_accept",
+                min_val=0.0,
+                max_val=1.0,
+                range_inclusive=False,
+            )
+        self._target_accept = (
+            0.9 if target_accept is None and step == "hmc" else target_accept
+        )
 
         # create PyMC model object
         track_gradients = step in ("nuts", "hmc")

--- a/sbi/samplers/mcmc/pymc_wrapper.py
+++ b/sbi/samplers/mcmc/pymc_wrapper.py
@@ -9,7 +9,12 @@ import pytensor.tensor as pt
 import torch
 
 from sbi.utils.torchutils import tensor2numpy
-from sbi.utils.typechecks import validate_float_range
+from sbi.utils.typechecks import validate_target_accept
+
+# PyMC's `HamiltonianMC` defaults to `target_accept=0.65`, which mixes poorly on
+# peaked posteriors and biases the samples (see sbi #1908). NUTS is unaffected and
+# keeps PyMC's own default.
+_DEFAULT_HMC_TARGET_ACCEPT = 0.9
 
 
 class PyMCPotential(pt.Op):  # type: ignore
@@ -134,10 +139,11 @@ class PyMCSampler:
             seed: Random seed passed to `pymc.sample` for reproducible sampling.
                 If None (default), PyMC seeds from system entropy.
             target_accept: Target acceptance probability for the `"hmc"` and
-                `"nuts"` step methods. If `None`, HMC uses sbi's default of `0.9`,
-                while NUTS keeps PyMC's backend default. The HMC default avoids poor
-                finite-chain mixing observed with PyMC's `0.65` default in sbi's
-                Gaussian regression test. Ignored for the `"slice"` step.
+                `"nuts"` step methods. If `None`, HMC uses sbi's default of `0.9`
+                (`_DEFAULT_HMC_TARGET_ACCEPT`), while NUTS keeps PyMC's backend
+                default. The HMC default avoids poor finite-chain mixing observed
+                with PyMC's `0.65` default in sbi's Gaussian regression test.
+                Ignored for the `"slice"` step.
         """
         self.param_name = param_name
         self._step = step
@@ -149,16 +155,11 @@ class PyMCSampler:
         self._progressbar = progressbar
         self._device = device
         self._seed = seed
-        if target_accept is not None:
-            validate_float_range(
-                target_accept,
-                "target_accept",
-                min_val=0.0,
-                max_val=1.0,
-                range_inclusive=False,
-            )
+        validate_target_accept(target_accept)
         self._target_accept = (
-            0.9 if target_accept is None and step == "hmc" else target_accept
+            _DEFAULT_HMC_TARGET_ACCEPT
+            if target_accept is None and step == "hmc"
+            else target_accept
         )
 
         # create PyMC model object

--- a/sbi/utils/typechecks.py
+++ b/sbi/utils/typechecks.py
@@ -110,17 +110,9 @@ def validate_target_accept(x: Any) -> None:
 
     Args:
         x: The value to validate. `None` means "use the sampler default".
-
-    Raises:
-        TypeError: If x is neither `None` nor a number.
-        ValueError: If x is not strictly between 0.0 and 1.0.
     """
 
-    if x is None:
-        return
-
-    if not isinstance(x, (float, int)):
-        raise TypeError(f"target_accept must be a float, but got {type(x).__name__}")
-
-    if not 0.0 < x < 1.0:
-        raise ValueError("target_accept must be strictly between 0.0 and 1.0.")
+    if x is not None:
+        validate_float_range(
+            x, "target_accept", min_val=0.0, max_val=1.0, range_inclusive=False
+        )

--- a/sbi/utils/typechecks.py
+++ b/sbi/utils/typechecks.py
@@ -100,3 +100,19 @@ def validate_float_range(
             raise ValueError(
                 f"{field_name} must be strictly between {min_val} and {max_val}."
             )
+
+
+def validate_target_accept(x: Any) -> None:
+    """Validate that x is `None` or a target acceptance probability in (0, 1).
+
+    `target_accept` is validated at several public boundaries (`MCMCPosterior`,
+    `MCMCPosteriorParameters`, `PyMCSampler`), so the policy lives here.
+
+    Args:
+        x: The value to validate. `None` means "use the sampler default".
+    """
+
+    if x is not None:
+        validate_float_range(
+            x, "target_accept", min_val=0.0, max_val=1.0, range_inclusive=False
+        )

--- a/sbi/utils/typechecks.py
+++ b/sbi/utils/typechecks.py
@@ -110,9 +110,17 @@ def validate_target_accept(x: Any) -> None:
 
     Args:
         x: The value to validate. `None` means "use the sampler default".
+
+    Raises:
+        TypeError: If x is neither `None` nor a number.
+        ValueError: If x is not strictly between 0.0 and 1.0.
     """
 
-    if x is not None:
-        validate_float_range(
-            x, "target_accept", min_val=0.0, max_val=1.0, range_inclusive=False
-        )
+    if x is None:
+        return
+
+    if not isinstance(x, (float, int)):
+        raise TypeError(f"target_accept must be a float, but got {type(x).__name__}")
+
+    if not 0.0 < x < 1.0:
+        raise ValueError("target_accept must be strictly between 0.0 and 1.0.")

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -178,6 +178,36 @@ def test_c2st_pymc_sampler_on_Gaussian(
 
 
 @pytest.mark.mcmc
+@pytest.mark.parametrize(
+    ("method", "target_accept", "expected"),
+    [
+        ("hmc_pymc", None, 0.9),  # HMC default is raised (PyMC's 0.65 is biased)
+        ("hmc_pymc", 0.99, 0.99),  # user override wins
+        ("nuts_pymc", None, None),  # NUTS keeps PyMC's own default
+    ],
+)
+def test_pymc_target_accept_forwarded(method, target_accept, expected):
+    """target_accept from the user reaches the PyMC sampler with the right default."""
+    theta_dim = 2
+    prior = BoxUniform(low=-2 * ones(theta_dim), high=2 * ones(theta_dim))
+
+    def potential_fn(theta):
+        return -0.5 * (theta**2).sum(axis=-1)
+
+    mcmc_posterior = build_from_potential(potential_fn, prior)
+    mcmc_posterior.sample(
+        (10,),
+        method=method,
+        target_accept=target_accept,
+        num_chains=1,
+        warmup_steps=10,
+        thin=1,
+        show_progress_bars=False,
+    )
+    assert mcmc_posterior._posterior_sampler._target_accept == expected
+
+
+@pytest.mark.mcmc
 def test_direct_mcmc_unconditional():
     "Test MCMCPosterior from user defined potential (unconditional)"
     num_samples = 100

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -158,6 +158,10 @@ def test_c2st_pymc_sampler_on_Gaussian(
         draws=(int(num_samples / num_chains)),  # PyMC does not use thinning
         tune=warmup,
         chains=num_chains,
+        seed=0,  # reproducible sampling; PyMC is not covered by the global seed
+        # PyMC's HMC default (target_accept=0.65) is biased on this peaked
+        # target (c2st ~0.63); 0.95 samples it accurately. See #1894 follow-up.
+        target_accept=0.95,
     )
     samples = sampler.run()
     assert samples.shape == (

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -178,6 +178,8 @@ def test_c2st_pymc_sampler_on_Gaussian(
 @pytest.mark.parametrize(
     ("step", "target_accept", "expected"),
     [
+        # 0.9 is spelled out rather than imported from `_DEFAULT_HMC_TARGET_ACCEPT` so
+        # that changing the documented default has to be a deliberate test update.
         ("hmc", None, 0.9),
         ("hmc", 0.99, 0.99),
         ("nuts", None, None),

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -159,9 +159,6 @@ def test_c2st_pymc_sampler_on_Gaussian(
         tune=warmup,
         chains=num_chains,
         seed=0,  # reproducible sampling; PyMC is not covered by the global seed
-        # PyMC's HMC default (target_accept=0.65) is biased on this peaked
-        # target (c2st ~0.63); 0.95 samples it accurately. See #1894 follow-up.
-        target_accept=0.95,
     )
     samples = sampler.run()
     assert samples.shape == (
@@ -179,32 +176,47 @@ def test_c2st_pymc_sampler_on_Gaussian(
 
 @pytest.mark.mcmc
 @pytest.mark.parametrize(
-    ("method", "target_accept", "expected"),
+    ("step", "target_accept", "expected"),
     [
-        ("hmc_pymc", None, 0.9),  # HMC default is raised (PyMC's 0.65 is biased)
-        ("hmc_pymc", 0.99, 0.99),  # user override wins
-        ("nuts_pymc", None, None),  # NUTS keeps PyMC's own default
+        ("hmc", None, 0.9),
+        ("hmc", 0.99, 0.99),
+        ("nuts", None, None),
     ],
 )
-def test_pymc_target_accept_forwarded(method, target_accept, expected):
-    """target_accept from the user reaches the PyMC sampler with the right default."""
+def test_pymc_target_accept_default_and_override(step, target_accept, expected):
+    """PyMC HMC uses sbi's default and explicit user values take precedence."""
+    from sbi.samplers.mcmc.pymc_wrapper import PyMCSampler
+
+    theta_dim = 2
+
+    def potential_fn(theta):
+        return -0.5 * (theta**2).sum(axis=-1)
+
+    sampler = PyMCSampler(
+        potential_fn=potential_fn,
+        initvals=np.zeros((1, theta_dim)),
+        step=step,
+        target_accept=target_accept,
+        draws=1,
+        tune=1,
+        chains=1,
+    )
+    assert sampler._target_accept == expected
+
+
+@pytest.mark.mcmc
+def test_mcmc_posterior_rejects_invalid_target_accept():
+    """Per-call overrides validate target_accept at the public API boundary."""
     theta_dim = 2
     prior = BoxUniform(low=-2 * ones(theta_dim), high=2 * ones(theta_dim))
 
     def potential_fn(theta):
         return -0.5 * (theta**2).sum(axis=-1)
 
-    mcmc_posterior = build_from_potential(potential_fn, prior)
-    mcmc_posterior.sample(
-        (10,),
-        method=method,
-        target_accept=target_accept,
-        num_chains=1,
-        warmup_steps=10,
-        thin=1,
-        show_progress_bars=False,
-    )
-    assert mcmc_posterior._posterior_sampler._target_accept == expected
+    with pytest.warns(UserWarning, match="unconditional potential"):
+        posterior = build_from_potential(potential_fn, prior)
+    with pytest.raises(ValueError, match="target_accept"):
+        posterior.sample((1,), method="hmc_pymc", target_accept=0.0)
 
 
 @pytest.mark.mcmc

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -396,6 +396,20 @@ def test_invalid_literal_field_values():
     MCMCPosteriorParameters(method="invalid")
 
 
+@pytest.mark.parametrize("target_accept", [None, 0.5, 0.9, 0.99])
+def test_mcmc_target_accept_accepts_valid_values(target_accept):
+    """target_accept accepts None or a probability in (0, 1)."""
+    params = MCMCPosteriorParameters(target_accept=target_accept)
+    assert params.target_accept == target_accept
+
+
+@pytest.mark.parametrize("target_accept", [0.0, 1.0, 1.5, -0.1])
+def test_mcmc_target_accept_rejects_invalid_values(target_accept):
+    """target_accept outside (0, 1) is rejected."""
+    with pytest.raises(ValueError, match="target_accept"):
+        MCMCPosteriorParameters(target_accept=target_accept)
+
+
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
Follow-up to #1894 because CD is failing again. Once the lockfile fix let the pymc
tests run again in CD, `test_c2st_pymc_sampler_on_Gaussian` failed on the `hmc`
parametrizations with c2st around 0.62.

However, it's not flaky: pymc's `HamiltonianMC` defaults to `target_accept=0.65`,
which mixes poorly on this peaked Gaussian and biases the samples, regardless of
seed, warmup, or number of draws. NUTS works fine.

To fix this:

- expose `seed` and `target_accept` on `PyMCSampler`
- **default `hmc_pymc` to `target_accept=0.9`** (`_DEFAULT_HMC_TARGET_ACCEPT` in
  `pymc_wrapper.py`) to get accurate HMC posteriors (c2st ~0.51 vs ~0.62);
  `nuts_pymc` keeps PyMC's backend default and `slice_pymc` is unchanged
- make the new default overridable via `MCMCPosterior(target_accept=...)`,
  `MCMCPosterior.sample(target_accept=...)` and
  `MCMCPosteriorParameters.target_accept`, validated to be in `(0, 1)`
- seed the c2st test for reproducible sampling; it now relies on the new `0.9`
  default rather than passing its own value

`target_accept` is PyMC-only: `pymc.Slice` does not take it, so it is forwarded
only for the `hmc`/`nuts` steps, and the Pyro samplers (`hmc_pyro`, `nuts_pyro`)
ignore it entirely.

Since this silently changes a default, there is a CHANGELOG entry under
`v0.26.1` → Bug Fixes.

Note: the c2st test is marked `slow`, I will run the CD on this branch via
workflow dispatch.