### PR TITLE
fix: transform_to_unconstrained follows device moves for Zuko flows (#1893)

### DIFF
--- a/sbi/neural_nets/estimators/zuko_flow.py
+++ b/sbi/neural_nets/estimators/zuko_flow.py
@@ -40,8 +40,7 @@ class ZukoFlow(ConditionalDensityEstimator):
             condition_shape: Event shape of the condition.
             prior_transform: Optional unconstrained prior transform prepended to the
                 flow (for ``z_score_x="transform_to_unconstrained"``). Kept as a
-                reference so it follows ``.to()``/``.double()``; its tensors are
-                buried in a plain attribute that ``nn.Module`` cannot reach.
+                reference so it follows ``.to()``/``.double()``.
         """
 
         # assert len(condition_shape) == 1, "Zuko Flows require 1D conditions."

--- a/sbi/neural_nets/estimators/zuko_flow.py
+++ b/sbi/neural_nets/estimators/zuko_flow.py
@@ -1,7 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor, nn
@@ -11,7 +11,8 @@ from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
     UnconditionalDensityEstimator,
 )
-from sbi.sbi_types import Shape
+from sbi.sbi_types import Shape, TorchTransform
+from sbi.utils.sbiutils import _apply_to_transform
 
 
 class ZukoFlow(ConditionalDensityEstimator):
@@ -27,6 +28,7 @@ class ZukoFlow(ConditionalDensityEstimator):
         embedding_net: nn.Module,
         input_shape: torch.Size,
         condition_shape: torch.Size,
+        prior_transform: Optional[TorchTransform] = None,
     ):
         r"""Initialize the conditional density estimator.
 
@@ -36,6 +38,10 @@ class ZukoFlow(ConditionalDensityEstimator):
                 density is being evaluated (and which is also the event_shape
                 of samples).
             condition_shape: Event shape of the condition.
+            prior_transform: Optional unconstrained prior transform prepended to the
+                flow (for ``z_score_x="transform_to_unconstrained"``). Kept as a
+                reference so it follows ``.to()``/``.double()``; its tensors are
+                buried in a plain attribute that ``nn.Module`` cannot reach.
         """
 
         # assert len(condition_shape) == 1, "Zuko Flows require 1D conditions."
@@ -43,6 +49,13 @@ class ZukoFlow(ConditionalDensityEstimator):
             net=net, input_shape=input_shape, condition_shape=condition_shape
         )
         self._embedding_net = embedding_net
+        self._prior_transform = prior_transform
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        if self._prior_transform is not None:
+            _apply_to_transform(self._prior_transform, fn)
+        return self
 
     @property
     def embedding_net(self) -> nn.Module:

--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -1295,9 +1295,7 @@ def _prepare_x_transforms(
     Returns:
         Tuple ``(transforms, prior_transform)``: the transforms to prepend (empty
         tuple if no preprocessing) and the raw unconstrained prior transform
-        (``None`` unless ``z_score_x == "transform_to_unconstrained"``). The latter
-        is returned so the estimator can keep a reference and move it with ``.to()``
-        (it is otherwise buried in a plain attribute invisible to ``nn.Module``).
+        (``None`` unless ``z_score_x == "transform_to_unconstrained"``).
     """
     transforms = ()
     prior_transform = None

--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -18,6 +18,7 @@ from zuko.lazy import Flow, LazyDistribution
 
 from sbi.neural_nets.estimators import NFlowsFlow, ZukoFlow, ZukoUnconditionalFlow
 from sbi.neural_nets.estimators.tabpfn_flow import TabPFNFlow
+from sbi.sbi_types import TorchTransform
 from sbi.utils.nn_utils import MADEMoGWrapper, get_numel
 from sbi.utils.sbiutils import (
     assert_transform_to_unconstrained_supported,
@@ -1148,7 +1149,7 @@ def build_zuko_flow(
     )
 
     # Get x transforms (z-score or logit transform)
-    x_transforms = _prepare_x_transforms(z_score_x, batch_x, x_dist)
+    x_transforms, prior_transform = _prepare_x_transforms(z_score_x, batch_x, x_dist)
 
     # Combine all transforms
     transforms = x_transforms + base_transforms
@@ -1164,6 +1165,7 @@ def build_zuko_flow(
         embedding_net,
         input_shape=batch_x[0].shape,
         condition_shape=batch_y[0].shape,
+        prior_transform=prior_transform,
     )
 
     return flow
@@ -1281,7 +1283,7 @@ def _prepare_x_transforms(
     ],
     batch_x: Tensor,
     x_dist: Optional[Distribution],
-) -> tuple:
+) -> Tuple[Tuple, Optional[TorchTransform]]:
     """
     Prepare transforms to prepend for x processing.
 
@@ -1291,9 +1293,14 @@ def _prepare_x_transforms(
         x_dist: Distribution for unconstrained transformation.
 
     Returns:
-        Tuple of transforms to prepend (empty tuple if no preprocessing).
+        Tuple ``(transforms, prior_transform)``: the transforms to prepend (empty
+        tuple if no preprocessing) and the raw unconstrained prior transform
+        (``None`` unless ``z_score_x == "transform_to_unconstrained"``). The latter
+        is returned so the estimator can keep a reference and move it with ``.to()``
+        (it is otherwise buried in a plain attribute invisible to ``nn.Module``).
     """
     transforms = ()
