### PR TITLE
Add VectorFieldEstimatorBuilder for FMPE / NPSE trainers

### DIFF
--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -323,7 +323,9 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
         return self._summary
 
     @classmethod
-    def _wrap_builder(cls, builder: "_EstimatorBuilderBase") -> Callable:
+    def _wrap_builder(
+        cls, builder: "_EstimatorBuilderBase"
+    ) -> Callable[[Tensor, Tensor], ConditionalEstimatorType]:
         """Wrap an estimator builder as a ``(batch_theta, batch_x)`` callable."""
         input_is_theta = cls._INPUT_IS_THETA
 

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -11,8 +11,10 @@ from datetime import datetime
 from inspect import currentframe
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Dict,
     Generic,
     List,
@@ -34,6 +36,9 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard.writer import SummaryWriter
 from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
@@ -235,6 +240,10 @@ def infer(
 class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
     """Abstract base class for neural inference methods."""
 
+    _INPUT_IS_THETA: ClassVar[bool] = True
+    """If True, batch_theta maps to batch_input. LikelihoodEstimatorTrainer
+    overrides to False because NLE models p(x|θ)."""
+
     def __init__(
         self,
         prior: Optional[Distribution] = None,
@@ -312,6 +321,18 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
     @property
     def summary(self):
         return self._summary
+
+    @classmethod
+    def _wrap_builder(cls, builder: "_EstimatorBuilderBase") -> Callable:
+        """Wrap an estimator builder as a ``(batch_theta, batch_x)`` callable."""
+        input_is_theta = cls._INPUT_IS_THETA
+
+        def build_fn(batch_theta, batch_x):
+            if input_is_theta:
+                return builder.build(batch_input=batch_theta, batch_condition=batch_x)
+            return builder.build(batch_input=batch_x, batch_condition=batch_theta)
+
+        return build_fn
 
     @abstractmethod
     def append_simulations(

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -240,9 +240,8 @@ def infer(
 class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
     """Abstract base class for neural inference methods."""
 
+    # Overridden by subclasses when needed (e.g., LikelihoodEstimatorTrainer).
     _INPUT_IS_THETA: ClassVar[bool] = True
-    """If True, batch_theta maps to batch_input. LikelihoodEstimatorTrainer
-    overrides to False because NLE models p(x|θ)."""
 
     def __init__(
         self,

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -5,7 +5,6 @@ import warnings
 from abc import ABC
 from typing import (
     Any,
-    Callable,
     ClassVar,
     Dict,
     Literal,
@@ -48,6 +47,7 @@ from sbi.utils.torchutils import assert_all_finite
 
 class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], ABC):
     _ALLOWED_BUILDER_TYPES: ClassVar[Tuple[type, ...]] = (DensityEstimatorBuilder,)
+    _INPUT_IS_THETA = False  # NLE models p(x|θ): input=x, condition=θ
 
     def __init__(
         self,
@@ -396,23 +396,6 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
         start_idx = int(context.discard_prior_samples and self._round > 0)
 
         return start_idx
-
-    @staticmethod
-    def _wrap_builder(
-        builder: _EstimatorBuilderBase,
-    ) -> Callable:
-        """Wrap a builder object as a legacy-compatible build function.
-
-        This allows the existing `_initialize_neural_network` flow to work
-        unchanged: the returned callable has the same `(batch_theta, batch_x)`
-        signature as the functions produced by `likelihood_nn`.
-        """
-
-        def build_fn(batch_theta, batch_x):
-            # NLE models p(x|θ): input=x, condition=θ
-            return builder.build(batch_input=batch_x, batch_condition=batch_theta)
-
-        return build_fn
 
     def _initialize_neural_network(
         self,

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -47,7 +47,7 @@ from sbi.utils.torchutils import assert_all_finite
 
 class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], ABC):
     _ALLOWED_BUILDER_TYPES: ClassVar[Tuple[type, ...]] = (DensityEstimatorBuilder,)
-    _INPUT_IS_THETA = False  # NLE models p(x|θ): input=x, condition=θ
+    _INPUT_IS_THETA: ClassVar[bool] = False  # NLE models p(x|θ): input=x, condition=θ
 
     def __init__(
         self,

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -562,22 +562,6 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         assert_all_finite(loss, "NPE loss")
         return calibration_kernel(x) * loss
 
-    @staticmethod
-    def _wrap_builder(
-        builder: _EstimatorBuilderBase,
-    ) -> Callable:
-        """Wrap a builder object as a legacy-compatible build function.
-
-        This allows the existing ``_initialize_neural_network`` flow to work
-        unchanged: the returned callable has the same ``(batch_theta, batch_x)``
-        signature as the functions produced by ``posterior_nn``.
-        """
-
-        def build_fn(batch_theta, batch_x):
-            return builder.build(batch_input=batch_theta, batch_condition=batch_x)
-
-        return build_fn
-
     def _check_proposal(self, proposal):
         """
         Check for validity of the provided proposal distribution.

--- a/sbi/inference/trainers/nre/nre_base.py
+++ b/sbi/inference/trainers/nre/nre_base.py
@@ -4,7 +4,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import asdict, replace
-from typing import Any, Callable, Dict, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, eye, ones
@@ -484,22 +484,6 @@ class RatioEstimatorTrainer(NeuralInference[RatioEstimator], ABC):
             )
 
             del x, theta
-
-    @staticmethod
-    def _wrap_builder(
-        builder: _EstimatorBuilderBase,
-    ) -> Callable:
-        """Wrap a builder object as a legacy-compatible build function.
-
-        This allows the existing ``_initialize_neural_network`` flow to work
-        unchanged: the returned callable has the same ``(batch_theta, batch_x)``
-        signature as the functions produced by ``classifier_nn``.
-        """
-
-        def build_fn(batch_theta, batch_x):
-            return builder.build(batch_input=batch_theta, batch_condition=batch_x)
-
-        return build_fn
 
     def _get_losses(self, batch: Sequence[Tensor], loss_args: LossArgs) -> Tensor:
         """

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -380,7 +380,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             self._best_model_state_dict = None
 
         # Check if we have a new best loss
-        if self._val_loss < self._best_val_loss:
+        if epoch == 0 or self._val_loss < self._best_val_loss:
             self._best_val_loss = self._val_loss
             self._epochs_since_last_improvement = 0
             self._best_model_state_dict = deepcopy(neural_net.state_dict())

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -50,7 +50,8 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             VF_MODELS,
             VectorFieldEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
-        ] = None,  # type: ignore[assignment]  # Subclasses always provide a value.
+            None,
+        ] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -373,14 +374,14 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         assert self._neural_net is not None
         neural_net = self._neural_net
 
-        # Initialize tracking variables if not exists
-        if not hasattr(self, '_best_val_loss'):
-            self._best_val_loss = float('inf')
+        # A stale best-val-loss would stop this run early on the earlier run's weights.
+        if epoch == 0:
+            self._best_val_loss = float("inf")
             self._epochs_since_last_improvement = 0
             self._best_model_state_dict = None
 
         # Check if we have a new best loss
-        if epoch == 0 or self._val_loss < self._best_val_loss:
+        if self._val_loss < self._best_val_loss:
             self._best_val_loss = self._val_loss
             self._epochs_since_last_improvement = 0
             self._best_model_state_dict = deepcopy(neural_net.state_dict())

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import asdict, replace
-from typing import Any, Callable, Dict, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, ones
@@ -24,6 +24,11 @@ from sbi.inference.trainers._contracts import LossArgsVF, StartIndexContext, Tra
 from sbi.inference.trainers.base import LossArgs
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    VF_MODELS,
+    VectorFieldEstimatorBuilder,
+    _EstimatorBuilderBase,
+)
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
     check_estimator_arg,
@@ -42,9 +47,10 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         self,
         prior: Optional[Distribution] = None,
         vector_field_estimator_builder: Union[
-            Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+            VF_MODELS,
+            VectorFieldEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
-        ] = "mlp",
+        ] = None,  # type: ignore[assignment]  # Subclasses always provide a value.
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -60,11 +66,15 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
 
         Args:
             prior: Prior distribution.
-            vector_field_estimator_builder: Neural network architecture for the
-                vector field estimator. Can be a string (e.g. 'mlp' or 'ada_mlp') or a
-                callable that implements the `ConditionalEstimatorBuildFn` protocol
-                with `__call__` that receives `theta` and `x` and returns a
-                `ConditionalVectorFieldEstimator`.
+            vector_field_estimator_builder: The vector-field estimator
+                used for flow-matching or score-matching inference.
+                Subclasses resolve a default ``VectorFieldEstimatorBuilder``
+                before calling the base. A ``VectorFieldEstimatorBuilder``
+                can be passed to configure the estimator. If it is a string
+                (deprecated), use a pre-configured network of the provided
+                type (one of mlp, ada_mlp, transformer,
+                transformer_cross_attn). Alternatively, a function that
+                builds a custom neural network can be provided.
             device: Device to run the training on.
             logging_level: Logging level for the training. Can be an integer or a
                 string.
@@ -82,17 +92,19 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             show_progress_bars=show_progress_bars,
         )
 
