### PR TITLE
fix: make vector-field tests order-independent

### DIFF
--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import random
 from dataclasses import asdict
 from typing import List, Literal
 
@@ -33,6 +34,7 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils import BoxUniform
 from sbi.utils.metrics import check_c2st
+from sbi.utils.sbiutils import seed_all_backends
 from sbi.utils.user_input_checks import process_simulator
 
 from .test_utils import get_dkl_gaussian_prior
@@ -300,9 +302,14 @@ def train_vector_field_model(vector_field_type, prior_type):
     if cache_key in _trained_models_cache:
         return _trained_models_cache[cache_key]
 
+    # Fixed seed for a deterministic cached model; save/restore RNG so training
+    # leaves the caller's stream untouched (keeps tests order-independent).
+    rng_state = (random.getstate(), np.random.get_state(), torch.get_rng_state())
+    seed_all_backends(0)
+
     # Train the model
     num_dim = 2
-    num_simulations = 6000
+    num_simulations = 12000
 
     # likelihood_mean will be likelihood_shift+theta
     likelihood_shift = -1.0 * ones(num_dim)
@@ -333,6 +340,11 @@ def train_vector_field_model(vector_field_type, prior_type):
     x = linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     estimator = inference.append_simulations(theta, x).train()
+
+    # Restore RNG (see above).
+    random.setstate(rng_state[0])
+    np.random.set_state(rng_state[1])
+    torch.set_rng_state(rng_state[2])
 
     result = {
         "estimator": estimator,


### PR DESCRIPTION
Follow-up to #1910. `test_iid_log_prob[5-gaussian-ve]` started failing once CD sharding changed test execution order.

**Problem**: `train_vector_field_model` caches a model per `(vector_field_type, prior_type)` but trained it on the ambient RNG state, so both the cached model *and* the RNG depend of whichever test trained it depended on which test ran first. Sharding via `pytest split` changed that order, and a green run was really passing by luck of the ordering.

**Fix**:
- seed training with a fixed seed to get a deterministic cached model;
- save/restore the global RNG around training so that a test that trains a model leaves the same RNG state as one that reuses it (order-independent downstream sampling);
- raise `num_simulations` 6000 to 12000, because a fixed seed alone was a quality gamble (good VE, but c2st 0.95 for FMPE iid inference; 12k lands FMPE at 0.68, under the 0.85 ceiling).

**Verified**: the VE diff is now bit-identical whether the test trains or reuses the model (1.1436985731124878 both ways), and the full vector-field suite passes (89 passed).