+    prior_transform = None
     z_score_x_bool, structured_x = z_score_parser(z_score_x)
     if z_score_x == "transform_to_unconstrained":
         if x_dist is None:
@@ -1306,13 +1313,13 @@ def _prepare_x_transforms(
                 "`x_dist` requires a `.support` attribute for"
                 "an unconstrained transformation."
             )
-        transform_to_unconstrained = biject_transform_zuko(mcmc_transform(x_dist))
-        transforms = (transform_to_unconstrained,)
+        prior_transform = mcmc_transform(x_dist, device=batch_x.device)
+        transforms = (biject_transform_zuko(prior_transform),)
     elif z_score_x_bool:
         z_score_transform = standardizing_transform_zuko(batch_x, structured_x)
         transforms = (z_score_transform,)
 
-    return transforms
+    return transforms, prior_transform
 
 
 def build_zuko_unconditional_flow(

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -811,17 +811,19 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
     return theta_repeated, x_repeated
 
 
-def _apply_to_transform(
-    transform: TorchTransform, fn: Callable[[Tensor], Tensor]
+def _walk_transform_tensors(
+    transform: TorchTransform, visit: Callable[[object, str, Tensor], None]
 ) -> None:
-    """Apply fn to all tensors in a transform tree.
+    """Walk a transform tree, calling ``visit(holder, key, tensor)`` per tensor.
 
-    Walks ComposeTransform.parts, IndependentTransform.base_transform,
-    etc., so .to() calls propagate into the transform.
+    Traverses ``ComposeTransform.parts``, ``IndependentTransform.base_transform``,
+    etc., so callers can move (``.to()``) or collect the tensors held inside a
+    transform, which are otherwise invisible to ``nn.Module._apply``.
 
     Args:
         transform: Root of the transform tree.
-        fn: Callable applied to each tensor (e.g. ``lambda t: t.to(device)``).
+        visit: Callback invoked for each tensor with its holder object and
+            attribute name, e.g. to reassign or accumulate it.
     """
     seen = set()
 
@@ -831,7 +833,7 @@ def _apply_to_transform(
         seen.add(id(t))
         for key, val in list(t.__dict__.items()):
             if isinstance(val, Tensor):
-                object.__setattr__(t, key, fn(val))
+                visit(t, key, val)
             elif isinstance(val, (list, tuple)):
                 for item in val:
                     if isinstance(item, TorchTransform):
@@ -842,10 +844,27 @@ def _apply_to_transform(
     _walk(transform)
 
 
-def _transform_tensors(
-    transform: TorchTransform,
-) -> List[Tensor]:
-    """Collect every tensor in a transform tree (mirror of _apply_to_transform).
+def _apply_to_transform(
+    transform: TorchTransform, fn: Callable[[Tensor], Tensor]
+) -> None:
+    """Apply fn to all tensors in a transform tree.
+
+    So ``.to()``/``.double()`` calls propagate into a transform held as a plain
+    attribute (e.g. a prior transform on an estimator).
+
+    Args:
+        transform: Root of the transform tree.
+        fn: Callable applied to each tensor (e.g. ``lambda t: t.to(device)``).
+    """
+
+    def _move(holder, key, tensor):
+        object.__setattr__(holder, key, fn(tensor))
+
+    _walk_transform_tensors(transform, _move)
+
+
+def _transform_tensors(transform: TorchTransform) -> List[Tensor]:
+    """Collect every tensor in a transform tree.
 
     Args:
         transform: Root of the transform tree.
@@ -853,24 +872,10 @@ def _transform_tensors(
     Returns:
         List of all tensors found in the transform tree.
     """
-    seen = set()
     tensors: List[Tensor] = []
-
-    def _walk(t):
-        if id(t) in seen:
-            return
-        seen.add(id(t))
-        for val in t.__dict__.values():
-            if isinstance(val, Tensor):
-                tensors.append(val)
-            elif isinstance(val, (list, tuple)):
-                for item in val:
-                    if isinstance(item, TorchTransform):
-                        _walk(item)
-            elif isinstance(val, TorchTransform):
-                _walk(val)
-
-    _walk(transform)
+    _walk_transform_tensors(
+        transform, lambda _holder, _key, tensor: tensors.append(tensor)
+    )
     return tensors
 
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -811,19 +811,19 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
     return theta_repeated, x_repeated
 
 
-def _walk_transform_tensors(
-    transform: TorchTransform, visit: Callable[[object, str, Tensor], None]
+def _apply_to_transform(
+    transform: TorchTransform, fn: Callable[[Tensor], Tensor]
 ) -> None:
-    """Walk a transform tree, calling ``visit(holder, key, tensor)`` per tensor.
+    """Apply fn to all tensors in a transform tree, in place.
 
-    Traverses ``ComposeTransform.parts``, ``IndependentTransform.base_transform``,
-    etc., so callers can move (``.to()``) or collect the tensors held inside a
-    transform, which are otherwise invisible to ``nn.Module._apply``.
+    So ``.to()``/``.double()`` calls propagate into a transform held as a plain
+    attribute (e.g. a prior transform on an estimator), which is otherwise
+    invisible to ``nn.Module._apply``. Traverses ``ComposeTransform.parts``,
+    ``IndependentTransform.base_transform`` and nested inverses.
 
     Args:
         transform: Root of the transform tree.
-        visit: Callback invoked for each tensor with its holder object and
-            attribute name, e.g. to reassign or accumulate it.
+        fn: Callable applied to each tensor (e.g. ``lambda t: t.to(device)``).
     """
     seen = set()
 
@@ -833,7 +833,7 @@ def _walk_transform_tensors(
         seen.add(id(t))
         for key, val in list(t.__dict__.items()):
             if isinstance(val, Tensor):
-                visit(t, key, val)
+                object.__setattr__(t, key, fn(val))
             elif isinstance(val, (list, tuple)):
                 for item in val:
                     if isinstance(item, TorchTransform):
@@ -842,41 +842,6 @@ def _walk_transform_tensors(
                 _walk(val)
 
     _walk(transform)
-
-
-def _apply_to_transform(
-    transform: TorchTransform, fn: Callable[[Tensor], Tensor]
-) -> None:
-    """Apply fn to all tensors in a transform tree.
-
-    So ``.to()``/``.double()`` calls propagate into a transform held as a plain
-    attribute (e.g. a prior transform on an estimator).
-
-    Args:
-        transform: Root of the transform tree.
-        fn: Callable applied to each tensor (e.g. ``lambda t: t.to(device)``).
-    """
-
-    def _move(holder, key, tensor):
-        object.__setattr__(holder, key, fn(tensor))
-
-    _walk_transform_tensors(transform, _move)
-
-
-def _transform_tensors(transform: TorchTransform) -> List[Tensor]:
-    """Collect every tensor in a transform tree.
-
-    Args:
-        transform: Root of the transform tree.
-
-    Returns:
-        List of all tensors found in the transform tree.
-    """
-    tensors: List[Tensor] = []
-    _walk_transform_tensors(
-        transform, lambda _holder, _key, tensor: tensors.append(tensor)
-    )
-    return tensors
 
 
 def mcmc_transform(

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -58,6 +58,25 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _collect_transform_tensors(transform):
+    """Collect every tensor in a transform tree, reusing the production walk.
+
+    Test helper for the transform_to_unconstrained device/dtype checks: drives
+    ``_apply_to_transform`` with a recording identity fn so we don't duplicate the
+    tree-walk in the tests.
+    """
+    from sbi.utils.sbiutils import _apply_to_transform
+
+    collected = []
+
+    def _record(tensor):
+        collected.append(tensor)
+        return tensor
+
+    _apply_to_transform(transform, _record)
+    return collected
+
+
 @pytest.mark.slow
 @pytest.mark.gpu
 @pytest.mark.parametrize(
@@ -897,7 +916,6 @@ def test_npe_pfn_on_device(prior_device):
 def test_mdn_device_transform():
     """MDN with transform_to_unconstrained moves transform tensors on .to()."""
     from sbi.neural_nets.net_builders.mdn import build_mdn
-    from sbi.utils.sbiutils import _transform_tensors
 
     device = process_device("gpu")
     prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
@@ -905,7 +923,7 @@ def test_mdn_device_transform():
     est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
     est.to(device)
 
-    transform_tensors = _transform_tensors(est._prior_transform)
+    transform_tensors = _collect_transform_tensors(est._prior_transform)
     assert transform_tensors, "expected the prior transform to hold tensors"
     for t in transform_tensors:
         assert t.device.type == device.split(":")[0], (
@@ -928,7 +946,6 @@ def test_mdn_transform_follows_dtype():
     Runs on every CI (no GPU needed).
     """
     from sbi.neural_nets.net_builders.mdn import build_mdn
-    from sbi.utils.sbiutils import _transform_tensors
 
     prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
     bx, by = prior.sample((256,)), torch.randn(256, 3)
@@ -936,7 +953,7 @@ def test_mdn_transform_follows_dtype():
 
     est.double()
 
-    transform_tensors = _transform_tensors(est._prior_transform)
+    transform_tensors = _collect_transform_tensors(est._prior_transform)
     assert transform_tensors, "expected the prior transform to hold tensors"
     assert all(t.dtype == torch.float64 for t in transform_tensors)
 
@@ -950,7 +967,6 @@ def test_mdn_transform_follows_dtype():
 def test_zuko_device_transform():
     """Zuko flow with transform_to_unconstrained moves transform tensors on .to()."""
     from sbi.neural_nets.net_builders.flow import build_zuko_maf
-    from sbi.utils.sbiutils import _transform_tensors
 
     device = process_device("gpu")
     prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
@@ -958,7 +974,7 @@ def test_zuko_device_transform():
     est = build_zuko_maf(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
     est.to(device)
 
-    transform_tensors = _transform_tensors(est._prior_transform)
+    transform_tensors = _collect_transform_tensors(est._prior_transform)
     assert transform_tensors, "expected the prior transform to hold tensors"
     for t in transform_tensors:
         assert t.device.type == device.split(":")[0], (
@@ -982,7 +998,6 @@ def test_zuko_transform_follows_dtype():
     .double()/.to() cast would silently leave it on the old dtype/device.
     """
     from sbi.neural_nets.net_builders.flow import build_zuko_maf
-    from sbi.utils.sbiutils import _transform_tensors
 
     prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
     bx, by = prior.sample((256,)), torch.randn(256, 3)
@@ -990,6 +1005,6 @@ def test_zuko_transform_follows_dtype():
 
     est.double()
 
-    transform_tensors = _transform_tensors(est._prior_transform)
+    transform_tensors = _collect_transform_tensors(est._prior_transform)
     assert transform_tensors, "expected the prior transform to hold tensors"
     assert all(t.dtype == torch.float64 for t in transform_tensors)

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -912,9 +912,12 @@ def test_npe_pfn_on_device(prior_device):
     )
 
 
-@pytest.mark.gpu
 def test_mdn_device_transform():
-    """MDN with transform_to_unconstrained moves transform tensors on .to()."""
+    """MDN with transform_to_unconstrained moves transform tensors on .to().
+
+    Runs on any available accelerator (CUDA or MPS); the module-level skipif
+    gates it off on CPU-only machines.
+    """
     from sbi.neural_nets.net_builders.mdn import build_mdn
 
     device = process_device("gpu")
@@ -963,9 +966,12 @@ def test_mdn_transform_follows_dtype():
     assert lp.dtype == torch.float64
 
 
-@pytest.mark.gpu
 def test_zuko_device_transform():
-    """Zuko flow with transform_to_unconstrained moves transform tensors on .to()."""
+    """Zuko flow with transform_to_unconstrained moves transform tensors on .to().
+
+    Runs on any available accelerator (CUDA or MPS); the module-level skipif
+    gates it off on CPU-only machines.
+    """
     from sbi.neural_nets.net_builders.flow import build_zuko_maf
 
     device = process_device("gpu")

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -944,3 +944,52 @@ def test_mdn_transform_follows_dtype():
     cond = torch.randn(1, 3).double()
     lp = est.log_prob(theta.unsqueeze(1), cond)
     assert lp.dtype == torch.float64
+
+
+@pytest.mark.gpu
+def test_zuko_device_transform():
+    """Zuko flow with transform_to_unconstrained moves transform tensors on .to()."""
+    from sbi.neural_nets.net_builders.flow import build_zuko_maf
+    from sbi.utils.sbiutils import _transform_tensors
+
+    device = process_device("gpu")
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((512,)), torch.randn(512, 3)
+    est = build_zuko_maf(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+    est.to(device)
+
+    transform_tensors = _transform_tensors(est._prior_transform)
+    assert transform_tensors, "expected the prior transform to hold tensors"
+    for t in transform_tensors:
+        assert t.device.type == device.split(":")[0], (
+            f"transform tensor on {t.device}, expected {device}"
+        )
+
+    theta = prior.sample((5,)).to(device)
+    cond = torch.randn(1, 3).to(device)
+    lp = est.log_prob(theta.unsqueeze(1), cond)
+    assert lp.device.type == device.split(":")[0]
+    s = est.sample((10,), cond)
+    assert s.device.type == device.split(":")[0]
+
+
+def test_zuko_transform_follows_dtype():
+    """Zuko transform_to_unconstrained transform follows dtype casts.
+
+    Runs on every CI (no GPU needed): guards that the prior transform is reachable
+    by nn.Module._apply through the estimator's _apply override. Unlike the network
+    weights, the transform lives behind a plain attribute, so without the override a
+    .double()/.to() cast would silently leave it on the old dtype/device.
+    """
+    from sbi.neural_nets.net_builders.flow import build_zuko_maf
+    from sbi.utils.sbiutils import _transform_tensors
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((256,)), torch.randn(256, 3)
+    est = build_zuko_maf(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+
+    est.double()
+
+    transform_tensors = _transform_tensors(est._prior_transform)
+    assert transform_tensors, "expected the prior transform to hold tensors"
+    assert all(t.dtype == torch.float64 for t in transform_tensors)

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -711,14 +711,13 @@ def test_mdn_transform_to_unconstrained():
     assert s.shape[0] == 10 and torch.isfinite(s).all()
 
 
-def test_walk_transform_tensors_reaches_nested_tensors():
-    """The shared transform walker reaches tensors behind lists, nesting and .inv.
+def test_apply_to_transform_reaches_nested_tensors():
+    """`_apply_to_transform` reaches tensors behind lists, nesting and .inv.
 
-    Guards `_walk_transform_tensors` (and its `_apply_to_transform` /
-    `_transform_tensors` wrappers), which move a prior transform onto a device.
     The leaf `loc`/`scale` sit behind `_InverseTransform -> IndependentTransform ->
     ComposeTransform.parts (a list) -> AffineTransform`, so a walk that missed the
-    list branch or the inverse would silently move nothing.
+    list branch or the inverse would silently touch nothing. A dtype cast is the
+    observable effect: both leaves must change.
     """
     from torch.distributions.transforms import (
         AffineTransform,
@@ -726,22 +725,15 @@ def test_walk_transform_tensors_reaches_nested_tensors():
         SigmoidTransform,
     )
 
-    from sbi.utils.sbiutils import _apply_to_transform, _transform_tensors
+    from sbi.utils.sbiutils import _apply_to_transform
 
-    loc, scale = torch.zeros(3), torch.ones(3)
-    affine = AffineTransform(loc, scale)
+    affine = AffineTransform(torch.zeros(3), torch.ones(3))
     # matches the shape mcmc_transform produces for a bounded prior, then inverted.
     transform = IndependentTransform(
         ComposeTransform([SigmoidTransform(), affine]), 1
     ).inv
 
-    # collector reaches exactly the two leaf tensors (same objects), not zero.
-    tensors = _transform_tensors(transform)
-    assert len(tensors) == 2
-    assert any(t is loc for t in tensors)
-    assert any(t is scale for t in tensors)
-
-    # apply reaches every tensor via the same walk (dtype cast as an observable op).
+    assert affine.loc.dtype == torch.float32 and affine.scale.dtype == torch.float32
     _apply_to_transform(transform, lambda t: t.double())
     assert affine.loc.dtype == torch.float64
     assert affine.scale.dtype == torch.float64

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -709,3 +709,39 @@ def test_mdn_transform_to_unconstrained():
     assert torch.allclose(lp, mog.log_prob(z) + ldj, atol=1e-5)
     s = est.sample((10,), cond)
     assert s.shape[0] == 10 and torch.isfinite(s).all()
+
+
+def test_walk_transform_tensors_reaches_nested_tensors():
+    """The shared transform walker reaches tensors behind lists, nesting and .inv.
+
+    Guards `_walk_transform_tensors` (and its `_apply_to_transform` /
+    `_transform_tensors` wrappers), which move a prior transform onto a device.
+    The leaf `loc`/`scale` sit behind `_InverseTransform -> IndependentTransform ->
+    ComposeTransform.parts (a list) -> AffineTransform`, so a walk that missed the
+    list branch or the inverse would silently move nothing.
+    """
+    from torch.distributions.transforms import (
+        AffineTransform,
+        ComposeTransform,
+        SigmoidTransform,
+    )
+
+    from sbi.utils.sbiutils import _apply_to_transform, _transform_tensors
+
+    loc, scale = torch.zeros(3), torch.ones(3)
+    affine = AffineTransform(loc, scale)
+    # matches the shape mcmc_transform produces for a bounded prior, then inverted.
+    transform = IndependentTransform(
+        ComposeTransform([SigmoidTransform(), affine]), 1
+    ).inv
+
+    # collector reaches exactly the two leaf tensors (same objects), not zero.
+    tensors = _transform_tensors(transform)
+    assert len(tensors) == 2
+    assert any(t is loc for t in tensors)
+    assert any(t is scale for t in tensors)
+
+    # apply reaches every tensor via the same walk (dtype cast as an observable op).
+    _apply_to_transform(transform, lambda t: t.double())
+    assert affine.loc.dtype == torch.float64
+    assert affine.scale.dtype == torch.float64


### PR DESCRIPTION
Follow-up to #1896. Makes the `transform_to_unconstrained` z-scoring transform follow `.to()`/`.cuda()`/`.mps()` for Zuko flows. It already worked for MDN, but the Zuko path left the transform on CPU and crashed on a device mismatch.

The transform is a `torch.distributions.Transform` (not an `nn.Module`), buried in a plain `CallableTransform` attribute, so `nn.Module._apply` never moved its tensors. Fix: thread the device into `mcmc_transform`, keep a reference on `ZukoFlow`, and move it in an `_apply` override (mirrors the MDN estimator).

Also folds in a small cleanup of the #1896 walker: collapses the two near-identical tree-walkers into a single `_apply_to_transform` (the collector was test-only).

Tests: a gpu device test + an unmarked CPU dtype test for the Zuko path.

Part of #1893; the serialization fix follows in a stacked PR.

Written with Claude Code assistance.