-        # The `vector_field_estimator_builder` is either a string or a callable.
-        # The function creating the neural network is attached to
-        # `_build_neural_net`. It will be called in the first round and receive
-        # thetas and xs as inputs, so that they can be used for shape inference and
-        # potentially for z-scoring.
-        #
-        # When it's a callable, we use it directly. When it's a string, subclasses
-        # are responsible for calling `_build_default_nn_fn` with the appropriate
-        # subclass-specific arguments (e.g. sde_type for NPSE).
         check_estimator_arg(vector_field_estimator_builder)
-        if not isinstance(vector_field_estimator_builder, str):
+
+        if isinstance(vector_field_estimator_builder, _EstimatorBuilderBase):
+            if not isinstance(
+                vector_field_estimator_builder, VectorFieldEstimatorBuilder
+            ):
+                raise TypeError(
+                    "VF trainers require a VectorFieldEstimatorBuilder; got "
+                    f"{type(vector_field_estimator_builder).__name__}. Use "
+                    "VectorFieldEstimatorBuilder(model=...)."
+                )
+            self._build_neural_net = self._wrap_builder(vector_field_estimator_builder)
+        elif not isinstance(vector_field_estimator_builder, str):
             self._build_neural_net = vector_field_estimator_builder
 
         self._proposal_roundwise = []
@@ -100,7 +112,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
     @abstractmethod
     def _build_default_nn_fn(
         self,
-        model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+        model: VF_MODELS,
     ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]: ...
 
     def append_simulations(
@@ -361,9 +373,9 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         assert self._neural_net is not None
         neural_net = self._neural_net
 
-        # A stale best-val-loss would stop this run early on the earlier run's weights.
-        if epoch == 0:
-            self._best_val_loss = float("inf")
+        # Initialize tracking variables if not exists
+        if not hasattr(self, '_best_val_loss'):
+            self._best_val_loss = float('inf')
             self._epochs_since_last_improvement = 0
             self._best_model_state_dict = None
 

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -692,6 +692,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             theta, x, _ = self.get_simulations(starting_round=start_idx)
             # Use only training data for building the neural net (z-scoring transforms)
 
+            assert self._build_neural_net is not None
             self._neural_net = self._build_neural_net(
                 theta[self.train_indices].to("cpu"),
                 x[self.train_indices].to("cpu"),

--- a/sbi/inference/trainers/vfpe/fmpe.py
+++ b/sbi/inference/trainers/vfpe/fmpe.py
@@ -3,6 +3,7 @@
 
 
 import warnings
+from dataclasses import replace
 from typing import Any, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
@@ -19,6 +20,10 @@ from sbi.neural_nets.estimators.base import (
     ConditionalVectorFieldEstimator,
 )
 from sbi.neural_nets.factory import posterior_flow_nn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    VF_MODELS,
+    VectorFieldEstimatorBuilder,
+)
 from sbi.sbi_types import Tracker
 
 
@@ -69,9 +74,11 @@ class FMPE(VectorFieldTrainer):
         self,
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
-            Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+            VF_MODELS,
+            VectorFieldEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
-        ] = "mlp",
+            None,
+        ] = None,
         density_estimator: Optional[
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]
         ] = None,
@@ -85,13 +92,15 @@ class FMPE(VectorFieldTrainer):
 
         Args:
             prior: Prior distribution.
-            vf_estimator: Neural network architecture used to learn the
-                vector field estimator. Can be a string (e.g. 'mlp', 'ada_mlp',
-                'transformer' or 'transformer_cross_attn') or a callable that implements
-                the `ConditionalEstimatorBuildFn` protocol with `__call__` that receives
-                `theta` and `x` and returns a `ConditionalVectorFieldEstimator`.
-                To configure estimator-level options, use `posterior_flow_nn` to
-                build a custom callable and pass it here.
+            vf_estimator: The vector-field estimator used for flow-matching
+                inference. If ``None`` (default), uses a
+                ``VectorFieldEstimatorBuilder`` with default settings. A
+                ``VectorFieldEstimatorBuilder`` can be passed to configure
+                the estimator. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                mlp, ada_mlp, transformer, transformer_cross_attn).
+                Alternatively, a function that builds a custom neural
+                network can be provided.
             density_estimator: Deprecated. Use `vf_estimator` instead.
             device: Device to use for training.
             logging_level: Logging level.
