### PR TITLE
fixed outdated copyright statement in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,12 +18,17 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 import shutil
+import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = 'sbi'
-copyright = '2020, sbi team'
+
+today = datetime.datetime.today()
+current_year = today.strftime('%Y')
+
 author = 'sbi team'
+copyright = f'2020-{current_year}, {author}'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,17 +18,12 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 import shutil
-import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = 'sbi'
-
-start_year = 2020
-current_year = datetime.date.today().year
-
 author = 'sbi team'
-copyright = f'{start_year}, {author}' if current_year == start_year else f'{start_year}-{current_year}, {author}'
+copyright = f'2020-%Y, {author}'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,11 +24,11 @@ import datetime
 
 project = 'sbi'
 
-today = datetime.datetime.today()
-current_year = today.strftime('%Y')
+start_year = 2020
+current_year = datetime.date.today().year
 
 author = 'sbi team'
-copyright = f'2020-{current_year}, {author}'
+copyright = f'{start_year}, {author}' if current_year == start_year else f'{start_year}-{current_year}, {author}'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
I saw that the docs report an outdated year for the copyright:

<img width="1165" height="445" alt="image" src="https://github.com/user-attachments/assets/1d138f00-42ea-4bc3-9d5d-c237d9efd657" />

This PR contains a fix that adds current copyright year at time of the docs being built. I hope this fix is future proof. 