### PR TITLE
surgical removal of x_o.setter

### DIFF
--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -69,11 +69,6 @@ class BasePotential(metaclass=ABCMeta):
                 "No observed data is available. Use `potential_fn.set_x(x_o)`."
             )
 
-    @x_o.setter
-    def x_o(self, x_o: Optional[Tensor]) -> None:
-        """Check the shape of the observed data and, if valid, set it."""
-        self.set_x(x_o)
-
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
 

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -479,7 +479,7 @@ class ElboOptimizer(DivergenceOptimizer):
             samples = self.q.rsample(torch.Size((num_samples,)))
             log_q = self.q.log_prob(samples)
 
-        self.potential_fn.x_o = x_o
+        self.potential_fn.set_x(x_o)
         log_potential = self.potential_fn(samples)
         elbo = log_potential - log_q
         return elbo
@@ -638,7 +638,7 @@ class ForwardKLOptimizer(DivergenceOptimizer):
         if hasattr(self.q, "clear_cache"):
             self.q.clear_cache()
         logq = self.q.log_prob(samples)
-        self.potential_fn.x_o = x_o
+        self.potential_fn.set_x(x_o)
         logp = self.potential_fn(samples)
         with torch.no_grad():
             logweights = logp - logq

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -430,11 +430,6 @@ class ConditionedPotential(BasePotential):
         else:
             raise ValueError("No observed data is available.")
 
-    @x_o.setter
-    def x_o(self, x_o: Optional[Tensor]) -> None:
-        """Check the shape of the observed data and, if valid, set it."""
-        self.set_x(x_o)
-
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
 


### PR DESCRIPTION
This PR removes the optional x_o.setter function that just falls back to set_x. Since set_x will be removed in future releases, this simplification should make it more readable.

Local tests passed.