### PR TITLE
chore: make Dependabot GitHub Actions updates monthly and grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Reduce PR noise from routine GitHub Actions version bumps:

- Switch the `github-actions` update interval from **weekly → monthly**.
- **Group** all action updates into a single PR (catch-all `patterns: ["*"]`) instead of one PR per action.

Net effect: the recurring stream of individual action-bump PRs (e.g. `actions/cache`, `astral-sh/setup-uv`, `docker/login-action`) collapses to roughly **one grouped PR per month**.

## What this does *not* change

Dependabot **security updates** are advisory-driven and enabled in repo settings, independent of this schedule — they will keep opening promptly regardless of the monthly interval. Python (`uv`) dependencies remain covered by security updates only, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)