### PR TITLE
Add RatioEstimatorBuilder for NRE trainers and base class improvements

### DIFF
--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -123,14 +123,13 @@ class MNLE(LikelihoodEstimatorTrainer):
                 stacklevel=2,
             )
             density_estimator = likelihood_nn(model="mnle")
-        elif isinstance(density_estimator, _EstimatorBuilderBase) and not isinstance(
-            density_estimator, MixedDensityEstimatorBuilder
-        ):
-            raise TypeError(
-                "MNLE requires a MixedDensityEstimatorBuilder; got "
-                f"{type(density_estimator).__name__}. Use "
-                "MixedDensityEstimatorBuilder(continuous_model=...)."
-            )
+        elif isinstance(density_estimator, _EstimatorBuilderBase):
+            if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
+                raise TypeError(
+                    "MNLE requires a MixedDensityEstimatorBuilder; got "
+                    f"{type(density_estimator).__name__}. Use "
+                    "MixedDensityEstimatorBuilder(continuous_model=...)."
+                )
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
 

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -124,13 +124,14 @@ class MNLE(LikelihoodEstimatorTrainer):
                 stacklevel=2,
             )
             density_estimator = likelihood_nn(model="mnle")
-        elif isinstance(density_estimator, _EstimatorBuilderBase):  # noqa: SIM102
-            if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
-                raise TypeError(
-                    "MNLE requires a MixedDensityEstimatorBuilder; got "
-                    f"{type(density_estimator).__name__}. Use "
-                    "MixedDensityEstimatorBuilder(continuous_model=...)."
-                )
+        elif isinstance(density_estimator, _EstimatorBuilderBase) and not isinstance(
+            density_estimator, MixedDensityEstimatorBuilder
+        ):
+            raise TypeError(
+                "MNLE requires a MixedDensityEstimatorBuilder; got "
+                f"{type(density_estimator).__name__}. Use "
+                "MixedDensityEstimatorBuilder(continuous_model=...)."
+            )
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
 

--- a/sbi/inference/trainers/nle/mnle.py
+++ b/sbi/inference/trainers/nle/mnle.py
@@ -118,12 +118,13 @@ class MNLE(LikelihoodEstimatorTrainer):
                 )
             warnings.warn(
                 "Passing a string for `density_estimator` is deprecated. "
-                "Use MixedDensityEstimatorBuilder(...) instead.",
+                "Use MixedDensityEstimatorBuilder(...) instead, e.g. "
+                "`from sbi.neural_nets import MixedDensityEstimatorBuilder`.",
                 FutureWarning,
                 stacklevel=2,
             )
             density_estimator = likelihood_nn(model="mnle")
-        elif isinstance(density_estimator, _EstimatorBuilderBase):
+        elif isinstance(density_estimator, _EstimatorBuilderBase):  # noqa: SIM102
             if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
                 raise TypeError(
                     "MNLE requires a MixedDensityEstimatorBuilder; got "

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -93,7 +93,8 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
         elif isinstance(density_estimator, str):
             warnings.warn(
                 "Passing a string for `density_estimator` is deprecated. "
-                "Use DensityEstimatorBuilder(model=...) instead.",
+                "Use DensityEstimatorBuilder(model=...) instead, e.g. "
+                "`from sbi.neural_nets import DensityEstimatorBuilder`.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -125,14 +125,13 @@ class MNPE(NPE_C):
                 stacklevel=2,
             )
             density_estimator = posterior_nn(model="mnpe")
-        elif isinstance(density_estimator, _EstimatorBuilderBase) and not isinstance(
-            density_estimator, MixedDensityEstimatorBuilder
-        ):
-            raise TypeError(
-                "MNPE requires a MixedDensityEstimatorBuilder; got "
-                f"{type(density_estimator).__name__}. Use "
-                "MixedDensityEstimatorBuilder(continuous_model=...)."
-            )
+        elif isinstance(density_estimator, _EstimatorBuilderBase):
+            if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
+                raise TypeError(
+                    "MNPE requires a MixedDensityEstimatorBuilder; got "
+                    f"{type(density_estimator).__name__}. Use "
+                    "MixedDensityEstimatorBuilder(continuous_model=...)."
+                )
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
 

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -120,12 +120,13 @@ class MNPE(NPE_C):
                 )
             warnings.warn(
                 "Passing a string for `density_estimator` is deprecated. "
-                "Use MixedDensityEstimatorBuilder(...) instead.",
+                "Use MixedDensityEstimatorBuilder(...) instead, e.g. "
+                "`from sbi.neural_nets import MixedDensityEstimatorBuilder`.",
                 FutureWarning,
                 stacklevel=2,
             )
             density_estimator = posterior_nn(model="mnpe")
-        elif isinstance(density_estimator, _EstimatorBuilderBase):
+        elif isinstance(density_estimator, _EstimatorBuilderBase):  # noqa: SIM102
             if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
                 raise TypeError(
                     "MNPE requires a MixedDensityEstimatorBuilder; got "

--- a/sbi/inference/trainers/npe/mnpe.py
+++ b/sbi/inference/trainers/npe/mnpe.py
@@ -126,13 +126,14 @@ class MNPE(NPE_C):
                 stacklevel=2,
             )
             density_estimator = posterior_nn(model="mnpe")