@@ -103,6 +112,11 @@ class FMPE(VectorFieldTrainer):
         """
 
         if density_estimator is not None:
+            if vf_estimator is not None:
+                raise ValueError(
+                    "Cannot pass both `density_estimator` and `vf_estimator`. "
+                    "Use `vf_estimator` only; `density_estimator` is deprecated."
+                )
             warnings.warn(
                 "`density_estimator` is deprecated and will be removed in a future "
                 "release. Use `vf_estimator` instead.",
@@ -110,6 +124,27 @@ class FMPE(VectorFieldTrainer):
                 stacklevel=2,
             )
             vf_estimator = density_estimator
+
+        if vf_estimator is None:
+            vf_estimator = VectorFieldEstimatorBuilder(
+                estimator_type="flow",
+            )
+        elif isinstance(vf_estimator, VectorFieldEstimatorBuilder):
+            if vf_estimator.estimator_type is None:
+                vf_estimator = replace(vf_estimator, estimator_type="flow")
+            elif vf_estimator.estimator_type != "flow":
+                raise ValueError(
+                    "FMPE builds flow-matching estimators; got a builder with "
+                    f"estimator_type={vf_estimator.estimator_type!r}."
+                )
+        elif isinstance(vf_estimator, str):
+            warnings.warn(
+                "Passing a string for `vf_estimator` is deprecated. "
+                "Use VectorFieldEstimatorBuilder(model=...) instead, e.g. "
+                "`from sbi.neural_nets import VectorFieldEstimatorBuilder`.",
+                FutureWarning,
+                stacklevel=2,
+            )
 
         super().__init__(
             prior=prior,
@@ -121,7 +156,7 @@ class FMPE(VectorFieldTrainer):
             vector_field_estimator_builder=vf_estimator,
         )
 
-        # When vf_estimator is a string, build the default neural net.
+        # When vf_estimator is a string (deprecated path), build the default.
         if isinstance(vf_estimator, str):
             self._build_neural_net = self._build_default_nn_fn(model=vf_estimator)
 
@@ -173,6 +208,6 @@ class FMPE(VectorFieldTrainer):
 
     def _build_default_nn_fn(
         self,
-        model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+        model: VF_MODELS,
     ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]:
         return posterior_flow_nn(model=model)

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -84,7 +84,7 @@ class NPSE(VectorFieldTrainer):
         density_estimator: Optional[
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]
         ] = None,
-        sde_type: Literal["vp", "ve", "subvp"] = "ve",
+        sde_type: Optional[Literal["vp", "ve", "subvp"]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -107,11 +107,13 @@ class NPSE(VectorFieldTrainer):
             score_estimator: Deprecated, use `vf_estimator` instead.
             density_estimator: Deprecated, use `vf_estimator` instead.
             sde_type: Type of SDE to use. Must be one of ['vp', 've', 'subvp'].
-                When ``vf_estimator`` is ``None``, forwarded to the default
+                Defaults to ``None`` (resolved to ``"ve"``). When
+                ``vf_estimator`` is ``None``, forwarded to the default
                 builder. When a ``VectorFieldEstimatorBuilder`` is passed,
-                ``sde_type`` must match the builder's value or be left at the
-                default (set it on the builder instead). When a string
-                (deprecated), forwarded to ``posterior_score_nn``.
+                a non-``None`` ``sde_type`` that differs from the builder's
+                value raises ``ValueError`` (set it on the builder instead).
+                When a string (deprecated), forwarded to
+                ``posterior_score_nn``.
             device: Device to run the training on.
             logging_level: Logging level for the training. Can be an integer or a
                 string.
@@ -155,19 +157,28 @@ class NPSE(VectorFieldTrainer):
             )
             vf_estimator = density_estimator
 
-        # Builder owns sde_type; reject conflicting trainer-level value.
-        if isinstance(vf_estimator, VectorFieldEstimatorBuilder) and sde_type != "ve":
+        # Builder owns sde_type; reject only when both are explicitly supplied
+        # and they disagree.
+        if (
+            isinstance(vf_estimator, VectorFieldEstimatorBuilder)
+            and sde_type is not None
+            and vf_estimator.sde_type is not None
+            and sde_type != vf_estimator.sde_type
+        ):
             raise ValueError(
-                f"Cannot pass `sde_type={sde_type!r}` when a "
-                "VectorFieldEstimatorBuilder is provided. Set `sde_type` on "
-                "the builder instead: "
+                f"Conflicting `sde_type`: trainer received {sde_type!r} but "
+                f"the builder has {vf_estimator.sde_type!r}. Set `sde_type` "
+                "on the builder only: "
                 f"VectorFieldEstimatorBuilder(sde_type={sde_type!r})."
             )
+
+        # Resolve sde_type sentinel for non-builder paths.
+        resolved_sde_type = sde_type if sde_type is not None else "ve"
 
         if vf_estimator is None:
             vf_estimator = VectorFieldEstimatorBuilder(
                 estimator_type="score",
-                sde_type=sde_type,
+                sde_type=resolved_sde_type,
             )
         elif isinstance(vf_estimator, VectorFieldEstimatorBuilder):
             if vf_estimator.estimator_type is None:
@@ -199,7 +210,7 @@ class NPSE(VectorFieldTrainer):
         # When vf_estimator is a string (deprecated path), build the default.
         if isinstance(vf_estimator, str):
             self._build_neural_net = self._build_default_nn_fn(
-                model=vf_estimator, sde_type=sde_type
+                model=vf_estimator, sde_type=resolved_sde_type
             )
 
     def build_posterior(

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -107,8 +107,11 @@ class NPSE(VectorFieldTrainer):
             score_estimator: Deprecated, use `vf_estimator` instead.
             density_estimator: Deprecated, use `vf_estimator` instead.
             sde_type: Type of SDE to use. Must be one of ['vp', 've', 'subvp'].
-                Only used when `vf_estimator` is a string (i.e. when using the
-                default builder). Ignored when a custom callable is passed.
+                When ``vf_estimator`` is ``None``, forwarded to the default
+                builder. When a ``VectorFieldEstimatorBuilder`` is passed,
+                ``sde_type`` must match the builder's value or be left at the
+                default (set it on the builder instead). When a string
+                (deprecated), forwarded to ``posterior_score_nn``.
             device: Device to run the training on.
             logging_level: Logging level for the training. Can be an integer or a
                 string.

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -2,6 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import warnings
+from dataclasses import replace
 from typing import Any, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
@@ -15,6 +16,10 @@ from sbi.inference.trainers.vfpe.base_vf_inference import (
 from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.factory import posterior_score_nn
+from sbi.neural_nets.net_builders.estimator_configs import (
+    VF_MODELS,
+    VectorFieldEstimatorBuilder,
+)
 from sbi.sbi_types import Tracker
 
 
@@ -65,12 +70,14 @@ class NPSE(VectorFieldTrainer):
         self,
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
-            Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+            VF_MODELS,
+            VectorFieldEstimatorBuilder,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
-        ] = "mlp",
+            None,
+        ] = None,
         score_estimator: Optional[
             Union[
-                Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+                VF_MODELS,
                 ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
             ]
         ] = None,
@@ -88,14 +95,15 @@ class NPSE(VectorFieldTrainer):
 
         Args:
             prior: Prior distribution.
-            vf_estimator: Neural network architecture for the
-                vector field estimator aiming to estimate the marginal scores of the
-                target diffusion process. Can be a string (e.g. 'mlp', 'ada_mlp',
-                'transformer' or 'transformer_cross_attn') or a callable that implements
-                the `ConditionalEstimatorBuildFn` protocol with `__call__` that receives
-                `theta` and `x` and returns a `ConditionalVectorFieldEstimator`.
-                To configure estimator-level options (e.g. noise schedules for VE),
-                use `posterior_score_nn` to build a custom callable and pass it here.
+            vf_estimator: The vector-field estimator used for score-matching
+                inference. If ``None`` (default), uses a
+                ``VectorFieldEstimatorBuilder`` with default settings. A
+                ``VectorFieldEstimatorBuilder`` can be passed to configure
+                the estimator. If it is a string (deprecated), use a
+                pre-configured network of the provided type (one of
+                mlp, ada_mlp, transformer, transformer_cross_attn).
+                Alternatively, a function that builds a custom neural
+                network can be provided.
             score_estimator: Deprecated, use `vf_estimator` instead.
             density_estimator: Deprecated, use `vf_estimator` instead.
             sde_type: Type of SDE to use. Must be one of ['vp', 've', 'subvp'].
@@ -117,6 +125,11 @@ class NPSE(VectorFieldTrainer):
                 free inference with conditional score based diffusion models." ICML 2024
         """
         if score_estimator is not None:
+            if vf_estimator is not None:
+                raise ValueError(
+                    "Cannot pass both `score_estimator` and `vf_estimator`. "
+                    "Use `vf_estimator` only; `score_estimator` is deprecated."
+                )
             warnings.warn(
                 "`score_estimator` is deprecated and will be removed in a future "
                 "release. Use `vf_estimator` instead.",
@@ -126,6 +139,11 @@ class NPSE(VectorFieldTrainer):
             vf_estimator = score_estimator
 
         if density_estimator is not None:
+            if vf_estimator is not None:
+                raise ValueError(
+                    "Cannot pass both `density_estimator` and `vf_estimator`. "
+                    "Use `vf_estimator` only; `density_estimator` is deprecated."
+                )
             warnings.warn(
                 "`density_estimator` is deprecated and will be removed in a future "
                 "release. Use `vf_estimator` instead.",
@@ -133,6 +151,37 @@ class NPSE(VectorFieldTrainer):
                 stacklevel=2,
             )
             vf_estimator = density_estimator
+
+        # Builder owns sde_type; reject conflicting trainer-level value.
+        if isinstance(vf_estimator, VectorFieldEstimatorBuilder) and sde_type != "ve":
+            raise ValueError(
+                f"Cannot pass `sde_type={sde_type!r}` when a "
+                "VectorFieldEstimatorBuilder is provided. Set `sde_type` on "
+                "the builder instead: "
+                f"VectorFieldEstimatorBuilder(sde_type={sde_type!r})."
+            )
+
+        if vf_estimator is None:
+            vf_estimator = VectorFieldEstimatorBuilder(
+                estimator_type="score",
+                sde_type=sde_type,
+            )
+        elif isinstance(vf_estimator, VectorFieldEstimatorBuilder):
+            if vf_estimator.estimator_type is None:
+                vf_estimator = replace(vf_estimator, estimator_type="score")
+            elif vf_estimator.estimator_type != "score":
+                raise ValueError(
+                    "NPSE builds score estimators; got a builder with "
+                    f"estimator_type={vf_estimator.estimator_type!r}."
+                )
+        elif isinstance(vf_estimator, str):
+            warnings.warn(
+                "Passing a string for `vf_estimator` is deprecated. "
+                "Use VectorFieldEstimatorBuilder(model=...) instead, e.g. "
+                "`from sbi.neural_nets import VectorFieldEstimatorBuilder`.",
+                FutureWarning,
+                stacklevel=2,
+            )
 
         super().__init__(
             prior=prior,
@@ -144,8 +193,7 @@ class NPSE(VectorFieldTrainer):
             show_progress_bars=show_progress_bars,
         )
 
-        # When vf_estimator is a string, build the default neural net using
-        # the NPSE-specific builder which requires sde_type.
+        # When vf_estimator is a string (deprecated path), build the default.
         if isinstance(vf_estimator, str):
             self._build_neural_net = self._build_default_nn_fn(
                 model=vf_estimator, sde_type=sde_type
@@ -197,7 +245,7 @@ class NPSE(VectorFieldTrainer):
 
     def _build_default_nn_fn(
         self,
-        model: Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+        model: VF_MODELS,
         sde_type: Literal["vp", "ve", "subvp"] = "ve",
     ) -> ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator]:
         return posterior_score_nn(model=model, sde_type=sde_type)

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -188,6 +188,9 @@ class NPSE(VectorFieldTrainer):
                     "NPSE builds score estimators; got a builder with "
                     f"estimator_type={vf_estimator.estimator_type!r}."
                 )
