### PR TITLE
fix: constrain pymc to avoid arviz-1.x import break, test CI on py3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
-        split_size: [4]
-        group_number: [1, 2, 3, 4]
+        python-version: ['3.10', '3.13']
+        split_size: [6]
+        group_number: [1, 2, 3, 4, 5, 6]
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
 [project.optional-dependencies]
 tabpfn = ["tabpfn"]
 notebook = ["notebook"]
-pymc = ["pymc>=5.0.0"]
+# pymc>=5.28.1 on py>=3.12 avoids the pymc/arviz-1.x import break (see PR #1907).
+pymc = ["pymc>=5.0.0", "pymc>=5.28.1; python_version >= '3.12'"]
 pyro = ["pyro-ppl>=1.3.1"]
 all = ["sbi[pymc]", "sbi[pyro]", "sbi[tabpfn]"]
 doc = [

--- a/uv.lock
+++ b/uv.lock
@@ -4168,6 +4168,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },
+    { name = "pymc", marker = "python_full_version >= '3.12' and extra == 'pymc'", specifier = ">=5.28.1" },
     { name = "pymc", marker = "extra == 'pymc'", specifier = ">=5.0.0" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pyro-ppl", marker = "extra == 'pyro'", specifier = ">=1.3.1" },


### PR DESCRIPTION
The monthly lockfile upgrade (#1907) reintroduced the pymc/arviz import break on Python >=3.12. Root cause: `sbi[pymc]` only requires `pymc>=5.0.0`, and pymc <5.28.1 declares an *unbounded* `arviz` dependency. On Python >=3.12 (where arviz 1.x is installable) the resolver can pair an old pymc with arviz 1.x, and arviz 1.x removed top-level names pymc imports (`InferenceData`, `concat`), so `import pymc` fails. Python <3.12 is unaffected because arviz 1.x requires Python >=3.12.

pymc already fixed this on its side, twice: `pymc>=5.28.1` caps `arviz<1.0`, and `pymc>=6.0.0` (Python >=3.12) moved to `arviz>=1.1.0,<2.0`. So the fix is to stop accepting the one pymc range that has an unbounded arviz on the Python versions where it matters.

### Changes
- **`pyproject.toml`**: `pymc = ["pymc>=5.0.0", "pymc>=5.28.1; python_version >= '3.12'"]`. On py>=3.12 this forces a pymc with a sane arviz bound (5.28.x with `arviz<1.0`, or 6.x with arviz 1.x); py<3.12 is unchanged. This is wheel-visible, so it protects pip users too (not just our locked CI).
- **`uv.lock`**: regenerated — a single added metadata line, no package version churn (still resolves pymc 5.28.3 + arviz 0.23.4).
- **`ci.yml`**: run the fast suite on Python 3.13 in addition to 3.10. The main CI matrix was 3.10-only, so a lockfile change that breaks only on >=3.12 passed PR CI and failed only post-merge in `cd.yml`. Split raised 4->6 to keep wall-clock low across the two versions without overloading the shared runner pool.

### Verification
- `uv lock` resolves pymc 5.28.3 + arviz 0.23.4 (no arviz 1.x).
- A simulated `uv lock --upgrade` now resolves pymc 6.0.1 + arviz 1.2.0 on py>=3.12, and I confirmed sbi's `PyMCSampler` works against that stack (nuts/slice c2st pass; hmc needs the `target_accept` fix in #1908, unrelated to this).