-        elif isinstance(density_estimator, _EstimatorBuilderBase):  # noqa: SIM102
-            if not isinstance(density_estimator, MixedDensityEstimatorBuilder):
-                raise TypeError(
-                    "MNPE requires a MixedDensityEstimatorBuilder; got "
-                    f"{type(density_estimator).__name__}. Use "
-                    "MixedDensityEstimatorBuilder(continuous_model=...)."
-                )
+        elif isinstance(density_estimator, _EstimatorBuilderBase) and not isinstance(
+            density_estimator, MixedDensityEstimatorBuilder
+        ):
+            raise TypeError(
+                "MNPE requires a MixedDensityEstimatorBuilder; got "
+                f"{type(density_estimator).__name__}. Use "
+                "MixedDensityEstimatorBuilder(continuous_model=...)."
+            )
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
 

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -118,7 +118,8 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         elif isinstance(density_estimator, str):
             warnings.warn(
                 "Passing a string for `density_estimator` is deprecated. "
-                "Use DensityEstimatorBuilder(model=...) instead.",
+                "Use DensityEstimatorBuilder(model=...) instead, e.g. "
+                "`from sbi.neural_nets import DensityEstimatorBuilder`.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -84,11 +84,13 @@ class BNRE(NRE_A):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
-                default settings. A `RatioEstimatorBuilder` can be passed to configure 
-                the classifier. If it is a string (deprecated), use a pre-configured 
-                network of the provided type (one of linear, mlp, resnet). Alternatively, 
-                a function that builds a custom neural network can be provided.
+            classifier: If `None` (default), uses a
+                `RatioEstimatorBuilder` with default settings. A
+                `RatioEstimatorBuilder` can be passed to configure
+                the classifier. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that
+                builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -84,9 +84,10 @@ class BNRE(NRE_A):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a
-                `RatioEstimatorBuilder` with default settings. A
-                `RatioEstimatorBuilder` can be passed to configure
+            classifier: The classifier used to approximate the
+                likelihood-to-evidence ratio. If ``None`` (default), uses a
+                ``RatioEstimatorBuilder`` with default settings. A
+                ``RatioEstimatorBuilder`` can be passed to configure
                 the classifier. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that

--- a/sbi/inference/trainers/nre/bnre.py
+++ b/sbi/inference/trainers/nre/bnre.py
@@ -11,6 +11,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 from sbi.inference.trainers._contracts import LossArgs, LossArgsBNRE
 from sbi.inference.trainers.nre.nre_a import NRE_A
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import RatioEstimatorBuilder
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -65,7 +66,12 @@ class BNRE(NRE_A):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
+        classifier: Union[
+            str,
+            RatioEstimatorBuilder,
+            ConditionalEstimatorBuildFn[RatioEstimator],
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -78,13 +84,11 @@ class BNRE(NRE_A):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: Classifier trained to approximate likelihood ratios. If it is
-                a string, use a pre-configured network of the provided type (one of
-                linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuildFn` protocol. The callable will
-                be called with the first batch of simulations (theta, x), which can thus
-                be used for shape inference and potentially for z-scoring. It returns a
-                `RatioEstimator`.
+            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
+                default settings. A `RatioEstimatorBuilder` can be passed to configure 
+                the classifier. If it is a string (deprecated), use a pre-configured 
+                network of the provided type (one of linear, mlp, resnet). Alternatively, 
+                a function that builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -13,6 +13,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import RatioEstimatorBuilder
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -63,7 +64,12 @@ class NRE_A(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
+        classifier: Union[
+            str,
+            RatioEstimatorBuilder,
+            ConditionalEstimatorBuildFn[RatioEstimator],
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -76,13 +82,11 @@ class NRE_A(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: Classifier trained to approximate likelihood ratios. If it is
-                a string, use a pre-configured network of the provided type (one of
-                linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuildFn` protocol. The callable will
-                be called with the first batch of simulations (theta, x), which can
-                thus be used for shape inference and potentially for z-scoring. It
-                returns a `RatioEstimator`.
+            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
+                default settings. A `RatioEstimatorBuilder` can be passed to configure 
+                the classifier. If it is a string (deprecated), use a pre-configured 
+                network of the provided type (one of linear, mlp, resnet). Alternatively, 
+                a function that builds a custom neural network can be provided.            
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -82,11 +82,13 @@ class NRE_A(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
-                default settings. A `RatioEstimatorBuilder` can be passed to configure 
-                the classifier. If it is a string (deprecated), use a pre-configured 
-                network of the provided type (one of linear, mlp, resnet). Alternatively, 
-                a function that builds a custom neural network can be provided.            
+            classifier: If `None` (default), uses a
+                `RatioEstimatorBuilder` with default settings. A
+                `RatioEstimatorBuilder` can be passed to configure
+                the classifier. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that
+                builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_a.py
+++ b/sbi/inference/trainers/nre/nre_a.py
@@ -82,9 +82,10 @@ class NRE_A(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a
-                `RatioEstimatorBuilder` with default settings. A
-                `RatioEstimatorBuilder` can be passed to configure
+            classifier: The classifier used to approximate the
+                likelihood-to-evidence ratio. If ``None`` (default), uses a
+                ``RatioEstimatorBuilder`` with default settings. A
+                ``RatioEstimatorBuilder`` can be passed to configure
                 the classifier. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -82,11 +82,13 @@ class NRE_B(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
-                default settings. A `RatioEstimatorBuilder` can be passed to configure 
-                the classifier. If it is a string (deprecated), use a pre-configured 
-                network of the provided type (one of linear, mlp, resnet). Alternatively, 
-                a function that builds a custom neural network can be provided.
+            classifier: If `None` (default), uses a
+                `RatioEstimatorBuilder` with default settings. A
+                `RatioEstimatorBuilder` can be passed to configure
+                the classifier. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that
+                builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -82,9 +82,10 @@ class NRE_B(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a
-                `RatioEstimatorBuilder` with default settings. A
-                `RatioEstimatorBuilder` can be passed to configure
+            classifier: The classifier used to approximate the
+                likelihood-to-evidence ratio. If ``None`` (default), uses a
+                ``RatioEstimatorBuilder`` with default settings. A
+                ``RatioEstimatorBuilder`` can be passed to configure
                 the classifier. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that

--- a/sbi/inference/trainers/nre/nre_b.py
+++ b/sbi/inference/trainers/nre/nre_b.py
@@ -13,6 +13,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import RatioEstimatorBuilder
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -63,7 +64,12 @@ class NRE_B(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
+        classifier: Union[
+            str,
+            RatioEstimatorBuilder,
+            ConditionalEstimatorBuildFn[RatioEstimator],
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -76,13 +82,11 @@ class NRE_B(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: Classifier trained to approximate likelihood ratios. If it is
-                a string, use a pre-configured network of the provided type (one of
-                linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuildFn` protocol. The callable will
-                be called with the first batch of simulations (theta, x), which can thus
-                be used for shape inference and potentially for z-scoring. It returns a
-                `RatioEstimator`.
+            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
+                default settings. A `RatioEstimatorBuilder` can be passed to configure 
+                the classifier. If it is a string (deprecated), use a pre-configured 
+                network of the provided type (one of linear, mlp, resnet). Alternatively, 
+                a function that builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -108,7 +108,8 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
         elif isinstance(classifier, str):
             warnings.warn(
                 "Passing a string for `classifier` is deprecated. "
-                "Use RatioEstimatorBuilder(model=...) instead.",
+                "Use RatioEstimatorBuilder(model=...) instead, e.g. "
+                "`from sbi.neural_nets import RatioEstimatorBuilder`.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -79,11 +79,13 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
           (normalizing constant) of the data $x$.
 
         Args:
-            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
-                default settings. A `RatioEstimatorBuilder` can be passed to configure 
-                the classifier. If it is a string (deprecated), use a pre-configured 
-                network of the provided type (one of linear, mlp, resnet). Alternatively, 
-                a function that builds a custom neural network can be provided.
+            classifier: If `None` (default), uses a
+                `RatioEstimatorBuilder` with default settings. A
+                `RatioEstimatorBuilder` can be passed to configure
+                the classifier. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that
+                builds a custom neural network can be provided.
 
         See docstring of `NeuralInference` class for all other arguments.
         """

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -113,15 +113,13 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
                 stacklevel=3,
             )
             self._build_neural_net = classifier_nn(model=classifier)
-        elif isinstance(classifier, _EstimatorBuilderBase) and not isinstance(
-            classifier, RatioEstimatorBuilder
-        ):
-            raise TypeError(
-                "NRE requires a RatioEstimatorBuilder; got "
-                f"{type(classifier).__name__}. Use "
-                "RatioEstimatorBuilder(model=...)."
-            )
         elif isinstance(classifier, _EstimatorBuilderBase):
+            if not isinstance(classifier, RatioEstimatorBuilder):
+                raise TypeError(
+                    "NRE requires a RatioEstimatorBuilder; got "
+                    f"{type(classifier).__name__}. Use "
+                    "RatioEstimatorBuilder(model=...)."
+                )
             self._build_neural_net = self._wrap_builder(classifier)
         else:
             self._build_neural_net = classifier

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -79,9 +79,10 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
           (normalizing constant) of the data $x$.
 
         Args:
-            classifier: If `None` (default), uses a
-                `RatioEstimatorBuilder` with default settings. A
-                `RatioEstimatorBuilder` can be passed to configure
+            classifier: The classifier used to approximate the
+                likelihood-to-evidence ratio. If ``None`` (default), uses a
+                ``RatioEstimatorBuilder`` with default settings. A
+                ``RatioEstimatorBuilder`` can be passed to configure
                 the classifier. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -4,7 +4,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import asdict, replace
-from typing import Any, Dict, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Literal, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, eye, ones
@@ -32,6 +32,10 @@ from sbi.inference.trainers.base import (
 )
 from sbi.neural_nets import classifier_nn
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    RatioEstimatorBuilder,
+    _EstimatorBuilderBase,
+)
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
@@ -45,7 +49,12 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
+        classifier: Union[
+            Literal["linear", "mlp", "resnet"],
+            RatioEstimatorBuilder,
+            ConditionalEstimatorBuildFn[RatioEstimator],
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -70,13 +79,11 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
           (normalizing constant) of the data $x$.
 
         Args:
-            classifier: Classifier trained to approximate likelihood ratios. If it is
-                a string, use a pre-configured network of the provided type (one of
-                linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuildFn` protocol. The callable will
-                be called with the first batch of simulations (theta, x), which can thus
-                be used for shape inference and potentially for z-scoring. It returns a
-                `RatioEstimator`.
+            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
+                default settings. A `RatioEstimatorBuilder` can be passed to configure 
+                the classifier. If it is a string (deprecated), use a pre-configured 
+                network of the provided type (one of linear, mlp, resnet). Alternatively, 
+                a function that builds a custom neural network can be provided.
 
         See docstring of `NeuralInference` class for all other arguments.
         """
@@ -90,14 +97,30 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             show_progress_bars=show_progress_bars,
         )
 
-        # As detailed in the docstring, `density_estimator` is either a string or
-        # a callable. The function creating the neural network is attached to
-        # `_build_neural_net`. It will be called in the first round and receive
-        # thetas and xs as inputs, so that they can be used for shape inference and
-        # potentially for z-scoring.
-        check_estimator_arg(classifier)
-        if isinstance(classifier, str):
+        if classifier is not None:
+            check_estimator_arg(classifier)
+        if classifier is None:
+            self._build_neural_net = self._wrap_builder(
+                RatioEstimatorBuilder(model="resnet")
+            )
+        elif isinstance(classifier, str):
+            warnings.warn(
+                "Passing a string for `classifier` is deprecated. "
+                "Use RatioEstimatorBuilder(model=...) instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
             self._build_neural_net = classifier_nn(model=classifier)
+        elif isinstance(classifier, _EstimatorBuilderBase) and not isinstance(
+            classifier, RatioEstimatorBuilder
+        ):
+            raise TypeError(
+                "NRE requires a RatioEstimatorBuilder; got "
+                f"{type(classifier).__name__}. Use "
+                "RatioEstimatorBuilder(model=...)."
+            )
+        elif isinstance(classifier, _EstimatorBuilderBase):
+            self._build_neural_net = self._wrap_builder(classifier)
         else:
             self._build_neural_net = classifier
 
@@ -464,6 +487,22 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             )
 
             del x, theta
+
+    @staticmethod
+    def _wrap_builder(
+        builder: _EstimatorBuilderBase,
+    ) -> Callable:
+        """Wrap a builder object as a legacy-compatible build function.
+
+        This allows the existing ``_initialize_neural_network`` flow to work
+        unchanged: the returned callable has the same ``(batch_theta, batch_x)``
+        signature as the functions produced by ``classifier_nn``.
+        """
+
+        def build_fn(batch_theta, batch_x):
+            return builder.build(batch_input=batch_theta, batch_condition=batch_x)
+
+        return build_fn
 
     def _get_losses(self, batch: Sequence[Tensor], loss_args: LossArgs) -> Tensor:
         """

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -13,6 +13,7 @@ from sbi.inference.trainers.nre.nre_base import (
     RatioEstimatorTrainer,
 )
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import RatioEstimatorBuilder
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.sbi_types import Tracker
 from sbi.utils.sbiutils import del_entries
@@ -60,7 +61,12 @@ class NRE_C(RatioEstimatorTrainer):
     def __init__(
         self,
         prior: Optional[Distribution] = None,
-        classifier: Union[str, ConditionalEstimatorBuildFn[RatioEstimator]] = "resnet",
+        classifier: Union[
+            str,
+            RatioEstimatorBuilder,
+            ConditionalEstimatorBuildFn[RatioEstimator],
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -73,13 +79,11 @@ class NRE_C(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: Classifier trained to approximate likelihood ratios. If it is
-                a string, use a pre-configured network of the provided type (one of
-                linear, mlp, resnet), or a callable that implements the
-                `ConditionalEstimatorBuildFn` protocol. The callable will
-                be called with the first batch of simulations (theta, x), which can thus
-                be used for shape inference and potentially for z-scoring. It returns a
-                `RatioEstimator`.
+            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
+                default settings. A `RatioEstimatorBuilder` can be passed to configure 
+                the classifier. If it is a string (deprecated), use a pre-configured 
+                network of the provided type (one of linear, mlp, resnet). Alternatively, 
+                a function that builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -79,11 +79,13 @@ class NRE_C(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a `RatioEstimatorBuilder` with 
-                default settings. A `RatioEstimatorBuilder` can be passed to configure 
-                the classifier. If it is a string (deprecated), use a pre-configured 
-                network of the provided type (one of linear, mlp, resnet). Alternatively, 
-                a function that builds a custom neural network can be provided.
+            classifier: If `None` (default), uses a
+                `RatioEstimatorBuilder` with default settings. A
+                `RatioEstimatorBuilder` can be passed to configure
+                the classifier. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that
+                builds a custom neural network can be provided.
             device: Training device, e.g., "cpu", "cuda" or "cuda:{0, 1, ...}".
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/trainers/nre/nre_c.py
+++ b/sbi/inference/trainers/nre/nre_c.py
@@ -79,9 +79,10 @@ class NRE_C(RatioEstimatorTrainer):
             prior: A probability distribution that expresses prior knowledge about the
                 parameters, e.g. which ranges are meaningful for them. If `None`, the
                 prior must be passed to `.build_posterior()`.
-            classifier: If `None` (default), uses a
-                `RatioEstimatorBuilder` with default settings. A
-                `RatioEstimatorBuilder` can be passed to configure
+            classifier: The classifier used to approximate the
+                likelihood-to-evidence ratio. If ``None`` (default), uses a
+                ``RatioEstimatorBuilder`` with default settings. A
+                ``RatioEstimatorBuilder`` can be passed to configure
                 the classifier. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that

--- a/sbi/neural_nets/__init__.py
+++ b/sbi/neural_nets/__init__.py
@@ -9,6 +9,11 @@ from sbi.neural_nets.factory import (
     posterior_nn,
     posterior_score_nn,
 )
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+    MixedDensityEstimatorBuilder,
+    RatioEstimatorBuilder,
+)
 
 
 def __getattr__(name):
@@ -55,4 +60,7 @@ __all__ = [
     "posterior_nn",
     "posterior_score_nn",
     "posterior_flow_nn",
+    "DensityEstimatorBuilder",
+    "MixedDensityEstimatorBuilder",
+    "RatioEstimatorBuilder",
 ]

--- a/sbi/neural_nets/net_builders/__init__.py
+++ b/sbi/neural_nets/net_builders/__init__.py
@@ -7,7 +7,11 @@ from sbi.neural_nets.net_builders.classifier import (
     build_mlp_classifier,
     build_resnet_classifier,
 )
-from sbi.neural_nets.net_builders.estimator_configs import DensityEstimatorBuilder
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+    MixedDensityEstimatorBuilder,
+    RatioEstimatorBuilder,
+)
 from sbi.neural_nets.net_builders.flow import (
     build_made,
     build_maf,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -492,6 +492,7 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
 
+
 _MIXED_ALWAYS_OK: frozenset = frozenset({
     "num_categories_per_variable",
     "embedding_net",
@@ -584,6 +585,7 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
             **kwargs,
         )
 
+
 CLASSIFIER_MODELS = Literal["linear", "mlp", "resnet"]
 
 _VALID_CLASSIFIER_MODELS = frozenset(get_args(CLASSIFIER_MODELS))
@@ -643,4 +645,3 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
         build_fn = _classifier_build_fns()[self.model]
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
-

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -106,7 +106,6 @@ class _EstimatorBuilderBase:
                 parts.append(f"{f.name}={val!r}")
         return f"{cls.__name__}({', '.join(parts)})"
 
-
     @staticmethod
     @lru_cache(maxsize=None)
     def _fn_param_names(build_fn) -> frozenset:
@@ -531,7 +530,8 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
 
     Sibling of ``DensityEstimatorBuilder`` with a field set tailored to
     mixed-type data.  The continuous-component model is selected via
-    ``continuous_model``; there is no ``model`` field.
+    ``continuous_model`` (density-estimator model for the continuous
+    variables); there is no ``model`` field.
     """
 
     continuous_model: str = "nsf"

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -106,6 +106,23 @@ class _EstimatorBuilderBase:
                 parts.append(f"{f.name}={val!r}")
         return f"{cls.__name__}({', '.join(parts)})"
 
+    def _build_kwargs(self) -> dict:
+        """Non-None fields as builder kwargs, alias-translated, minus discriminators.
+
+        Field names are translated via ``_BUILD_KWARG_ALIASES`` so that
+        user-facing names (e.g. ``z_score_input``) map to the legacy
+        kwarg names (``z_score_x``) expected by ``build_*`` functions.
+        """
+        d = {
+            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in self._DISCRIMINATORS
+            and f.name != "extra_kwargs"
+            and getattr(self, f.name) is not None
+        }
+        d.update(self.extra_kwargs)
+        return d
+
     @staticmethod
     @lru_cache(maxsize=None)
     def _fn_param_names(build_fn) -> frozenset:
@@ -475,41 +492,6 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
 
-    def _build_kwargs(self) -> dict:
-        """Return non-None fields as a dict, excluding ``model``.
-
-        Field names are translated via ``_BUILD_KWARG_ALIASES`` so that
-        user-facing names (e.g. ``z_score_input``) map to the legacy
-        kwarg names (``z_score_x``) expected by ``build_*`` functions.
-        """
-        d = {
-            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
-            for f in fields(self)
-            if f.name not in ("model", "extra_kwargs")
-            and getattr(self, f.name) is not None
-        }
-        d.update(self.extra_kwargs)
-        return d
-
-
-_VALID_MIXED_CONTINUOUS_MODELS = frozenset({
-    "mdn",
-    "made",
-    "maf",
-    "maf_rqs",
-    "nsf",
-    "zuko_nice",
-    "zuko_maf",
-    "zuko_nsf",
-    "zuko_ncsf",
-    "zuko_sospf",
-    "zuko_naf",
-    "zuko_unaf",
-    "zuko_gf",
-    "zuko_bpf",
-})
-
-
 _MIXED_ALWAYS_OK: frozenset = frozenset({
     "num_categories_per_variable",
     "embedding_net",
@@ -535,7 +517,7 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     variables); there is no ``model`` field.
     """
 
-    continuous_model: str = "nsf"
+    continuous_model: DENSITY_MODELS = "nsf"  # type: ignore[valid-type]
 
     # --- Mixed-specific ---
     num_categories_per_variable: Optional[Tensor] = None
@@ -561,10 +543,10 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     z_score_condition: Optional[Literal["none", "independent", "structured"]] = None
 
     def __post_init__(self):
-        if self.continuous_model not in _VALID_MIXED_CONTINUOUS_MODELS:
+        if self.continuous_model not in _VALID_DENSITY_MODELS:
             raise ValueError(
                 f"Unknown continuous_model {self.continuous_model!r}. "
-                f"Must be one of {sorted(_VALID_MIXED_CONTINUOUS_MODELS)}."
+                f"Must be one of {sorted(_VALID_DENSITY_MODELS)}."
             )
         super().__post_init__()
         from sbi.neural_nets.net_builders.mixed_nets import model_builders
@@ -601,18 +583,6 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
             flow_model=self.continuous_model,
             **kwargs,
         )
-
-    def _build_kwargs(self) -> dict:
-        """Return non-None fields as a dict, excluding ``continuous_model``."""
-        d = {
-            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
-            for f in fields(self)
-            if f.name not in ("continuous_model", "extra_kwargs")
-            and getattr(self, f.name) is not None
-        }
-        d.update(self.extra_kwargs)
-        return d
-
 
 CLASSIFIER_MODELS = Literal["linear", "mlp", "resnet"]
 
@@ -674,13 +644,3 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
 
-    def _build_kwargs(self) -> dict:
-        """Return non-None fields as a dict, excluding ``model``."""
-        d = {
-            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
-            for f in fields(self)
-            if f.name not in ("model", "extra_kwargs")
-            and getattr(self, f.name) is not None
-        }
-        d.update(self.extra_kwargs)
-        return d

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -519,6 +519,7 @@ _MIXED_ALWAYS_OK: frozenset = frozenset({
     "discrete_hidden_features",
     "discrete_hidden_layers",
     "continuous_hidden_features",
+    "dropout_probability",
     "z_score_input",
     "z_score_condition",
 })

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -20,9 +20,22 @@ intentionally forward ``None`` to override a non-None builder default (e.g.
 preserving typed field annotations.
 """
 
-from dataclasses import dataclass, fields
-from typing import Any, Callable, Literal, Optional, Sequence, Union, get_args
+import inspect
+from dataclasses import MISSING, dataclass, field, fields
+from functools import lru_cache
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+    get_args,
+    get_origin,
+)
 
+import torch.nn as nn
 from torch import Tensor
 
 from sbi.neural_nets.estimators.base import (
@@ -32,17 +45,117 @@ from sbi.neural_nets.estimators.base import (
 from sbi.neural_nets.estimators.mixed_density_estimator import MixedDensityEstimator
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 
+_BUILD_KWARG_ALIASES: dict = {
+    "z_score_input": "z_score_x",
+    "z_score_condition": "z_score_y",
+}
+"""Maps user-facing field names to the legacy kwarg names expected by the
+downstream ``build_*`` functions."""
 
-@dataclass
+
+def _literal_values(tp) -> frozenset:
+    """Extract allowed values from a (possibly nested) ``Literal`` type.
+    Unwraps ``Optional[Literal[...]]`` and ``Union[Literal[...], ...]``
+    recursively.
+    """
+    if get_origin(tp) is Literal:
+        return frozenset(get_args(tp))
+    out: frozenset = frozenset()
+    for a in get_args(tp):
+        out = out | _literal_values(a)
+    return out
+
+
+@dataclass(frozen=True, eq=False, repr=False)
 class _EstimatorBuilderBase:
     """Shared base providing ``from_kwargs()``, ``to_dict()``, and the abstract
     ``build()`` contract for all estimator builders."""
 
-    extra_kwargs: dict = None  # type: ignore
+    extra_kwargs: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        if self.extra_kwargs is None:
-            self.extra_kwargs = {}
+        for f in fields(self):
+            allowed = _literal_values(f.type)
+            val = getattr(self, f.name)
+            if allowed and val is not None and val not in allowed:
+                raise ValueError(
+                    f"Invalid value {val!r} for `{f.name}`. "
+                    f"Must be one of {sorted(map(str, allowed))} or None."
+                )
+
+    _DISCRIMINATORS: ClassVar[frozenset] = frozenset({
+        "model",
+        "continuous_model",
+        "estimator_type",
+    })
+
+    def __repr__(self) -> str:
+        cls = type(self)
+        parts: list[str] = []
+        for f in fields(self):
+            val = getattr(self, f.name)
+            if f.name == "extra_kwargs":
+                if val:
+                    parts.append(f"extra_kwargs={val!r}")
+                continue
+            if f.name in self._DISCRIMINATORS:
+                parts.append(f"{f.name}={val!r}")
+            elif f.default is not MISSING and val is f.default:
+                continue
+            elif val is not None:
+                parts.append(f"{f.name}={val!r}")
+        return f"{cls.__name__}({', '.join(parts)})"
+
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _fn_param_names(build_fn) -> frozenset:
+        """Return the set of explicit parameter names for *build_fn*,
+        excluding ``batch_x``, ``batch_y`` and ``**kwargs``."""
+        return frozenset(
+            p.name
+            for p in inspect.signature(build_fn).parameters.values()
+            if p.kind is not inspect.Parameter.VAR_KEYWORD
+            and p.name not in ("batch_x", "batch_y")
+        )
+
+    def _reject_inapplicable_fields(
+        self,
+        build_fn,
+        *,
+        discriminator: str,
+        always_ok: frozenset = frozenset(),
+    ) -> None:
+        """Raise ``ValueError`` if any non-None field would be silently
+        ignored by *build_fn*.
+
+        Args:
+            build_fn: The downstream builder function whose signature
+                defines the set of accepted parameter names.
+            discriminator: Name of the field that selects which build
+                function is used (e.g. ``"model"``).
+            always_ok: Additional field names that are always
+                acceptable regardless of *build_fn*'s signature.
+        """
+        allowed = self._fn_param_names(build_fn) | always_ok
+        set_fields = {
+            f.name
+            for f in fields(self)
+            if f.name not in ("extra_kwargs", discriminator)
+            and getattr(self, f.name) is not None
+        }
+        bad = {
+            n
+            for n in set_fields
+            if n not in allowed and _BUILD_KWARG_ALIASES.get(n, n) not in allowed
+        }
+        if bad:
+            raise ValueError(
+                f"Field(s) {sorted(bad)} are not used by "
+                f"{discriminator}={getattr(self, discriminator)!r} and would "
+                "be silently ignored. To forward library-specific options, "
+                "use `extra_kwargs`."
+            )
 
     @classmethod
     def from_kwargs(cls, **kwargs) -> "_EstimatorBuilderBase":
@@ -109,7 +222,7 @@ class _EstimatorBuilderBase:
         return d
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class ConditionalFlowConfig(_EstimatorBuilderBase):
     """Configuration for conditional normalizing-flow density estimator builders.
 
@@ -169,7 +282,7 @@ class ConditionalFlowConfig(_EstimatorBuilderBase):
     dtype: Optional[Any] = None
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class ClassifierConfig(_EstimatorBuilderBase):
     """Configuration for classifier builders (NRE).
 
@@ -189,7 +302,7 @@ class ClassifierConfig(_EstimatorBuilderBase):
     use_batch_norm: Optional[bool] = None
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class MarginalFlowConfig(_EstimatorBuilderBase):
     """Configuration for marginal density estimator builders.
 
@@ -212,6 +325,58 @@ class MarginalFlowConfig(_EstimatorBuilderBase):
     components: Optional[int] = None  # zuko_gf
 
 
+def _density_build_fns() -> dict:
+    """Build-function mapping for density estimators."""
+    from sbi.neural_nets.net_builders.flow import (
+        build_made,
+        build_maf,
+        build_maf_rqs,
+        build_nsf,
+        build_zuko_bpf,
+        build_zuko_gf,
+        build_zuko_maf,
+        build_zuko_naf,
+        build_zuko_ncsf,
+        build_zuko_nice,
+        build_zuko_nsf,
+        build_zuko_sospf,
+        build_zuko_unaf,
+    )
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+
+    return {
+        "mdn": build_mdn,
+        "made": build_made,
+        "maf": build_maf,
+        "maf_rqs": build_maf_rqs,
+        "nsf": build_nsf,
+        "zuko_nice": build_zuko_nice,
+        "zuko_maf": build_zuko_maf,
+        "zuko_nsf": build_zuko_nsf,
+        "zuko_ncsf": build_zuko_ncsf,
+        "zuko_sospf": build_zuko_sospf,
+        "zuko_naf": build_zuko_naf,
+        "zuko_unaf": build_zuko_unaf,
+        "zuko_gf": build_zuko_gf,
+        "zuko_bpf": build_zuko_bpf,
+    }
+
+
+def _classifier_build_fns() -> dict:
+    """Build-function mapping for ratio estimators."""
+    from sbi.neural_nets.net_builders.classifier import (
+        build_linear_classifier,
+        build_mlp_classifier,
+        build_resnet_classifier,
+    )
+
+    return {
+        "linear": build_linear_classifier,
+        "mlp": build_mlp_classifier,
+        "resnet": build_resnet_classifier,
+    }
+
+
 DENSITY_MODELS = Literal[
     "mdn",
     "made",
@@ -232,7 +397,7 @@ DENSITY_MODELS = Literal[
 _VALID_DENSITY_MODELS = frozenset(get_args(DENSITY_MODELS))
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class DensityEstimatorBuilder(_EstimatorBuilderBase):
     """Builder for continuous density estimators (NPE / NLE).
 
@@ -245,16 +410,16 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
     model: DENSITY_MODELS = "maf"  # type: ignore[valid-type]
 
     # --- Shared across most builders ---
-    z_score_x: Optional[
+    z_score_input: Optional[
         Literal["none", "independent", "structured", "transform_to_unconstrained"]
     ] = None
-    z_score_y: Optional[
+    z_score_condition: Optional[
         Literal["none", "independent", "structured", "transform_to_unconstrained"]
     ] = None
     hidden_features: Optional[Union[int, Sequence[int]]] = None
     num_transforms: Optional[int] = None
     num_bins: Optional[int] = None
-    embedding_net: Optional[Any] = None
+    embedding_net: Optional[nn.Module] = None
     num_components: Optional[int] = None
 
     # --- NFlows-specific (MAF, NSF, MAF-RQS) ---
@@ -280,12 +445,16 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
     components: Optional[int] = None  # zuko_gf
 
     def __post_init__(self):
-        super().__post_init__()
         if self.model not in _VALID_DENSITY_MODELS:
             raise ValueError(
                 f"Unknown model {self.model!r}. "
                 f"Must be one of {sorted(_VALID_DENSITY_MODELS)}."
             )
+        super().__post_init__()
+        self._reject_inapplicable_fields(
+            _density_build_fns()[self.model],
+            discriminator="model",
+        )
 
     def build(
         self, batch_input: Tensor, batch_condition: Tensor
@@ -303,48 +472,19 @@ class DensityEstimatorBuilder(_EstimatorBuilderBase):
             A ``ConditionalDensityEstimator`` (e.g., ``NFlowsFlow``,
             ``ZukoFlow``, or MDN).
         """
-        from sbi.neural_nets.net_builders.flow import (
-            build_made,
-            build_maf,
-            build_maf_rqs,
-            build_nsf,
-            build_zuko_bpf,
-            build_zuko_gf,
-            build_zuko_maf,
-            build_zuko_naf,
-            build_zuko_ncsf,
-            build_zuko_nice,
-            build_zuko_nsf,
-            build_zuko_sospf,
-            build_zuko_unaf,
-        )
-        from sbi.neural_nets.net_builders.mdn import build_mdn
-
-        builders = {
-            "mdn": build_mdn,
-            "made": build_made,
-            "maf": build_maf,
-            "maf_rqs": build_maf_rqs,
-            "nsf": build_nsf,
-            "zuko_nice": build_zuko_nice,
-            "zuko_maf": build_zuko_maf,
-            "zuko_nsf": build_zuko_nsf,
-            "zuko_ncsf": build_zuko_ncsf,
-            "zuko_sospf": build_zuko_sospf,
-            "zuko_naf": build_zuko_naf,
-            "zuko_unaf": build_zuko_unaf,
-            "zuko_gf": build_zuko_gf,
-            "zuko_bpf": build_zuko_bpf,
-        }
-
-        build_fn = builders[self.model]
+        build_fn = _density_build_fns()[self.model]
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
 
     def _build_kwargs(self) -> dict:
-        """Return non-None fields as a dict, excluding ``model``."""
+        """Return non-None fields as a dict, excluding ``model``.
+
+        Field names are translated via ``_BUILD_KWARG_ALIASES`` so that
+        user-facing names (e.g. ``z_score_input``) map to the legacy
+        kwarg names (``z_score_x``) expected by ``build_*`` functions.
+        """
         d = {
-            f.name: getattr(self, f.name)
+            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
             for f in fields(self)
             if f.name not in ("model", "extra_kwargs")
             and getattr(self, f.name) is not None
@@ -371,7 +511,21 @@ _VALID_MIXED_CONTINUOUS_MODELS = frozenset({
 })
 
 
-@dataclass
+_MIXED_ALWAYS_OK: frozenset = frozenset({
+    "num_categories_per_variable",
+    "embedding_net",
+    "combined_embedding_net",
+    "log_transform_x",
+    "hidden_features",
+    "discrete_hidden_features",
+    "discrete_hidden_layers",
+    "continuous_hidden_features",
+    "z_score_input",
+    "z_score_condition",
+})
+
+
+@dataclass(frozen=True, eq=False, repr=False)
 class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     """Builder for mixed (continuous + discrete) density estimators (MNLE / MNPE).
 
@@ -383,9 +537,9 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     continuous_model: str = "nsf"
 
     # --- Mixed-specific ---
-    num_categories_per_variable: Optional[Any] = None
-    embedding_net: Optional[Any] = None
-    combined_embedding_net: Optional[Any] = None
+    num_categories_per_variable: Optional[Tensor] = None
+    embedding_net: Optional[nn.Module] = None
+    combined_embedding_net: Optional[nn.Module] = None
     log_transform_x: bool = False
 
     # --- Shared sizing ---
@@ -402,16 +556,23 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     dropout_probability: Optional[float] = None
 
     # --- Z-scoring ---
-    z_score_x: Optional[Literal["none", "independent", "structured"]] = None
-    z_score_y: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_input: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_condition: Optional[Literal["none", "independent", "structured"]] = None
 
     def __post_init__(self):
-        super().__post_init__()
         if self.continuous_model not in _VALID_MIXED_CONTINUOUS_MODELS:
             raise ValueError(
                 f"Unknown continuous_model {self.continuous_model!r}. "
                 f"Must be one of {sorted(_VALID_MIXED_CONTINUOUS_MODELS)}."
             )
+        super().__post_init__()
+        from sbi.neural_nets.net_builders.mixed_nets import model_builders
+
+        self._reject_inapplicable_fields(
+            model_builders[self.continuous_model],
+            discriminator="continuous_model",
+            always_ok=_MIXED_ALWAYS_OK,
+        )
 
     def build(
         self, batch_input: Tensor, batch_condition: Tensor
@@ -443,7 +604,7 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
     def _build_kwargs(self) -> dict:
         """Return non-None fields as a dict, excluding ``continuous_model``."""
         d = {
-            f.name: getattr(self, f.name)
+            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
             for f in fields(self)
             if f.name not in ("continuous_model", "extra_kwargs")
             and getattr(self, f.name) is not None
@@ -457,7 +618,7 @@ CLASSIFIER_MODELS = Literal["linear", "mlp", "resnet"]
 _VALID_CLASSIFIER_MODELS = frozenset(get_args(CLASSIFIER_MODELS))
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class RatioEstimatorBuilder(_EstimatorBuilderBase):
     """Builder for ratio estimators / classifiers (NRE).
 
@@ -469,11 +630,11 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
     model: CLASSIFIER_MODELS = "resnet"  # type: ignore[valid-type]
 
     # --- Shared across classifiers ---
-    z_score_x: Optional[Literal["none", "independent", "structured"]] = None
-    z_score_y: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_input: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_condition: Optional[Literal["none", "independent", "structured"]] = None
     hidden_features: Optional[int] = None
-    embedding_net_x: Optional[Any] = None
-    embedding_net_y: Optional[Any] = None
+    embedding_net_x: Optional[nn.Module] = None
+    embedding_net_y: Optional[nn.Module] = None
 
     # --- ResNet-specific ---
     num_blocks: Optional[int] = None
@@ -481,15 +642,19 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
     use_batch_norm: Optional[bool] = None
 
     # --- MLP-specific ---
-    norm_layer: Optional[Callable] = None
+    norm_layer: Optional[Callable[[int], nn.Module]] = None
 
     def __post_init__(self):
-        super().__post_init__()
         if self.model not in _VALID_CLASSIFIER_MODELS:
             raise ValueError(
                 f"Unknown model {self.model!r}. "
                 f"Must be one of {sorted(_VALID_CLASSIFIER_MODELS)}."
             )
+        super().__post_init__()
+        self._reject_inapplicable_fields(
+            _classifier_build_fns()[self.model],
+            discriminator="model",
+        )
 
     def build(self, batch_input: Tensor, batch_condition: Tensor) -> RatioEstimator:
         """Build the classifier by dispatching to the appropriate
@@ -504,26 +669,14 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
         Returns:
             A ``RatioEstimator``.
         """
-        from sbi.neural_nets.net_builders.classifier import (
-            build_linear_classifier,
-            build_mlp_classifier,
-            build_resnet_classifier,
-        )
-
-        builders = {
-            "linear": build_linear_classifier,
-            "mlp": build_mlp_classifier,
-            "resnet": build_resnet_classifier,
-        }
-
-        build_fn = builders[self.model]
+        build_fn = _classifier_build_fns()[self.model]
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
 
     def _build_kwargs(self) -> dict:
         """Return non-None fields as a dict, excluding ``model``."""
         d = {
-            f.name: getattr(self, f.name)
+            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
             for f in fields(self)
             if f.name not in ("model", "extra_kwargs")
             and getattr(self, f.name) is not None

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -21,7 +21,7 @@ preserving typed field annotations.
 """
 
 from dataclasses import dataclass, fields
-from typing import Any, Literal, Optional, Sequence, Union, get_args
+from typing import Any, Callable, Literal, Optional, Sequence, Union, get_args
 
 from torch import Tensor
 
@@ -30,6 +30,7 @@ from sbi.neural_nets.estimators.base import (
     ConditionalEstimator,
 )
 from sbi.neural_nets.estimators.mixed_density_estimator import MixedDensityEstimator
+from sbi.neural_nets.ratio_estimators import RatioEstimator
 
 
 @dataclass
@@ -445,6 +446,86 @@ class MixedDensityEstimatorBuilder(_EstimatorBuilderBase):
             f.name: getattr(self, f.name)
             for f in fields(self)
             if f.name not in ("continuous_model", "extra_kwargs")
+            and getattr(self, f.name) is not None
+        }
+        d.update(self.extra_kwargs)
+        return d
+
+
+CLASSIFIER_MODELS = Literal["linear", "mlp", "resnet"]
+
+_VALID_CLASSIFIER_MODELS = frozenset(get_args(CLASSIFIER_MODELS))
+
+
+@dataclass
+class RatioEstimatorBuilder(_EstimatorBuilderBase):
+    """Builder for ratio estimators / classifiers (NRE).
+
+    Covers linear, MLP, and ResNet classifiers used by ``NRE_A``, ``NRE_B``,
+    ``NRE_C``, and ``BNRE``.  Fields mirror the parameters of the underlying
+    ``build_*_classifier`` functions.
+    """
+
+    model: CLASSIFIER_MODELS = "resnet"  # type: ignore[valid-type]
+
+    # --- Shared across classifiers ---
+    z_score_x: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_y: Optional[Literal["none", "independent", "structured"]] = None
+    hidden_features: Optional[int] = None
+    embedding_net_x: Optional[Any] = None
+    embedding_net_y: Optional[Any] = None
+
+    # --- ResNet-specific ---
+    num_blocks: Optional[int] = None
+    dropout_probability: Optional[float] = None
+    use_batch_norm: Optional[bool] = None
+
+    # --- MLP-specific ---
+    norm_layer: Optional[Callable] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.model not in _VALID_CLASSIFIER_MODELS:
+            raise ValueError(
+                f"Unknown model {self.model!r}. "
+                f"Must be one of {sorted(_VALID_CLASSIFIER_MODELS)}."
+            )
+
+    def build(self, batch_input: Tensor, batch_condition: Tensor) -> RatioEstimator:
+        """Build the classifier by dispatching to the appropriate
+        ``build_*_classifier`` function.
+
+        Args:
+            batch_input: Batch of the modeled variable used for
+                shape inference and z-scoring.
+            batch_condition: Batch of the conditioning variable
+                used for shape inference and z-scoring.
+
+        Returns:
+            A ``RatioEstimator``.
+        """
+        from sbi.neural_nets.net_builders.classifier import (
+            build_linear_classifier,
+            build_mlp_classifier,
+            build_resnet_classifier,
+        )
+
+        builders = {
+            "linear": build_linear_classifier,
+            "mlp": build_mlp_classifier,
+            "resnet": build_resnet_classifier,
+        }
+
+        build_fn = builders[self.model]
+        kwargs = self._build_kwargs()
+        return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
+
+    def _build_kwargs(self) -> dict:
+        """Return non-None fields as a dict, excluding ``model``."""
+        d = {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in ("model", "extra_kwargs")
             and getattr(self, f.name) is not None
         }
         d.update(self.extra_kwargs)

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -28,7 +28,7 @@ from sbi.utils.user_input_checks import check_data_device
 from sbi.utils.vector_field_utils import VectorFieldNet
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class _VectorFieldBaseConfig(_EstimatorBuilderBase):
     """Shared configuration fields for all vector field estimator builders.
 
@@ -68,7 +68,7 @@ class _VectorFieldBaseConfig(_EstimatorBuilderBase):
     time_emb_type: Optional[str] = None
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class ScoreEstimatorConfig(_VectorFieldBaseConfig):
     """Configuration for score-matching estimator builders (NPSE).
 
@@ -95,7 +95,7 @@ class ScoreEstimatorConfig(_VectorFieldBaseConfig):
     # config construction and are not forwarded through the config.
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class FlowEstimatorConfig(_VectorFieldBaseConfig):
     """Configuration for flow-matching estimator builders (FMPE).
 

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -98,17 +98,20 @@ def test_density_estimator_builder_loss_computable(model):
 
 
 @pytest.mark.parametrize(
-    "z_score_x, z_score_y",
+    "z_score_input, z_score_condition",
     [
         ("none", "none"),
         ("independent", "independent"),
         ("none", "independent"),
     ],
 )
-def test_density_estimator_builder_z_score_modes(z_score_x, z_score_y):
+def test_density_estimator_builder_z_score_modes(z_score_input, z_score_condition):
     """Test that z_score fields are forwarded and the estimator builds successfully."""
     builder = DensityEstimatorBuilder(
-        model="maf", z_score_x=z_score_x, z_score_y=z_score_y, num_transforms=2
+        model="maf",
+        z_score_input=z_score_input,
+        z_score_condition=z_score_condition,
+        num_transforms=2,
     )
     theta = torch.randn(100, 3)
     x = torch.randn(100, 2)

--- a/tests/npe_nle_builder_integration_test.py
+++ b/tests/npe_nle_builder_integration_test.py
@@ -248,13 +248,13 @@ def test_mixed_trainer_rejects_plain_density_builder(trainer_cls):
 
 
 def test_valid_continuous_models_match_builders():
-    """Guard against drift between _VALID_MIXED_CONTINUOUS_MODELS and mixed_nets."""
+    """Guard against drift between _VALID_DENSITY_MODELS and mixed_nets."""
     from sbi.neural_nets.net_builders.estimator_configs import (
-        _VALID_MIXED_CONTINUOUS_MODELS,
+        _VALID_DENSITY_MODELS,
     )
     from sbi.neural_nets.net_builders.mixed_nets import model_builders
 
-    assert frozenset(model_builders) == _VALID_MIXED_CONTINUOUS_MODELS
+    assert frozenset(model_builders) == _VALID_DENSITY_MODELS
 
 
 def test_valid_density_models_match_builders():

--- a/tests/npe_nle_builder_integration_test.py
+++ b/tests/npe_nle_builder_integration_test.py
@@ -255,3 +255,27 @@ def test_valid_continuous_models_match_builders():
     from sbi.neural_nets.net_builders.mixed_nets import model_builders
 
     assert frozenset(model_builders) == _VALID_MIXED_CONTINUOUS_MODELS
+
+
+def test_valid_density_models_match_builders():
+    """Guard against drift between _VALID_DENSITY_MODELS and _density_build_fns."""
+    from sbi.neural_nets.net_builders.estimator_configs import (
+        _VALID_DENSITY_MODELS,
+        _density_build_fns,
+    )
+
+    assert set(_density_build_fns().keys()) == _VALID_DENSITY_MODELS
+
+
+def test_density_z_score_alias():
+    """z_score_input to z_score_x and z_score_condition to z_score_y."""
+    builder = DensityEstimatorBuilder(
+        model="maf",
+        z_score_input="independent",
+        z_score_condition="structured",
+    )
+    kwargs = builder._build_kwargs()
+    assert "z_score_x" in kwargs
+    assert "z_score_y" in kwargs
+    assert "z_score_input" not in kwargs
+    assert "z_score_condition" not in kwargs

--- a/tests/nre_builder_integration_test.py
+++ b/tests/nre_builder_integration_test.py
@@ -76,7 +76,10 @@ def test_train_with_builder(trainer_cls, model):
     """Train with a RatioEstimatorBuilder end-to-end."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    builder = RatioEstimatorBuilder(model=model, hidden_features=16)
+    kwargs = {"model": model}
+    if model != "linear":
+        kwargs["hidden_features"] = 16
+    builder = RatioEstimatorBuilder(**kwargs)
     inference = trainer_cls(prior, classifier=builder, show_progress_bars=False)
 
     theta = prior.sample((200,))
@@ -137,3 +140,98 @@ def test_builder_role_shapes(trainer_cls):
 def test_check_estimator_arg_accepts_valid_inputs(estimator):
     """check_estimator_arg accepts ratio builders, strings, and callables."""
     check_estimator_arg(estimator)
+
+
+def test_literal_field_validation():
+    """Typos in Literal fields should raise ValueError at construction."""
+    with pytest.raises(ValueError, match="Invalid value.*z_score_input"):
+        RatioEstimatorBuilder(z_score_input="typo")
+    with pytest.raises(ValueError, match="Invalid value.*z_score_condition"):
+        RatioEstimatorBuilder(z_score_condition="typo")
+
+
+def test_inapplicable_fields_rejected():
+    """Fields not accepted by the chosen model's build_fn raise ValueError."""
+    # linear doesn't accept hidden_features
+    with pytest.raises(ValueError, match="silently ignored"):
+        RatioEstimatorBuilder(model="linear", hidden_features=64)
+    # linear doesn't accept num_blocks
+    with pytest.raises(ValueError, match="silently ignored"):
+        RatioEstimatorBuilder(model="linear", num_blocks=5)
+    # mlp doesn't accept num_blocks
+    with pytest.raises(ValueError, match="silently ignored"):
+        RatioEstimatorBuilder(model="mlp", num_blocks=5)
+
+
+def test_applicable_fields_accepted():
+    """Fields that ARE accepted by the chosen model should not raise."""
+    # resnet accepts all of these
+    RatioEstimatorBuilder(
+        model="resnet",
+        hidden_features=64,
+        num_blocks=3,
+        dropout_probability=0.1,
+        use_batch_norm=True,
+    )
+    # mlp accepts hidden_features and norm_layer
+    RatioEstimatorBuilder(model="mlp", hidden_features=64)
+
+
+def test_frozen_immutability():
+    """Builder instances should be frozen (immutable)."""
+    builder = RatioEstimatorBuilder(model="resnet")
+    with pytest.raises(AttributeError):
+        builder.model = "mlp"
+    with pytest.raises(AttributeError):
+        builder.hidden_features = 42
+
+
+def test_repr_shows_discriminator_and_set_fields():
+    """__repr__ should show model + only non-default fields."""
+    builder = RatioEstimatorBuilder(model="resnet", hidden_features=64)
+    r = repr(builder)
+    assert "model='resnet'" in r
+    assert "hidden_features=64" in r
+    assert "z_score_input" not in r
+    assert "extra_kwargs" not in r
+
+
+def test_repr_always_shows_discriminator_even_if_default():
+    """Discriminator field should appear even when it equals the default."""
+    builder = RatioEstimatorBuilder()
+    r = repr(builder)
+    assert "model='resnet'" in r
+
+
+def test_sync_classifier_build_fns():
+    """_VALID_CLASSIFIER_MODELS must match _classifier_build_fns() keys."""
+    from sbi.neural_nets.net_builders.estimator_configs import (
+        _VALID_CLASSIFIER_MODELS,
+        _classifier_build_fns,
+    )
+
+    assert set(_classifier_build_fns().keys()) == _VALID_CLASSIFIER_MODELS
+
+
+def test_z_score_alias_in_build_kwargs():
+    """z_score_input → z_score_x and z_score_condition → z_score_y."""
+    builder = RatioEstimatorBuilder(
+        model="resnet",
+        z_score_input="independent",
+        z_score_condition="structured",
+    )
+    kwargs = builder._build_kwargs()
+    assert "z_score_x" in kwargs
+    assert "z_score_y" in kwargs
+    assert kwargs["z_score_x"] == "independent"
+    assert kwargs["z_score_y"] == "structured"
+    # Original names should NOT appear
+    assert "z_score_input" not in kwargs
+    assert "z_score_condition" not in kwargs
+
+
+def test_warning_includes_import_path():
+    """String deprecation warning should include the import path."""
+    prior = MultivariateNormal(zeros(2), eye(2))
+    with pytest.warns(FutureWarning, match="from sbi.neural_nets import"):
+        NRE_A(prior, classifier="resnet", show_progress_bars=False)

--- a/tests/nre_builder_integration_test.py
+++ b/tests/nre_builder_integration_test.py
@@ -1,0 +1,139 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import warnings
+
+import pytest
+import torch
+from torch import eye, zeros
+from torch.distributions import MultivariateNormal
+
+from sbi.inference import BNRE, NRE_A, NRE_B, NRE_C
+from sbi.neural_nets import classifier_nn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    DensityEstimatorBuilder,
+    RatioEstimatorBuilder,
+)
+from sbi.neural_nets.ratio_estimators import RatioEstimator
+from sbi.utils.user_input_checks import check_estimator_arg
+
+_NRE_TRAINERS = [NRE_A, NRE_B, NRE_C, BNRE]
+
+
+@pytest.mark.parametrize(
+    "trainer_cls", _NRE_TRAINERS, ids=["nre_a", "nre_b", "nre_c", "bnre"]
+)
+def test_no_warning_for_valid_inputs(trainer_cls):
+    """None default, builder, and callable should not emit FutureWarning."""
+    prior = MultivariateNormal(zeros(2), eye(2))
+    builder = RatioEstimatorBuilder(model="resnet")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        trainer_cls(prior, show_progress_bars=False)
+        trainer_cls(prior, classifier=builder, show_progress_bars=False)
+        trainer_cls(
+            prior,
+            classifier=classifier_nn(model="resnet"),
+            show_progress_bars=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "trainer_cls", _NRE_TRAINERS, ids=["nre_a", "nre_b", "nre_c", "bnre"]
+)
+def test_string_emits_deprecation_warning(trainer_cls):
+    """Passing a string to classifier should emit FutureWarning."""
+    prior = MultivariateNormal(zeros(2), eye(2))
+    with pytest.warns(FutureWarning, match="deprecated"):
+        trainer_cls(prior, classifier="resnet", show_progress_bars=False)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls", _NRE_TRAINERS, ids=["nre_a", "nre_b", "nre_c", "bnre"]
+)
+def test_wrong_builder_type_raises(trainer_cls):
+    """Passing a DensityEstimatorBuilder should raise TypeError early."""
+    prior = MultivariateNormal(zeros(2), eye(2))
+    wrong_builder = DensityEstimatorBuilder(model="maf")
+    with pytest.raises(TypeError, match="RatioEstimatorBuilder"):
+        trainer_cls(prior, classifier=wrong_builder, show_progress_bars=False)
+
+
+def test_builder_invalid_model():
+    """Invalid model should raise ValueError at construction."""
+    with pytest.raises(ValueError, match="Unknown model"):
+        RatioEstimatorBuilder(model="invalid")
+
+
+@pytest.mark.parametrize(
+    "trainer_cls",
+    [NRE_A, NRE_B],
+    ids=["nre_a", "nre_b"],
+)
+@pytest.mark.parametrize("model", ("resnet", "mlp", "linear"))
+def test_train_with_builder(trainer_cls, model):
+    """Train with a RatioEstimatorBuilder end-to-end."""
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    builder = RatioEstimatorBuilder(model=model, hidden_features=16)
+    inference = trainer_cls(prior, classifier=builder, show_progress_bars=False)
+
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+    ratio_estimator = inference.append_simulations(theta, x).train(
+        max_num_epochs=2, training_batch_size=100
+    )
+    assert isinstance(ratio_estimator, RatioEstimator)
+
+    # Verify the trained estimator produces finite log-ratios on fresh data.
+    fresh_theta = prior.sample((10,))
+    fresh_x = fresh_theta + 0.1 * torch.randn_like(fresh_theta)
+    log_ratios = ratio_estimator.unnormalized_log_ratio(fresh_theta, fresh_x)
+    assert log_ratios.shape == (10,)
+    assert torch.isfinite(log_ratios).all()
+
+    # Posterior should be constructable and produce correct-shaped samples.
+    posterior = inference.build_posterior()
+    x_o = zeros(1, num_dim)
+    samples = posterior.sample((10,), x=x_o)
+    assert samples.shape == (10, num_dim)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls",
+    [NRE_A, NRE_B],
+    ids=["nre_a", "nre_b"],
+)
+def test_builder_role_shapes(trainer_cls):
+    """Verify input_shape=theta and condition_shape=x with asymmetric dims."""
+    num_dim_theta = 2
+    num_dim_x = 5
+    prior = MultivariateNormal(zeros(num_dim_theta), eye(num_dim_theta))
+    builder = RatioEstimatorBuilder(model="resnet", hidden_features=16)
+    inference = trainer_cls(prior, classifier=builder, show_progress_bars=False)
+
+    theta = prior.sample((200,))
+    x = torch.randn(200, num_dim_x)
+    estimator = inference.append_simulations(theta, x).train(
+        max_num_epochs=2, training_batch_size=100
+    )
+
+    assert estimator.input_shape == torch.Size([num_dim_theta])
+    assert estimator.condition_shape == torch.Size([num_dim_x])
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    (
+        RatioEstimatorBuilder(model="resnet"),
+        RatioEstimatorBuilder(model="mlp"),
+        RatioEstimatorBuilder(model="linear"),
+        "resnet",
+        classifier_nn(model="resnet"),
+    ),
+    ids=["resnet_builder", "mlp_builder", "linear_builder", "string", "callable"],
+)
+def test_check_estimator_arg_accepts_valid_inputs(estimator):
+    """check_estimator_arg accepts ratio builders, strings, and callables."""
+    check_estimator_arg(estimator)


### PR DESCRIPTION
## What does this PR do?

This PR continues the [GSoC 2026 Neural Network Builder API refactor](https://summerofcode.withgoogle.com/programs/2026/projects/P5QOhl9F) by introducing the `RatioEstimatorBuilder` for all four NRE trainers (`NRE_A`, `NRE_B`, `NRE_C`, `BNRE`).

Instead of passing a string like `classifier="resnet"` and hiding settings in kwargs, we can now pass a fully typed and clear configuration like `RatioEstimatorBuilder(model="resnet", hidden_features=64)` to use linear, MLP, or ResNet models. Passing `None` will silently default to a ResNet builder to keep the old behavior, while using the old string arguments is now deprecated.

## Files Changed

**`estimator_configs.py`**
- New `RatioEstimatorBuilder` dataclass configures and validates linear/MLP/ResNet classifiers, with `build()` routing to the right function.
- Builders are now frozen/immutable (use `dataclasses.replace()` to tweak), with safer `extra_kwargs` handling and a cleaner `__repr__` that only shows what's actually set.
- Renamed `z_score_x/y` to `z_score_input/condition` for clarity, with aliasing so it still maps correctly downstream.
- Validates at construction time, catches bad `Literal` values and flags hyperparameters that don't apply to the chosen model.

**`nre_base.py`**
- `classifier` now takes a `RatioEstimatorBuilder` (defaults to `None` -> ResNet); old string configs still work but warn, wrong types fail fast.
- Added `_wrap_builder` to bridge the new builder API to the legacy `(batch_theta, batch_x)` format.

**`nre_a.py`, `nre_b.py`, `nre_c.py`, `bnre.py`**
- Same `classifier` type hint/default update, docstrings refreshed to match.

**`npe_base.py`, `nle_base.py`, `mnle.py`, `mnpe.py`**
- Deprecation warnings now point to the exact import path for the new builder, plus a small isinstance-check cleanup in `mnle.py`/`mnpe.py`.

**`sbi/neural_nets/__init__.py`**
- Exports `DensityEstimatorBuilder` and `MixedDensityEstimatorBuilder` so those import paths actually resolve.

**`density_estimator_builder_test.py`**
- Updated for the `z_score_input`/`z_score_condition` rename.

**`nre_builder_integration_test.py`** *(new)*
- Integration tests across all NRE trainers: defaults, legacy warnings, validation, immutability, repr, z-score aliasing.

**`npe_nle_builder_integration_test.py`**
- Keeps builder fields in sync with build-function signatures, plus z-score alias tests.

## AI Usage

* Used Grammarly for PR description refinement, VS Code Copilot for code suggestions, and GPT OSS via Antigravity for docstrings and cosmetic updates.

## Does this close any issues?

N/A

## Any relevant code examples, logs, or error messages?

N/A
