### PR TITLE
fix: guard recursive object traversal against cycles

### DIFF
--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -659,6 +659,7 @@ def _base_recursor(
     key: Optional[str] = None,
     check: Callable[..., bool] = lambda obj: False,
     action: Callable[..., object] = lambda obj: obj,
+    _active: Optional[set[int]] = None,
 ):
     """Recursive function that traverses objects (e.g. Distributions) and applies
     an action to any encountered object that passes the check.
@@ -673,7 +674,17 @@ def _base_recursor(
             If the check evaluates to True, then ``action`` is applied.
         action: A function that specifies an operation on an object and returns
             a modified version.
+        _active: Object identities on the active recursion path. Used internally
+            to avoid infinite recursion in cyclic object graphs.
     """
+    if _active is None:
+        _active = set()
+
+    obj_id = id(obj)
+    if obj_id in _active:
+        return
+    _active.add(obj_id)
+
     if isinstance(obj, Module) and check(obj):
         action(obj)
     elif isinstance(obj, (Dict, OrderedDict)):
@@ -681,29 +692,43 @@ def _base_recursor(
             if check(o):
                 obj[k] = action(o)
             else:
-                _base_recursor(o, parent=obj, key=k, check=check, action=action)
+                _base_recursor(
+                    o,
+                    parent=obj,
+                    key=k,
+                    check=check,
+                    action=action,
+                    _active=_active,
+                )
     elif isinstance(obj, type):
         # Skip class/type objects to avoid modifying immutable C extension types
         # (e.g. torch.LongTensor) which fail on Python 3.13+.
-        return
+        pass
     elif hasattr(obj, "__dict__"):
         for k, o in obj.__dict__.items():
             if check(o):
                 setattr(obj, k, action(o))
             else:
-                _base_recursor(o, parent=obj, key=k, check=check, action=action)
+                _base_recursor(
+                    o,
+                    parent=obj,
+                    key=k,
+                    check=check,
+                    action=action,
+                    _active=_active,
+                )
     elif isinstance(obj, (List, Tuple, Generator)):
         new_obj = []
         for o in obj:
             if check(o):
                 new_obj.append(action(o))
             else:
-                _base_recursor(o, check=check, action=action)
+                _base_recursor(o, check=check, action=action, _active=_active)
                 new_obj.append(o)
         if parent is not None and key is not None:
             setattr(parent, key, type(obj)(new_obj))  # type: ignore
-    else:
-        return
+
+    _active.remove(obj_id)
 
 
 def move_all_tensor_to_device(obj: object, device: Union[str, torch.device]) -> None:

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import numpy as np
 import pytest
 import torch
@@ -14,6 +16,49 @@ from torch import eye, ones, zeros
 
 from sbi.utils import torchutils
 from tests.test_utils import kl_d_via_monte_carlo
+
+
+def test_base_recursor_handles_cyclic_object_graph():
+    class CyclicObject:
+        pass
+
+    root = CyclicObject()
+    tensor = torch.tensor(1.0)
+    root.tensor = tensor
+    root.self = root
+    root.mapping = {"root": root, "tensor": tensor}
+
+    processed = []
+
+    def process(obj):
+        processed.append(obj)
+        return obj
+
+    torchutils._base_recursor(root, check=torch.is_tensor, action=process)
+
+    assert len(processed) == 2
+    assert all(obj is tensor for obj in processed)
+
+
+def test_base_recursor_processes_aliased_containers():
+    class AliasedObject:
+        pass
+
+    root = AliasedObject()
+    tensor = torch.tensor(1.0, requires_grad=True) * 2
+    shared = [tensor]
+    root.first = shared
+    root.second = shared
+
+    torchutils._base_recursor(
+        root,
+        check=lambda obj: torch.is_tensor(obj) and not obj.is_leaf,
+        action=lambda obj: obj.detach(),
+    )
+
+    assert root.first[0].is_leaf
+    assert root.second[0].is_leaf
+    deepcopy(root)
 
 
 # XXX move to pytest? - investigate how to derive from TorchTestCase


### PR DESCRIPTION
PyTorch 2.13 exposes cyclic references in some distribution and transform object graphs. Before 
deepcopying VI posteriors, `detach_all_non_leaf_tensors()` recursively traverses these graphs; without cycle detection, it eventually raises RecursionError. 

This PR tracks object identities on the active recursion path. References back to an ancestor are skipped, while aliased objects reached through separate branches are still processed.

Regression tests cover both cyclic graphs and aliased containers.

Unblocks #1935 failing CI.