### PR TITLE
fix: make transform_to_unconstrained picklable (#1893)

### DIFF
--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -412,6 +412,21 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
             _apply_to_transform(self._prior_transform, fn)
         return self
 
+    def __getstate__(self):
+        # `_prior_transform` is an inverse transform whose data lives behind its
+        # `_inv` link; torch's Transform.__getstate__ nulls `_inv` on pickling,
+        # which would discard the transform. Store the forward instead (it pickles
+        # cleanly, carrying device/dtype) and re-invert it on load.
+        state = dict(super().__getstate__())
+        if self._prior_transform is not None:
+            state["_prior_transform"] = self._prior_transform.inv
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        if self._prior_transform is not None:
+            self._prior_transform = self._prior_transform.inv
+
     @property
     def embedding_net(self) -> nn.Module:
         """Return the embedding network."""

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -413,10 +413,8 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         return self
 
     def __getstate__(self):
-        # `_prior_transform` is an inverse transform whose data lives behind its
-        # `_inv` link; torch's Transform.__getstate__ nulls `_inv` on pickling,
-        # which would discard the transform. Store the forward instead (it pickles
-        # cleanly, carrying device/dtype) and re-invert it on load.
+        # torch drops an inverse transform's tensors on pickling; store the forward
+        # and re-invert on load.
         state = dict(super().__getstate__())
         if self._prior_transform is not None:
             state["_prior_transform"] = self._prior_transform.inv

--- a/sbi/neural_nets/estimators/mixture_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixture_density_estimator.py
@@ -17,6 +17,7 @@ from typing import Optional
 import numpy as np
 import torch
 from torch import Tensor, nn
+from torch.distributions.transforms import _InverseTransform
 from torch.nn import functional as F
 
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
@@ -413,17 +414,20 @@ class MixtureDensityEstimator(ConditionalDensityEstimator):
         return self
 
     def __getstate__(self):
-        # torch drops an inverse transform's tensors on pickling; store the forward
-        # and re-invert on load.
         state = dict(super().__getstate__())
-        if self._prior_transform is not None:
-            state["_prior_transform"] = self._prior_transform.inv
+        t = self._prior_transform
+        # torch drops an inverse transform's data (its `_inv`) on pickling; stash the
+        # wrapped forward and rebuild on load. Concrete transforms pickle fine as-is.
+        if isinstance(t, _InverseTransform):
+            state["_prior_transform"] = None
+            state["_prior_transform_forward"] = t.inv
         return state
 
     def __setstate__(self, state):
+        forward = state.pop("_prior_transform_forward", None)
         super().__setstate__(state)
-        if self._prior_transform is not None:
-            self._prior_transform = self._prior_transform.inv
+        if forward is not None:
+            self._prior_transform = forward.inv
 
     @property
     def embedding_net(self) -> nn.Module:

--- a/sbi/neural_nets/estimators/zuko_flow.py
+++ b/sbi/neural_nets/estimators/zuko_flow.py
@@ -59,36 +59,30 @@ class ZukoFlow(ConditionalDensityEstimator):
         return self
 
     def __getstate__(self):
-        # `_prior_transform` is the same inverse-transform object the flow holds
-        # (inside a CallableTransform). Torch would drop its data on pickling, so
-        # don't pickle this redundant reference — the CallableTransform pickles the
-        # transform correctly, and we re-link to it on load (see __setstate__). Keep
-        # a flag so __setstate__ can fail loudly if the re-link ever comes up empty.
+        # Store the forward (picklable); on load, re-link to the flow's own copy
+        # rather than this one, so device moves stay in sync (see __setstate__).
         state = dict(super().__getstate__())
-        state["_had_prior_transform"] = self._prior_transform is not None
-        state["_prior_transform"] = None
+        if self._prior_transform is not None:
+            state["_prior_transform"] = self._prior_transform.inv
         return state
 
     def __setstate__(self, state):
-        had_prior_transform = state.pop("_had_prior_transform", False)
         super().__setstate__(state)
-        self._prior_transform = self._find_prior_transform()
-        if had_prior_transform and self._prior_transform is None:
-            raise RuntimeError(
-                "ZukoFlow lost its prior transform while unpickling: it could not "
-                "be recovered from the flow. This likely means the installed `zuko` "
-                "version changed the flow's internal structure (the transform is "
-                "located via `zuko`'s `Partial.f` attribute in "
-                "`_find_prior_transform`)."
-            )
+        if self._prior_transform is not None:
+            self._prior_transform = self._find_prior_transform()
+            if self._prior_transform is None:
+                raise RuntimeError(
+                    "ZukoFlow lost its prior transform while unpickling: it could "
+                    "not be recovered from the flow. This likely means the installed "
+                    "`zuko` version changed the flow's internal structure (the "
+                    "transform is located via `zuko`'s `Partial.f` attribute in "
+                    "`_find_prior_transform`)."
+                )
 
     def _find_prior_transform(self) -> Optional[TorchTransform]:
         """Recover the prior transform from the flow's CallableTransform, if any.
 
-        Assumes at most one `CallableTransform` in the flow (true today: only the
-        single `transform_to_unconstrained` prior transform is wrapped this way).
-        Returns the first match; revisit if `_prepare_x_transforms` ever composes
-        multiple `CallableTransform`s.
+        Assumes at most one CallableTransform in the flow (true today).
         """
         for module in self.net.modules():
             wrapped = getattr(module, "f", None)

--- a/sbi/neural_nets/estimators/zuko_flow.py
+++ b/sbi/neural_nets/estimators/zuko_flow.py
@@ -40,7 +40,9 @@ class ZukoFlow(ConditionalDensityEstimator):
             condition_shape: Event shape of the condition.
             prior_transform: Optional unconstrained prior transform prepended to the
                 flow (for ``z_score_x="transform_to_unconstrained"``). Kept as a
-                reference so it follows ``.to()``/``.double()``.
+                reference so it follows ``.to()``/``.double()``. Preserved by
+                pickling the estimator (sbi's save path), not by ``state_dict()``;
+                reconstruct via the builder before ``load_state_dict()``.
         """
 
         # assert len(condition_shape) == 1, "Zuko Flows require 1D conditions."
@@ -60,18 +62,34 @@ class ZukoFlow(ConditionalDensityEstimator):
         # `_prior_transform` is the same inverse-transform object the flow holds
         # (inside a CallableTransform). Torch would drop its data on pickling, so
         # don't pickle this redundant reference — the CallableTransform pickles the
-        # transform correctly, and we re-link to it on load (see __setstate__).
+        # transform correctly, and we re-link to it on load (see __setstate__). Keep
+        # a flag so __setstate__ can fail loudly if the re-link ever comes up empty.
         state = dict(super().__getstate__())
-        if self._prior_transform is not None:
-            state["_prior_transform"] = None
+        state["_had_prior_transform"] = self._prior_transform is not None
+        state["_prior_transform"] = None
         return state
 
     def __setstate__(self, state):
+        had_prior_transform = state.pop("_had_prior_transform", False)
         super().__setstate__(state)
         self._prior_transform = self._find_prior_transform()
+        if had_prior_transform and self._prior_transform is None:
+            raise RuntimeError(
+                "ZukoFlow lost its prior transform while unpickling: it could not "
+                "be recovered from the flow. This likely means the installed `zuko` "
+                "version changed the flow's internal structure (the transform is "
+                "located via `zuko`'s `Partial.f` attribute in "
+                "`_find_prior_transform`)."
+            )
 
     def _find_prior_transform(self) -> Optional[TorchTransform]:
-        """Recover the prior transform from the flow's CallableTransform, if any."""
+        """Recover the prior transform from the flow's CallableTransform, if any.
+
+        Assumes at most one `CallableTransform` in the flow (true today: only the
+        single `transform_to_unconstrained` prior transform is wrapped this way).
+        Returns the first match; revisit if `_prepare_x_transforms` ever composes
+        multiple `CallableTransform`s.
+        """
         for module in self.net.modules():
             wrapped = getattr(module, "f", None)
             if isinstance(wrapped, CallableTransform):

--- a/sbi/neural_nets/estimators/zuko_flow.py
+++ b/sbi/neural_nets/estimators/zuko_flow.py
@@ -12,7 +12,7 @@ from sbi.neural_nets.estimators.base import (
     UnconditionalDensityEstimator,
 )
 from sbi.sbi_types import Shape, TorchTransform
-from sbi.utils.sbiutils import _apply_to_transform
+from sbi.utils.sbiutils import CallableTransform, _apply_to_transform
 
 
 class ZukoFlow(ConditionalDensityEstimator):
@@ -55,6 +55,28 @@ class ZukoFlow(ConditionalDensityEstimator):
         if self._prior_transform is not None:
             _apply_to_transform(self._prior_transform, fn)
         return self
+
+    def __getstate__(self):
+        # `_prior_transform` is the same inverse-transform object the flow holds
+        # (inside a CallableTransform). Torch would drop its data on pickling, so
+        # don't pickle this redundant reference — the CallableTransform pickles the
+        # transform correctly, and we re-link to it on load (see __setstate__).
+        state = dict(super().__getstate__())
+        if self._prior_transform is not None:
+            state["_prior_transform"] = None
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._prior_transform = self._find_prior_transform()
+
+    def _find_prior_transform(self) -> Optional[TorchTransform]:
+        """Recover the prior transform from the flow's CallableTransform, if any."""
+        for module in self.net.modules():
+            wrapped = getattr(module, "f", None)
+            if isinstance(wrapped, CallableTransform):
+                return wrapped.transform
+        return None
 
     @property
     def embedding_net(self) -> nn.Module:

--- a/sbi/neural_nets/net_builders/mdn.py
+++ b/sbi/neural_nets/net_builders/mdn.py
@@ -44,7 +44,10 @@ def build_mdn(
             over the entire batch, instead of per-dimension. Should be used when each
             sample is, for example, a time series or an image.
             - `transform_to_unconstrained`: transform inputs to unconstrained space
-            using the prior's support. Requires `x_dist` to be provided.
+            using the prior's support. Requires `x_dist` to be provided. This
+            transform follows `.to()`/`.cuda()`/`.double()` and is preserved by
+            pickling the estimator (the standard sbi save path), but is not part of
+            `state_dict()`; reconstruct via the builder before `load_state_dict()`.
         z_score_y: Whether to z-score ys passing into the network, same options as
             z_score_x.
         hidden_features: Number of hidden features.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -295,6 +295,16 @@ class CallableTransform:
     def __call__(self):
         return self.transform
 
+    def __getstate__(self):
+        # `transform` is an inverse transform whose data lives behind its `_inv`
+        # link, which torch's Transform.__getstate__ nulls on pickling. Store the
+        # forward instead (it pickles cleanly, keeping device/dtype) and re-invert
+        # on load, so a pickled Zuko flow keeps a working transform.
+        return {"transform": self.transform.inv}
+
+    def __setstate__(self, state):
+        self.transform = state["transform"].inv
+
 
 def biject_transform_zuko(
     transform: TorchTransform,

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -296,10 +296,8 @@ class CallableTransform:
         return self.transform
 
     def __getstate__(self):
-        # `transform` is an inverse transform whose data lives behind its `_inv`
-        # link, which torch's Transform.__getstate__ nulls on pickling. Store the
-        # forward instead (it pickles cleanly, keeping device/dtype) and re-invert
-        # on load, so a pickled Zuko flow keeps a working transform.
+        # torch drops an inverse transform's tensors on pickling; store the forward
+        # and re-invert on load.
         return {"transform": self.transform.inv}
 
     def __setstate__(self, state):

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -68,3 +68,27 @@ def test_picklability(
         pickle.dump(inference, handle)
     with open(f"{tmp_path}/saved_inference.pickle", "rb") as handle:
         _ = pickle.load(handle)
+
+
+def test_mdn_transform_to_unconstrained_picklable():
+    """An MDN using transform_to_unconstrained survives a pickle round-trip.
+
+    Regression: sbi stores the prior transform as an inverse transform, whose data
+    lives behind the `_inv` link that torch's Transform.__getstate__ nulls on
+    pickling. Naively pickling therefore discards the transform's tensors and yields
+    an object that raises "_inv must not be None" on first use.
+    """
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+    from sbi.utils import BoxUniform
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((256,)), torch.randn(256, 3)
+    est = build_mdn(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+
+    theta, cond = prior.sample((5,)).unsqueeze(1), torch.randn(1, 3)
+    expected = est.log_prob(theta, cond)
+
+    reloaded = pickle.loads(pickle.dumps(est))
+    actual = reloaded.log_prob(theta, cond)
+
+    assert torch.allclose(expected, actual)

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -94,6 +94,35 @@ def test_mdn_transform_to_unconstrained_picklable():
     assert torch.allclose(expected, actual)
 
 
+def test_mdn_pickle_preserves_concrete_prior_transform():
+    """A concrete (non-inverse) prior transform on an MDN survives pickling.
+
+    The `_inv`-dropping workaround only applies to inverse transforms. A concrete
+    forward transform (e.g. a user-supplied AffineTransform, as the __init__ contract
+    allows) must be pickled as-is; inverting it would wrap it in an inverse whose data
+    torch then drops on pickle.
+    """
+    from torch.distributions.transforms import AffineTransform
+
+    from sbi.neural_nets.net_builders.mdn import build_mdn
+    from sbi.utils import BoxUniform
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((256,)), torch.randn(256, 3)
+    est = build_mdn(bx, by)
+    # A concrete forward transform (maps constrained -> unconstrained), not the
+    # inverse wrapper that mcmc_transform produces.
+    est._prior_transform = AffineTransform(torch.zeros(2), 2 * torch.ones(2))
+
+    theta, cond = prior.sample((5,)).unsqueeze(1), torch.randn(1, 3)
+    expected = est.log_prob(theta, cond)
+
+    reloaded = pickle.loads(pickle.dumps(est))
+    actual = reloaded.log_prob(theta, cond)
+
+    assert torch.allclose(expected, actual)
+
+
 def test_zuko_transform_to_unconstrained_picklable():
     """A Zuko flow using transform_to_unconstrained survives a pickle round-trip.
 

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -92,3 +92,26 @@ def test_mdn_transform_to_unconstrained_picklable():
     actual = reloaded.log_prob(theta, cond)
 
     assert torch.allclose(expected, actual)
+
+
+def test_zuko_transform_to_unconstrained_picklable():
+    """A Zuko flow using transform_to_unconstrained survives a pickle round-trip.
+
+    Same root cause as the MDN case, but the transform is wrapped in a
+    CallableTransform inside the flow, and is additionally referenced by
+    ZukoFlow._prior_transform — both must come back consistent.
+    """
+    from sbi.neural_nets.net_builders.flow import build_zuko_maf
+    from sbi.utils import BoxUniform
+
+    prior = BoxUniform(-2 * torch.ones(2), 2 * torch.ones(2))
+    bx, by = prior.sample((256,)), torch.randn(256, 3)
+    est = build_zuko_maf(bx, by, z_score_x="transform_to_unconstrained", x_dist=prior)
+
+    theta, cond = prior.sample((5,)).unsqueeze(1), torch.randn(1, 3)
+    expected = est.log_prob(theta, cond)
+
+    reloaded = pickle.loads(pickle.dumps(est))
+    actual = reloaded.log_prob(theta, cond)
+
+    assert torch.allclose(expected, actual)


### PR DESCRIPTION
Stacked on #1932 (review/merge that first; this diff is only the last 3 commits).

Fixes pickling of MDN and Zuko estimators that use `transform_to_unconstrained`. Currently the reloaded object crashes with `AssertionError: _inv must not be None` on first use: the transform is stored as an inverse transform whose data lives behind the `_inv` link that torch's `Transform.__getstate__` nulls on pickling, so the tensors are silently dropped.

Fix: store the forward transform (which pickles cleanly, keeping device and dtype) and re-invert on load — via `__getstate__`/`__setstate__` on the MDN estimator and on `CallableTransform`. For Zuko, `ZukoFlow` re-links its reference to the flow's transform on load, and fails loudly if it can't (e.g. a future zuko internal change) rather than silently dropping device moves.

Pickling the whole posterior is sbi's supported save path, so this matters more than the `state_dict` gap — which we document instead of fixing (the transform is reconstructed via the builder; it's intentionally not carried in `state_dict()`).

Tests: pickle round-trip for both estimators.

Closes #1893.

Written with Claude Code assistance.