+            # Forward trainer's sde_type when the builder's is unset.
+            if vf_estimator.sde_type is None and sde_type is not None:
+                vf_estimator = replace(vf_estimator, sde_type=sde_type)
         elif isinstance(vf_estimator, str):
             warnings.warn(
                 "Passing a string for `vf_estimator` is deprecated. "

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -188,9 +188,6 @@ class NPSE(VectorFieldTrainer):
                     "NPSE builds score estimators; got a builder with "
                     f"estimator_type={vf_estimator.estimator_type!r}."
                 )
-            # Forward trainer's sde_type when the builder's is unset.
-            if vf_estimator.sde_type is None and sde_type is not None:
-                vf_estimator = replace(vf_estimator, sde_type=sde_type)
         elif isinstance(vf_estimator, str):
             warnings.warn(
                 "Passing a string for `vf_estimator` is deprecated. "

--- a/sbi/neural_nets/__init__.py
+++ b/sbi/neural_nets/__init__.py
@@ -13,6 +13,7 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     DensityEstimatorBuilder,
     MixedDensityEstimatorBuilder,
     RatioEstimatorBuilder,
+    VectorFieldEstimatorBuilder,
 )
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "posterior_nn",
     "posterior_score_nn",
     "posterior_flow_nn",
+    "VectorFieldEstimatorBuilder",
     "DensityEstimatorBuilder",
     "MixedDensityEstimatorBuilder",
     "RatioEstimatorBuilder",

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -12,6 +12,7 @@ from sbi.neural_nets.net_builders.classifier import (
     build_resnet_classifier,
 )
 from sbi.neural_nets.net_builders.estimator_configs import (
+    VF_MODELS,
     ClassifierConfig,
     ConditionalFlowConfig,
     MarginalFlowConfig,
@@ -342,7 +343,7 @@ def posterior_nn(
 
 def posterior_score_nn(
     model: Union[
-        Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+        VF_MODELS,
         VectorFieldNet,
     ] = "mlp",
     sde_type: str = "ve",
@@ -438,7 +439,7 @@ def posterior_score_nn(
 
 def posterior_flow_nn(
     model: Union[
-        Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
+        VF_MODELS,
         VectorFieldNet,
     ] = "mlp",
     z_score_theta: Optional[

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -375,7 +375,7 @@ def posterior_score_nn(
             - 'ada_mlp': Fully connected feed-forward with adaptive
                layer normalization for conditioning.
             - 'transformer': Transformer network.
-            - 'transformer_cross_attention': Transformer with cross-attention.
+            - 'transformer_cross_attn': Transformer with cross-attention.
             -  nn.Module: Custom network
             Defaults to 'mlp'.
         z_score_theta: Whether to z-score thetas passing into the network, can be one
@@ -466,7 +466,7 @@ def posterior_flow_nn(
             - 'ada_mlp': Fully connected feed-forward with adaptive
                 layer normalization for conditioning.
             - 'transformer': Transformer network.
-            - 'transformer_cross_attention': Transformer with cross-attention.
+            - 'transformer_cross_attn': Transformer with cross-attention.
             -  nn.Module: Custom network
             Defaults to 'mlp'.
         z_score_theta: Whether to z-score theta for time-dependent normalization.

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -376,6 +376,8 @@ def posterior_score_nn(
                layer normalization for conditioning.
             - 'transformer': Transformer network.
             - 'transformer_cross_attn': Transformer with cross-attention.
+                Requires sequence-shaped conditioning (3-D ``batch_y`` or an
+                ``embedding_net`` returning ``(batch, seq_len, emb_dim)``).
             -  nn.Module: Custom network
             Defaults to 'mlp'.
         z_score_theta: Whether to z-score thetas passing into the network, can be one
@@ -467,6 +469,8 @@ def posterior_flow_nn(
                 layer normalization for conditioning.
             - 'transformer': Transformer network.
             - 'transformer_cross_attn': Transformer with cross-attention.
+                Requires sequence-shaped conditioning (3-D ``batch_y`` or an
+                ``embedding_net`` returning ``(batch, seq_len, emb_dim)``).
             -  nn.Module: Custom network
             Defaults to 'mlp'.
         z_score_theta: Whether to z-score theta for time-dependent normalization.

--- a/sbi/neural_nets/net_builders/__init__.py
+++ b/sbi/neural_nets/net_builders/__init__.py
@@ -11,6 +11,7 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     DensityEstimatorBuilder,
     MixedDensityEstimatorBuilder,
     RatioEstimatorBuilder,
+    VectorFieldEstimatorBuilder,
 )
 from sbi.neural_nets.net_builders.flow import (
     build_made,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -39,6 +39,7 @@ import torch.nn as nn
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
     ConditionalEstimator,
@@ -157,11 +158,11 @@ class _EstimatorBuilderBase:
                 acceptable regardless of *build_fn*'s signature.
         """
         allowed = self._fn_param_names(build_fn) | always_ok
+        skip = self._DISCRIMINATORS | {"extra_kwargs"}
         set_fields = {
             f.name
             for f in fields(self)
-            if f.name not in ("extra_kwargs", discriminator)
-            and getattr(self, f.name) is not None
+            if f.name not in skip and getattr(self, f.name) is not None
         }
         bad = {
             n
@@ -699,3 +700,182 @@ class RatioEstimatorBuilder(_EstimatorBuilderBase):
         build_fn = _classifier_build_fns()[self.model]
         kwargs = self._build_kwargs()
         return build_fn(batch_x=batch_input, batch_y=batch_condition, **kwargs)
+
+
+VF_MODELS = Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"]
+
+_VALID_VF_MODELS = frozenset(get_args(VF_MODELS))
+
+
+def _vector_field_build_fns() -> dict:
+    """Build-function mapping for vector field estimators (per architecture)."""
+    from sbi.neural_nets.net_builders.vector_field_nets import (
+        build_adamlp_network,
+        build_standard_mlp_network,
+        build_transformer_network,
+    )
+
+    return {
+        "mlp": build_standard_mlp_network,
+        "ada_mlp": build_adamlp_network,
+        "transformer": build_transformer_network,
+        "transformer_cross_attn": build_transformer_network,
+    }
+
+
+_SCORE_ONLY_FIELDS: frozenset = frozenset({
+    "sde_type",
+    "train_schedule",
+    "solve_schedule",
+    "sigma_min",
+    "sigma_max",
+    "lognormal_mean",
+    "lognormal_std",
+    "power_law_exponent",
+    "beta_min",
+    "beta_max",
+})
+
+_FLOW_ONLY_FIELDS: frozenset = frozenset({"gaussian_baseline"})
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class VectorFieldEstimatorBuilder(_EstimatorBuilderBase):
+    """Builder for vector-field estimators (FMPE / NPSE).
+
+    Covers MLP, AdaMLP, Transformer, and cross-attention Transformer
+    architectures used by ``FMPE`` (flow matching) and ``NPSE`` (score
+    matching).  The ``estimator_type`` field selects between the two:
+    ``"flow"`` dispatches to ``build_flow_matching_estimator`` and
+    ``"score"`` dispatches to ``build_score_matching_estimator``.
+    """
+
+    _DISCRIMINATORS: ClassVar[frozenset] = frozenset({
+        "model",
+        "estimator_type",
+    })
+
+    model: VF_MODELS = "mlp"  # type: ignore[valid-type]
+    estimator_type: Optional[Literal["flow", "score"]] = None
+    sde_type: Optional[Literal["vp", "ve", "subvp"]] = None
+
+    # --- Shared fields ---
+    z_score_input: Optional[Literal["none", "independent", "structured"]] = None
+    z_score_condition: Optional[Literal["none", "independent", "structured"]] = None
+    hidden_features: Optional[Union[Sequence[int], int]] = None
+    num_layers: Optional[int] = None
+    time_embedding_dim: Optional[int] = None
+    embedding_net: Optional[nn.Module] = None
+
+    # --- Transformer-specific ---
+    num_heads: Optional[int] = None
+    mlp_ratio: Optional[int] = None
+
+    # --- Flow-matching-specific ---
+    gaussian_baseline: Optional[bool] = None
+
+    # --- Score-matching-specific (VE schedule) ---
+    train_schedule: Optional[Literal["uniform", "lognormal"]] = None
+    solve_schedule: Optional[Literal["uniform", "power_law"]] = None
+    sigma_min: Optional[float] = None
+    sigma_max: Optional[float] = None
+    lognormal_mean: Optional[float] = None
+    lognormal_std: Optional[float] = None
+    power_law_exponent: Optional[float] = None
+
+    # --- Score-matching-specific (VP / SubVP) ---
+    beta_min: Optional[float] = None
+    beta_max: Optional[float] = None
+
+    def __post_init__(self):
+        if self.model not in _VALID_VF_MODELS:
+            raise ValueError(
+                f"Unknown model {self.model!r}. "
+                f"Must be one of {sorted(_VALID_VF_MODELS)}."
+            )
+        super().__post_init__()
+
+        # Reject fields that don't apply to the chosen estimator_type.
+        # Skip this guard when estimator_type is None (resolved by the trainer).
+        if self.estimator_type is not None:
+            blocked = (
+                _SCORE_ONLY_FIELDS
+                if self.estimator_type == "flow"
+                else _FLOW_ONLY_FIELDS
+            )
+            bad = {
+                f.name
+                for f in fields(self)
+                if f.name in blocked and getattr(self, f.name) is not None
+            }
+            if bad:
+                raise ValueError(
+                    f"Field(s) {sorted(bad)} do not apply to "
+                    f"estimator_type={self.estimator_type!r}. Remove them or "
+                    f"change estimator_type."
+                )
+
+        # Reject fields inapplicable to the chosen model architecture.
+        always_ok = (
+            frozenset({"z_score_input", "z_score_condition"})
+            | _SCORE_ONLY_FIELDS
+            | _FLOW_ONLY_FIELDS
+        )
+        self._reject_inapplicable_fields(
+            _vector_field_build_fns()[self.model],
+            discriminator="model",
+            always_ok=always_ok,
+        )
+
+    def build(
+        self, batch_input: Tensor, batch_condition: Tensor
+    ) -> ConditionalVectorFieldEstimator:
+        """Build the vector-field estimator by dispatching to
+        ``build_flow_matching_estimator`` or
+        ``build_score_matching_estimator``.
+
+        Args:
+            batch_input: Batch of the modeled variable used for
+                shape inference and z-scoring.
+            batch_condition: Batch of the conditioning variable
+                used for shape inference and z-scoring.
+
+        Returns:
+            A ``ConditionalVectorFieldEstimator``.
+        """
+        from sbi.neural_nets.net_builders.vector_field_nets import (
+            build_vector_field_estimator,
+        )
+
+        if self.estimator_type is None:
+            raise ValueError(
+                "estimator_type is None. The trainer should resolve this "
+                "before calling build(). Use dataclasses.replace() to set "
+                "estimator_type='flow' or 'score'."
+            )
+
+        kwargs = self._build_kwargs()
+        # sde_type is excluded from _build_kwargs() and passed
+        # explicitly to build_vector_field_estimator.
+        sde_type = self.sde_type or "ve"
+
+        return build_vector_field_estimator(
+            batch_x=batch_input,
+            batch_y=batch_condition,
+            estimator_type=self.estimator_type,
+            sde_type=sde_type,
+            **kwargs,
+        )
+
+    def _build_kwargs(self) -> dict:
+        """Non-None fields minus discriminators and sde_type, alias-translated."""
+        excluded = self._DISCRIMINATORS | {"sde_type", "extra_kwargs"}
+        d = {
+            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in excluded and getattr(self, f.name) is not None
+        }
+        # The build function expects `net` for the architecture name.
+        d["net"] = self.model
+        d.update(self.extra_kwargs)
+        return d

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -820,7 +820,7 @@ class VectorFieldEstimatorBuilder(_EstimatorBuilderBase):
 
         # Reject fields inapplicable to the chosen model architecture.
         always_ok = (
-            frozenset({"z_score_input", "z_score_condition"})
+            frozenset({"z_score_input", "z_score_condition", "compose_standardization"})
             | _SCORE_ONLY_FIELDS
             | _FLOW_ONLY_FIELDS
         )

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -774,6 +774,9 @@ class VectorFieldEstimatorBuilder(_EstimatorBuilderBase):
     # --- Flow-matching-specific ---
     gaussian_baseline: Optional[bool] = None
 
+    # --- Shared estimator option ---
+    compose_standardization: Optional[bool] = None
+
     # --- Score-matching-specific (VE schedule) ---
     train_schedule: Optional[Literal["uniform", "lognormal"]] = None
     solve_schedule: Optional[Literal["uniform", "power_law"]] = None

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -745,9 +745,9 @@ class VectorFieldEstimatorBuilder(_EstimatorBuilderBase):
 
     Covers MLP, AdaMLP, Transformer, and cross-attention Transformer
     architectures used by ``FMPE`` (flow matching) and ``NPSE`` (score
-    matching).  The ``estimator_type`` field selects between the two:
-    ``"flow"`` dispatches to ``build_flow_matching_estimator`` and
-    ``"score"`` dispatches to ``build_score_matching_estimator``.
+    matching).  ``build()`` forwards to ``build_vector_field_estimator``,
+    which constructs a ``FlowMatchingEstimator`` for ``"flow"`` and a
+    ``ConditionalScoreEstimator`` subclass for ``"score"``.
     """
 
     _DISCRIMINATORS: ClassVar[frozenset] = frozenset({

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -170,7 +170,9 @@ def build_vector_field_estimator(
         mlp_ratio: Ratio for MLP hidden dimension (for transformer).
         net: Type of architecture to use, either "mlp", "ada_mlp", "transformer",
             "transformer_cross_attn" or a custom network following the
-            VectorFieldNet protocol.
+            VectorFieldNet protocol. ``"transformer_cross_attn"`` requires
+            sequence-shaped conditioning (3-D ``batch_y`` or an ``embedding_net``
+            that returns ``(batch, seq_len, emb_dim)``).
         gaussian_baseline: If True, use analytical Gaussian baseline velocity
             derived from Bayes' rule. The network then only learns the residual.
             Only used when estimator_type="flow". Defaults to False.
@@ -232,8 +234,8 @@ def build_vector_field_estimator(
         hidden_features_int = (
             hidden_features if isinstance(hidden_features, int) else hidden_features[0]
         )
-        # Pop is_x_emb_seq from kwargs to avoid duplicate forwarding.
-        kwargs.pop("is_x_emb_seq", None)
+        # Let an explicit kwarg win; fall back to deriving from net name.
+        is_x_emb_seq = kwargs.pop("is_x_emb_seq", net == "transformer_cross_attn")
         vectorfield_net = build_transformer_network(
             batch_x=batch_x,
             batch_y=batch_y,
@@ -243,7 +245,7 @@ def build_vector_field_estimator(
             mlp_ratio=mlp_ratio,
             time_embedding_dim=time_embedding_dim,
             embedding_net=embedding_net,
-            is_x_emb_seq=(net == "transformer_cross_attn"),
+            is_x_emb_seq=is_x_emb_seq,
             **kwargs,
         )
     else:

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -17,7 +17,10 @@ from sbi.neural_nets.estimators.score_estimator import (
     VEScoreEstimator,
     VPScoreEstimator,
 )
-from sbi.neural_nets.net_builders.estimator_configs import _EstimatorBuilderBase
+from sbi.neural_nets.net_builders.estimator_configs import (
+    VF_MODELS,
+    _EstimatorBuilderBase,
+)
 from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
     assert_transform_to_unconstrained_supported,
@@ -77,8 +80,8 @@ class ScoreEstimatorConfig(_VectorFieldBaseConfig):
     """Configuration for score-matching estimator builders (NPSE).
 
     Extends the base config with SDE-specific parameters for VE, VP, and SubVP
-    noise schedules.  Constructing an instance from user-supplied ``**kwargs``
-    ensures that typos and unknown parameters raise ``TypeError`` immediately.
+    noise schedules.  Unknown parameters raise ``TypeError`` on direct
+    construction but are warned-and-forwarded via ``from_kwargs()``.
     """
 
     # VE schedule params (Karras et al. 2022)
@@ -103,13 +106,11 @@ class ScoreEstimatorConfig(_VectorFieldBaseConfig):
 class FlowEstimatorConfig(_VectorFieldBaseConfig):
     """Configuration for flow-matching estimator builders (FMPE).
 
-    Currently identical to the base config.  Constructing an instance from
-    user-supplied ``**kwargs`` ensures that typos and unknown parameters raise
-    ``TypeError`` immediately — and that score-only parameters (e.g.
-    ``sigma_min``, ``beta_min``) are rejected early.
+    Currently identical to the base config.  Unknown parameters raise
+    ``TypeError`` on direct construction but are warned-and-forwarded
+    via ``from_kwargs()``.
     """
 
-    estimator_type: Optional[str] = None
     gaussian_baseline: Optional[bool] = None
 
 
@@ -136,8 +137,8 @@ def build_vector_field_estimator(
     batch_x: Tensor,
     batch_y: Tensor,
     estimator_type: Literal["flow", "score"] = "flow",
-    z_score_x: Optional[str] = None,
-    z_score_y: Optional[str] = None,
+    z_score_x: Optional[str] = "independent",
+    z_score_y: Optional[str] = "independent",
     embedding_net: nn.Module = nn.Identity(),
     sde_type: str = "ve",  # Only used for score estimator
     hidden_features: Union[Sequence[int], int] = 100,
@@ -145,10 +146,7 @@ def build_vector_field_estimator(
     num_layers: int = 5,
     num_heads: int = 10,
     mlp_ratio: int = 4,
-    net: Union[
-        Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"],
-        VectorFieldNet,
-    ] = "mlp",
+    net: Union[VF_MODELS, VectorFieldNet] = "mlp",
     gaussian_baseline: bool = False,
     compose_standardization: bool = False,
     **kwargs,
@@ -229,7 +227,7 @@ def build_vector_field_estimator(
             embedding_net=embedding_net,
             **kwargs,
         )
-    elif net == "transformer":
+    elif net in ("transformer", "transformer_cross_attn"):
         # For transformer, hidden_features must be an int
         hidden_features_int = (
             hidden_features if isinstance(hidden_features, int) else hidden_features[0]
@@ -243,6 +241,7 @@ def build_vector_field_estimator(
             mlp_ratio=mlp_ratio,
             time_embedding_dim=time_embedding_dim,
             embedding_net=embedding_net,
+            is_x_emb_seq=(net == "transformer_cross_attn"),
             **kwargs,
         )
     else:
@@ -1279,7 +1278,7 @@ def build_standard_mlp_network(
     activation: type[nn.Module] = nn.GELU,
     layer_norm: bool = True,
     skip_connections: bool = True,
-    time_emb_type: str = "random_fourier",
+    time_emb_type: str = "sinusoidal",
     sinusoidal_max_freq: float = 1000.0,
     fourier_scale: float = 30.0,
     **kwargs,

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -169,7 +169,7 @@ def build_vector_field_estimator(
         num_heads: Number of attention heads per block (for transformer).
         mlp_ratio: Ratio for MLP hidden dimension (for transformer).
         net: Type of architecture to use, either "mlp", "ada_mlp", "transformer",
-            "transformer_cross_attention" or a custom network following the
+            "transformer_cross_attn" or a custom network following the
             VectorFieldNet protocol.
         gaussian_baseline: If True, use analytical Gaussian baseline velocity
             derived from Bayes' rule. The network then only learns the residual.
@@ -232,6 +232,8 @@ def build_vector_field_estimator(
         hidden_features_int = (
             hidden_features if isinstance(hidden_features, int) else hidden_features[0]
         )
+        # Pop is_x_emb_seq from kwargs to avoid duplicate forwarding.
+        kwargs.pop("is_x_emb_seq", None)
         vectorfield_net = build_transformer_network(
             batch_x=batch_x,
             batch_y=batch_y,

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -367,4 +367,3 @@ def test_all_architectures_build(net, batch_y_3d, is_x_emb_seq_kwarg):
     )
     assert estimator is not None
     assert estimator.input_shape == torch.Size([3])
-

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -240,41 +240,131 @@ def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
         )
 
 
-def test_npse_sde_type_conflict_with_builder(gaussian_sims):
-    """Builder's sde_type is authoritative; trainer-level conflicts raise."""
+@pytest.mark.parametrize(
+    "builder_sde,trainer_sde,should_raise",
+    [
+        # values agree then no error
+        ("ve", "ve", False),
+        # values conflict then must raise
+        ("ve", "vp", True),
+        # builder only (trainer omits) then no error
+        ("vp", None, False),
+        # trainer only (no builder) then no error, forwarded to default builder
+        (None, "vp", False),
+    ],
+    ids=["agree", "conflict", "builder-only", "trainer-only"],
+)
+def test_npse_sde_type_interactions(
+    builder_sde, trainer_sde, should_raise, gaussian_sims
+):
+    """sde_type must raise only when both are supplied and they disagree."""
     prior, _, _ = gaussian_sims
-    with pytest.raises(ValueError, match="sde_type"):
+
+    builder_kwargs = {"estimator_type": "score"}
+    if builder_sde is not None:
+        builder_kwargs["sde_type"] = builder_sde
+
+    trainer_kwargs = {"prior": prior}
+    if trainer_sde is not None:
+        trainer_kwargs["sde_type"] = trainer_sde
+
+    if should_raise:
+        with pytest.raises(ValueError, match="sde_type"):
+            NPSE(
+                vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
+                **trainer_kwargs,
+            )
+    else:
+        # Should not raise.
         NPSE(
-            prior=prior,
-            vf_estimator=VectorFieldEstimatorBuilder(
-                estimator_type="score",
-                sde_type="ve",
-            ),
-            sde_type="vp",
+            vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
+            **trainer_kwargs,
         )
 
 
 @pytest.mark.parametrize("est_type", ["flow", "score"])
-def test_default_builder_applies_z_scoring(est_type):
-    """Default builder must z-score inputs, matching posterior_flow_nn defaults."""
+def test_default_builder_matches_factory_z_scoring(est_type):
+    """Builder and factory must produce identical z-scoring buffers."""
     theta = torch.randn(200, 2) + 5.0
     x = theta + 0.1 * torch.randn_like(theta)
+
+    # Build via builder.
     builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
-    estimator = builder.build(batch_input=theta, batch_condition=x)
-    mean = estimator.mean_0
-    std = estimator.std_0
-    assert not torch.equal(mean, torch.zeros_like(mean)), (
-        "mean_0 is all zeros: z-scoring was not applied to the input"
+    est_builder = builder.build(batch_input=theta, batch_condition=x)
+
+    # Build via factory.
+    if est_type == "flow":
+        from sbi.neural_nets.factory import posterior_flow_nn
+
+        factory_fn = posterior_flow_nn(model="mlp")
+    else:
+        from sbi.neural_nets.factory import posterior_score_nn
+
+        factory_fn = posterior_score_nn(model="mlp")
+    est_factory = factory_fn(theta, x)
+
+    # Compare z-scoring buffers on the input (theta) side.
+    assert torch.allclose(est_builder.mean_0, est_factory.mean_0), (
+        "mean_0 mismatch between builder and factory"
     )
-    assert not torch.equal(std, torch.ones_like(std)), (
-        "std_0 is all ones: z-scoring was not applied to the input"
+    assert torch.allclose(est_builder.std_0, est_factory.std_0), (
+        "std_0 mismatch between builder and factory"
     )
 
+    # Compare z-scoring on the condition (x) side.
     from sbi.utils.sbiutils import Standardize
 
-    has_standardize = any(
-        isinstance(m, Standardize) for m in estimator.embedding_net.modules()
+    def _get_standardize(module):
+        for m in module.modules():
+            if isinstance(m, Standardize):
+                return m
+        return None
+
+    std_builder = _get_standardize(est_builder.embedding_net)
+    std_factory = _get_standardize(est_factory.embedding_net)
+    assert std_builder is not None, "Builder embedding_net missing Standardize"
+    assert std_factory is not None, "Factory embedding_net missing Standardize"
+    assert torch.allclose(std_builder.mean, std_factory.mean), (
+        "embedding_net Standardize mean mismatch"
     )
-    assert has_standardize, (
-        "embedding_net has no Standardize layer: z-scoring was not applied to y"
+    assert torch.allclose(std_builder.std, std_factory.std), (
+        "embedding_net Standardize std mismatch"
     )
+
+
+@pytest.mark.parametrize(
+    "net,batch_y_3d,is_x_emb_seq_kwarg",
+    [
+        ("mlp", False, None),
+        ("ada_mlp", False, None),
+        ("transformer", False, None),
+        ("transformer_cross_attn", True, None),
+        # net="transformer" plus explicit is_x_emb_seq=True via kwargs
+        ("transformer", True, True),
+    ],
+    ids=["mlp", "ada_mlp", "transformer", "cross_attn", "transformer+is_x_emb_seq"],
+)
+def test_all_architectures_build(net, batch_y_3d, is_x_emb_seq_kwarg):
+    """All four architectures must build without error."""
+    from sbi.neural_nets.net_builders.vector_field_nets import (
+        build_vector_field_estimator,
+    )
+
+    batch_x = torch.randn(10, 3)
+    # Cross-attention needs sequence-shaped conditioning.
+    batch_y = torch.randn(10, 4, 8) if batch_y_3d else torch.randn(10, 5)
+
+    extra = {}
+    if is_x_emb_seq_kwarg is not None:
+        extra["is_x_emb_seq"] = is_x_emb_seq_kwarg
+
+    estimator = build_vector_field_estimator(
+        batch_x=batch_x,
+        batch_y=batch_y,
+        net=net,
+        estimator_type="flow",
+        **extra,
+    )
+    assert estimator is not None
+    assert estimator.input_shape == torch.Size([3])
+

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -1,0 +1,285 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import warnings
+from dataclasses import fields as dc_fields
+
+import pytest
+import torch
+from torch import zeros
+from torch.distributions import MultivariateNormal
+
+from sbi.inference import FMPE, NPSE
+from sbi.neural_nets.net_builders.estimator_configs import (
+    _FLOW_ONLY_FIELDS,
+    _SCORE_ONLY_FIELDS,
+    DensityEstimatorBuilder,
+    VectorFieldEstimatorBuilder,
+)
+
+
+@pytest.fixture
+def gaussian_sims():
+    prior = MultivariateNormal(zeros(2), torch.eye(2))
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+    return prior, theta, x
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_no_warning_for_valid_inputs(trainer_cls, gaussian_sims):
+    """None, builder, and callable should not emit FutureWarning."""
+    prior, _, _ = gaussian_sims
+    for inp in [None, VectorFieldEstimatorBuilder(model="mlp"), lambda t, x: None]:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            trainer_cls(prior=prior, vf_estimator=inp)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls,kwarg,match",
+    [
+        (NPSE, {"score_estimator": "mlp"}, "score_estimator"),
+        (FMPE, {"density_estimator": lambda t, x: None}, "density_estimator"),
+    ],
+    ids=["npse-score", "fmpe-density"],
+)
+def test_legacy_kwarg_warns(trainer_cls, kwarg, match, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.warns(FutureWarning, match=match):
+        trainer_cls(prior=prior, **kwarg)
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_wrong_builder_type_raises(trainer_cls, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.raises(TypeError, match="VectorFieldEstimatorBuilder"):
+        trainer_cls(prior=prior, vf_estimator=DensityEstimatorBuilder(model="maf"))
+
+
+def test_builder_invalid_model():
+    with pytest.raises(ValueError, match="Unknown model"):
+        VectorFieldEstimatorBuilder(model="invalid")
+
+
+@pytest.mark.parametrize(
+    "est_type,bad_field",
+    [("flow", {"sigma_min": 0.01}), ("score", {"gaussian_baseline": True})],
+    ids=["flow-rejects-score", "score-rejects-flow"],
+)
+def test_estimator_type_field_guard(est_type, bad_field):
+    with pytest.raises(ValueError, match="do not apply"):
+        VectorFieldEstimatorBuilder(estimator_type=est_type, **bad_field)
+
+
+def test_estimator_type_none_skips_field_guard():
+    """When estimator_type is None, flow/score field guard is skipped."""
+    # Should NOT raise even though sigma_min is a score-only field,
+    # because the guard is deferred to the trainer.
+    builder = VectorFieldEstimatorBuilder(model="mlp", sigma_min=0.01)
+    assert builder.estimator_type is None
+    assert builder.sigma_min == 0.01
+
+
+def test_estimator_type_none_build_raises():
+    """build() must raise if estimator_type is still None."""
+    builder = VectorFieldEstimatorBuilder(model="mlp")
+    with pytest.raises(ValueError, match="estimator_type is None"):
+        builder.build(
+            batch_input=torch.randn(10, 2),
+            batch_condition=torch.randn(10, 2),
+        )
+
+
+@pytest.mark.parametrize(
+    "trainer_cls,expected_type",
+    [(FMPE, "FlowMatchingEstimator"), (NPSE, "ScoreEstimator")],
+    ids=["fmpe-resolves-flow", "npse-resolves-score"],
+)
+def test_trainer_resolves_none_estimator_type(
+    trainer_cls, expected_type, gaussian_sims
+):
+    """Trainers must resolve estimator_type=None to the correct type."""
+    prior, theta, x = gaussian_sims
+    builder = VectorFieldEstimatorBuilder(model="mlp")
+    assert builder.estimator_type is None
+    trainer = trainer_cls(prior=prior, vf_estimator=builder)
+    trainer.append_simulations(theta, x)
+    est = trainer.train(max_num_epochs=1, training_batch_size=100)
+    assert expected_type in type(est).__name__
+
+
+@pytest.mark.parametrize(
+    "trainer_cls,wrong_type,match",
+    [
+        (FMPE, "score", "flow-matching"),
+        (NPSE, "flow", "score estimators"),
+    ],
+    ids=["fmpe-rejects-score", "npse-rejects-flow"],
+)
+def test_trainer_rejects_wrong_estimator_type(
+    trainer_cls, wrong_type, match, gaussian_sims
+):
+    """Trainer must raise when given a builder with the wrong estimator_type."""
+    prior, _, _ = gaussian_sims
+    with pytest.raises(ValueError, match=match):
+        trainer_cls(
+            prior=prior,
+            vf_estimator=VectorFieldEstimatorBuilder(
+                model="mlp", estimator_type=wrong_type
+            ),
+        )
+
+
+def test_per_arch_validation_rejects_num_heads_on_mlp():
+    """num_heads is transformer-only; must be rejected for model='mlp'."""
+    with pytest.raises(ValueError, match="num_heads"):
+        VectorFieldEstimatorBuilder(model="mlp", num_heads=8)
+
+
+def test_score_accepts_score_fields():
+    builder = VectorFieldEstimatorBuilder(
+        estimator_type="score",
+        sde_type="ve",
+        sigma_min=0.01,
+        sigma_max=50.0,
+    )
+    assert builder.sigma_min == 0.01
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_train_with_builder(trainer_cls, gaussian_sims):
+    """End-to-end: train with VectorFieldEstimatorBuilder and sample."""
+    prior, theta, x = gaussian_sims
+    est_type = "score" if trainer_cls is NPSE else "flow"
+    builder_kwargs = {"model": "mlp", "estimator_type": est_type}
+    if trainer_cls is NPSE:
+        builder_kwargs["sde_type"] = "ve"
+
+    trainer = trainer_cls(
+        prior=prior,
+        vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
+    )
+    trainer.append_simulations(theta, x)
+    estimator = trainer.train(max_num_epochs=2, training_batch_size=100)
+
+    assert estimator is not None
+    posterior = trainer.build_posterior(estimator)
+    samples = posterior.sample((10,), x=torch.randn(1, 2))
+    assert samples.shape == (10, 2)
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_builder_role_shapes(trainer_cls, gaussian_sims):
+    """Asymmetric dims catch silent role swaps (Decision 10/13)."""
+    prior = MultivariateNormal(zeros(2), torch.eye(2))
+    theta = prior.sample((200,))
+    x = theta.sum(dim=-1, keepdim=True) + 0.1 * torch.randn(200, 5)
+
+    est_type = "score" if trainer_cls is NPSE else "flow"
+    builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
+    trainer = trainer_cls(prior=prior, vf_estimator=builder)
+    trainer.append_simulations(theta, x)
+    estimator = trainer.train(max_num_epochs=1, training_batch_size=100)
+
+    assert estimator.input_shape == torch.Size([2])
+    assert estimator.condition_shape == torch.Size([5])
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_warning_includes_import_path(trainer_cls, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.warns(FutureWarning, match="from sbi.neural_nets import"):
+        trainer_cls(prior=prior, vf_estimator="mlp")
+
+
+def test_score_only_fields_match_config():
+    """_SCORE_ONLY_FIELDS must stay in sync with ScoreEstimatorConfig."""
+    from sbi.neural_nets.net_builders.vector_field_nets import (
+        ScoreEstimatorConfig,
+        _VectorFieldBaseConfig,
+    )
+
+    score_diff = {f.name for f in dc_fields(ScoreEstimatorConfig)} - {
+        f.name for f in dc_fields(_VectorFieldBaseConfig)
+    }
+    assert score_diff | {"sde_type"} == _SCORE_ONLY_FIELDS
+
+
+def test_flow_only_fields_match_config():
+    """_FLOW_ONLY_FIELDS must stay in sync with FlowEstimatorConfig."""
+    from sbi.neural_nets.net_builders.vector_field_nets import (
+        FlowEstimatorConfig,
+        _VectorFieldBaseConfig,
+    )
+
+    flow_diff = {f.name for f in dc_fields(FlowEstimatorConfig)} - {
+        f.name for f in dc_fields(_VectorFieldBaseConfig)
+    }
+    assert flow_diff == _FLOW_ONLY_FIELDS
+
+
+@pytest.mark.parametrize(
+    "trainer_cls,kwarg",
+    [
+        (NPSE, {"score_estimator": "mlp"}),
+        (NPSE, {"density_estimator": lambda t, x: None}),
+        (FMPE, {"density_estimator": lambda t, x: None}),
+    ],
+    ids=["npse-score", "npse-density", "fmpe-density"],
+)
+def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
+    """Passing a deprecated kwarg alongside vf_estimator should raise."""
+    prior, _, _ = gaussian_sims
+    est_type = "score" if trainer_cls is NPSE else "flow"
+    with pytest.raises(ValueError, match="Cannot pass both"):
+        trainer_cls(
+            prior=prior,
+            vf_estimator=VectorFieldEstimatorBuilder(estimator_type=est_type),
+            **kwarg,
+        )
+
+
+def test_npse_sde_type_conflict_with_builder(gaussian_sims):
+    """Builder's sde_type is authoritative; trainer-level conflicts raise."""
+    prior, _, _ = gaussian_sims
+    with pytest.raises(ValueError, match="sde_type"):
+        NPSE(
+            prior=prior,
+            vf_estimator=VectorFieldEstimatorBuilder(
+                estimator_type="score",
+                sde_type="ve",
+            ),
+            sde_type="vp",
+        )
+
+
+@pytest.mark.parametrize("est_type", ["flow", "score"])
+def test_default_builder_applies_z_scoring(est_type):
+    """Default builder must z-score inputs, matching posterior_flow_nn defaults."""
+    theta = torch.randn(200, 2) + 5.0
+    x = theta + 0.1 * torch.randn_like(theta)
+    builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
+    estimator = builder.build(batch_input=theta, batch_condition=x)
+    if est_type == "flow":
+        mean_attr, std_attr = "mean_0", "std_0"
+    else:
+        mean_attr, std_attr = "_mean_base", "_std_base"
+
+    mean = getattr(estimator, mean_attr)
+    std = getattr(estimator, std_attr)
+    assert not torch.equal(mean, torch.zeros_like(mean)), (
+        f"{mean_attr} is all zeros: z-scoring was not applied to the input"
+    )
+    assert not torch.equal(std, torch.ones_like(std)), (
+        f"{std_attr} is all ones: z-scoring was not applied to the input"
+    )
+
+    from sbi.utils.sbiutils import Standardize
+
+    has_standardize = any(
+        isinstance(m, Standardize) for m in estimator.embedding_net.modules()
+    )
+    assert has_standardize, (
+        "embedding_net has no Standardize layer: z-scoring was not applied to y"
+    )

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -241,24 +241,24 @@ def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
 
 
 @pytest.mark.parametrize(
-    "builder_sde,trainer_sde,should_raise",
+    "builder_sde,trainer_sde,should_raise,expected_cls",
     [
-        # values agree then no error
-        ("ve", "ve", False),
+        # values agree then no error, uses the agreed value
+        ("ve", "ve", False, "VEScoreEstimator"),
         # values conflict then must raise
-        ("ve", "vp", True),
-        # builder only (trainer omits) then no error
-        ("vp", None, False),
-        # trainer only (no builder) then no error, forwarded to default builder
-        (None, "vp", False),
+        ("ve", "vp", True, None),
+        # builder only (trainer omits) then no error, builder's value wins
+        ("vp", None, False, "VPScoreEstimator"),
+        # builder sde_type unset, trainer explicit then trainer's value forwarded
+        (None, "vp", False, "VPScoreEstimator"),
     ],
     ids=["agree", "conflict", "builder-only", "trainer-only"],
 )
 def test_npse_sde_type_interactions(
-    builder_sde, trainer_sde, should_raise, gaussian_sims
+    builder_sde, trainer_sde, should_raise, expected_cls, gaussian_sims
 ):
     """sde_type must raise only when both are supplied and they disagree."""
-    prior, _, _ = gaussian_sims
+    prior, theta, x = gaussian_sims
 
     builder_kwargs = {"estimator_type": "score"}
     if builder_sde is not None:
@@ -275,10 +275,14 @@ def test_npse_sde_type_interactions(
                 **trainer_kwargs,
             )
     else:
-        # Should not raise.
-        NPSE(
+        trainer = NPSE(
             vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
             **trainer_kwargs,
+        )
+        trainer.append_simulations(theta, x)
+        estimator = trainer.train(max_num_epochs=1, training_batch_size=100)
+        assert type(estimator).__name__ == expected_cls, (
+            f"Expected {expected_cls}, got {type(estimator).__name__}"
         )
 
 

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -170,7 +170,7 @@ def test_train_with_builder(trainer_cls, gaussian_sims):
 
 
 @pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_builder_role_shapes(trainer_cls, gaussian_sims):
+def test_builder_role_shapes(trainer_cls):
     """Asymmetric dims catch silent role swaps (Decision 10/13)."""
     prior = MultivariateNormal(zeros(2), torch.eye(2))
     theta = prior.sample((200,))
@@ -261,18 +261,13 @@ def test_default_builder_applies_z_scoring(est_type):
     x = theta + 0.1 * torch.randn_like(theta)
     builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
     estimator = builder.build(batch_input=theta, batch_condition=x)
-    if est_type == "flow":
-        mean_attr, std_attr = "mean_0", "std_0"
-    else:
-        mean_attr, std_attr = "_mean_base", "_std_base"
-
-    mean = getattr(estimator, mean_attr)
-    std = getattr(estimator, std_attr)
+    mean = estimator.mean_0
+    std = estimator.std_0
     assert not torch.equal(mean, torch.zeros_like(mean)), (
-        f"{mean_attr} is all zeros: z-scoring was not applied to the input"
+        "mean_0 is all zeros: z-scoring was not applied to the input"
     )
     assert not torch.equal(std, torch.ones_like(std)), (
-        f"{std_attr} is all ones: z-scoring was not applied to the input"
+        "std_0 is all ones: z-scoring was not applied to the input"
     )
 
     from sbi.utils.sbiutils import Standardize


### PR DESCRIPTION
## What does this PR do?

This PR continues the [GSoC 2026 Neural Network Builder API refactor](https://summerofcode.withgoogle.com/programs/2026/projects/P5QOhl9F) by introducing the `VectorFieldEstimatorBuilder` for both vector field trainers (`FMPE` & `NPSE`).

Instead of passing a string like `vf_estimator="mlp"` and configuring everything through factory functions, users can now pass a fully typed builder: `VectorFieldEstimatorBuilder(model="mlp", hidden_features=128)`. The builder covers all four network architectures (`mlp`, `ada_mlp`, `transformer`, `transformer_cross_attn`) and provides immediate validation — passing score-only arguments (like `beta_min`) to a flow-matching builder, architecture-specific fields to the wrong model (like `num_heads` for `"mlp"`), or `sde_type` mismatches all fail fast with helpful error messages.

The `estimator_type` field defaults to `None` and is automatically resolved by the trainer (`FMPE` → `"flow"`, `NPSE` → `"score"`), so users don't need to specify it unless they want explicit control. This brings `FMPE` and `NPSE` fully in line with the builder pattern previously added for `NPE`, `NLE`, and `NRE`.

## Files Changed

- **`estimator_configs.py`**: Added the `VectorFieldEstimatorBuilder` frozen dataclass with full typing, `estimator_type`/`sde_type` field guards, and per-architecture validation via `_reject_inapplicable_fields`.
- **`vector_field_nets.py`**: Fixed `time_emb_type` default to `"sinusoidal"` for parity with the factory path.
- **`fmpe.py` & `npse.py`**: Updated the trainers to accept `VectorFieldEstimatorBuilder`, resolve `estimator_type=None`, and reject mismatched types. Passing a string is still supported but emits a `FutureWarning`.
- **`base_vf_inference.py`**: Removed `None` from the base class signature and deleted the unreachable branch (subclasses own the default).
- **`trainers/base.py`**: Lifted `_wrap_builder` into `NeuralInference`, fixed docstring typo, and typed the `builder` parameter.
- **`nre_base.py`**: Removed the duplicate `_wrap_builder` (identical to the inherited base version).
- **`score_estimator.py`**: Fixed overlapping-memory crash by cloning `mean_0` / `std_0` in the score estimator constructor.
- **`tests/vf_builder_integration_test.py`**: Added tests for builder integration, `estimator_type` auto-resolution, cross-trainer rejection, per-architecture validation, conflict guards, and deprecation warnings.

## AI Usage

Used Grammarly for PR description refinement, VS Code Copilot for code suggestions, and GPT OSS via Antigravity for docstrings and cosmetic updates. Some tests were improved during review by Claude Opus 4.6 via Antigravity.

## Does this close any issues?

N/A
