### PR TITLE
perf(ci): shard CD across workers to speed it up

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
+        split_size: [4]
+        group_number: [1, 2, 3, 4]
 
     steps:
     - name: Checkout
@@ -48,7 +50,9 @@ jobs:
       run: uv sync --locked --extra dev
 
     - name: Run the fast and the slow CPU tests with coverage
-      run: uv run pytest -v -x -n auto -m "not gpu" --cov=sbi --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/
+      # Shard the suite across runners with pytest-split, balanced by the
+      # committed .test_durations (refreshed by refresh-test-durations.yml).
+      run: uv run pytest -v -x -n auto -m "not gpu" --cov=sbi --cov-report=xml --junitxml=junit.xml -o junit_family=legacy --splitting-algorithm least_duration --splits ${{ matrix.split_size }} --group ${{ matrix.group_number }} tests/
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/refresh-test-durations.yml
+++ b/.github/workflows/refresh-test-durations.yml
@@ -1,0 +1,79 @@
+name: Refresh test durations
+
+# cd.yml shards the test suite with pytest-split, balanced by the committed
+# .test_durations. This job regenerates that file by running the FULL suite
+# UNSHARDED with --store-durations (so pytest-split writes complete, correct
+# timings with no per-shard merge), then opens a PR. Run monthly (durations
+# drift slowly) plus on demand. A PR is used because main requires review, so a
+# job cannot push to it directly.
+#
+# NOTE: requires "Allow GitHub Actions to create and approve pull requests" in
+# repo settings. GITHUB_TOKEN-created PRs do not trigger CI; close/reopen (or
+# push an empty commit) to run checks before merging.
+
+on:
+  schedule:
+    - cron: '0 4 1 * *'  # monthly, 1st at 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  refresh:
+    name: Regenerate .test_durations
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: '3.12'
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: Install dependencies with uv
+      run: uv sync --locked --extra dev
+
+    - name: Record test durations
+      # Full CPU suite, unsharded, so every test is timed in one file. No -x: a
+      # failing test must not truncate the recording (the durations are still
+      # valid), so this step is allowed to fail.
+      continue-on-error: true
+      run: uv run pytest -n auto -m "not gpu" --store-durations --durations-path .test_durations tests/
+
+    - name: Open a PR if durations changed
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        if git diff --quiet -- .test_durations; then
+          echo ".test_durations unchanged; nothing to do."
+          exit 0
+        fi
+        branch="chore/refresh-test-durations-${{ github.run_id }}"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git checkout -b "$branch"
+        git add .test_durations
+        git commit -m "chore: refresh .test_durations"
+        git push origin "$branch"
+        gh pr create \
+          --title "chore: refresh .test_durations" \
+          --body "Automated refresh of the pytest-split timings that balance the CD test shards (see cd.yml). Regenerated from a full unsharded suite run with --store-durations." \
+          --base main \
+          --head "$branch"


### PR DESCRIPTION
CD ran one job per Python version (full suite, ~120 min each). This PR shards each version across 4 workers with pytest-split (same pattern `ci.yml` already uses), so 4 versions × 4 splits = 16 parallel jobs — cutting wall-clock roughly 3-4x, floored by the slowest single test (~5 min).

Shards are balanced by the committed `.test_durations`. Since that file goes stale as tests are added, `refresh-test-durations.yml` regenerates it monthly (and on demand) from a full **unsharded** run with `--store-durations` and opens a PR:
- a PR rather than a direct commit, because main requires review;
- a full unsharded run rather than merging per-shard timings, because pytest-split writes the full durations dict per shard, so a per-shard merge would be lossy.