### PR TITLE
docs: better VI posterior and sampling methods how-to-guides

### DIFF
--- a/docs/how_to_guide.rst
+++ b/docs/how_to_guide.rst
@@ -57,6 +57,7 @@ Sampling
 --------
 
 - :doc:`how_to_guide/09_sampler_interface`
+- :doc:`how_to_guide/26_variational_inference`
 - :doc:`how_to_guide/10_refine_posterior_with_importance_sampling`
 - :doc:`how_to_guide/11_iid_sampling_with_nle_or_nre`
 - :doc:`how_to_guide/12_mcmc_diagnostics_with_arviz`

--- a/docs/how_to_guide.rst
+++ b/docs/how_to_guide.rst
@@ -63,6 +63,7 @@ Sampling
 - :doc:`how_to_guide/12_mcmc_diagnostics_with_arviz`
 - :doc:`how_to_guide/23_using_pyro_with_sbi`
 - :doc:`how_to_guide/19_posterior_parameters`
+- :doc:`how_to_guide/25_choosing_vector_field_options`
 
 
 Diagnostics

--- a/docs/how_to_guide/06_choosing_inference_method.ipynb
+++ b/docs/how_to_guide/06_choosing_inference_method.ipynb
@@ -31,9 +31,8 @@
     "\n",
     "- For high-dimensional simulation outputs such as images or time series, start with NPE or NRE and use an [embedding network](04_embedding_networks.ipynb).\n",
     "- If low sampling latency is important, NPE directly produces posterior samples after training.\n",
-    "- For IID observations across trials, NLE or NRE can be especially useful; see the [IID-data guide](11_iid_sampling_with_nle_or_nre.ipynb).\n",
-    "- Use amortized neural-estimator training when the same learned estimator should support many observations. Consider a [multiround method](02_multiround_inference.ipynb) when tailoring simulations to one observation is worth the additional rounds.\n",
-    "- Do not use `SNPE_A` or `SNPE_B` unless you specifically need these legacy methods and understand their constraints."
+    "- For IID observations, meaning several independent trials $x_1, \\dots, x_N$ generated from the same parameter $\\theta$, NLE or NRE can be especially useful; see the [IID-data guide](11_iid_sampling_with_nle_or_nre.ipynb).\n",
+    "- Use amortized neural-estimator training when the same learned estimator should support many observations. Consider a [sequential (multiround) method](02_multiround_inference.ipynb) when tailoring simulations to one observation is worth the additional rounds."
    ]
   },
   {
@@ -49,11 +48,13 @@
    "id": "f91955d8",
    "metadata": {},
    "source": [
-    "**NPE** directly estimates the posterior. It does not require an additional sampler after training, so repeated `.sample()` calls are fast. NPE can use an embedding network to learn features of structured or high-dimensional observations.\n",
+    "**NPE** directly estimates the posterior, $q(\\theta \\mid x) \\approx p(\\theta \\mid x)$. It does not require an additional sampler after training, so repeated `.sample()` calls are fast. NPE can use an embedding network, trained jointly with the density estimator, to learn features of structured or high-dimensional observations.\n",
     "\n",
-    "**NLE** learns the conditional distribution of observations given parameters. After training, it can act as a fast emulator: for a chosen parameter value, synthetic observations can be generated without running the original simulator. Learning the full distribution of high-dimensional observations can be challenging, so data reduction or NPE/NRE may be more practical in that setting. To obtain posterior samples, combine the learned likelihood with the prior and a method from the [sampler guide](09_sampler_interface.ipynb). NLE can be simulation-efficient for IID observations.\n",
+    "**NLE** learns the conditional distribution of observations given parameters, $q(x \\mid \\theta) \\approx p(x \\mid \\theta)$. After training, it can act as a fast emulator: for a chosen parameter value, synthetic observations can be generated without running the original simulator. Learning the full distribution of high-dimensional observations can be challenging, so data reduction or NPE/NRE may be more practical in that setting. To obtain posterior samples, combine the learned likelihood with the prior via $p(\\theta \\mid x_o) \\propto p(x_o \\mid \\theta)\\,p(\\theta)$ and pick a method from the [sampler guide](09_sampler_interface.ipynb). NLE can be simulation-efficient for [IID observations](11_iid_sampling_with_nle_or_nre.ipynb).\n",
     "\n",
-    "**NRE** learns the likelihood-to-evidence ratio with a classifier. Like NLE, it needs an additional posterior sampler. Like NPE, it can use an embedding network for structured observations."
+    "**NRE** learns the likelihood-to-evidence ratio, $r(\\theta, x) \\approx p(x \\mid \\theta) / p(x)$, with a classifier, so that $p(\\theta \\mid x_o) \\propto r(\\theta, x_o)\\,p(\\theta)$. Like NLE, it needs an additional posterior sampler. Like NPE, it can use an embedding network, trained jointly with the classifier, for structured observations.\n",
+    "\n",
+    "Each family has several variants. `NPE` resolves to `NPE_C` and `NRE` resolves to `NRE_B`; `NPE_A`, `NPE_B`, `NRE_A`, `NRE_C`, and `BNRE` are available under their own names."
    ]
   },
   {

--- a/docs/how_to_guide/06_choosing_inference_method.ipynb
+++ b/docs/how_to_guide/06_choosing_inference_method.ipynb
@@ -19,7 +19,9 @@
     "- `NLE` (Neural Likelihood Estimation), and\n",
     "- `NRE` (Neural Ratio Estimation).\n",
     "\n",
-    "Each family learns a different probability distribution from simulations, which affects how posterior samples are obtained and which data types are easiest to handle. The neural estimators are usually amortized: they are trained across observations and can be reused for new observations. They can also be used in sequential workflows tailored to one observation."
+    "Each family learns a different probability distribution from simulations, which affects how posterior samples are obtained and which data types are easiest to handle. The neural estimators are usually amortized: they are trained across observations and can be reused for new observations. They can also be used in sequential workflows tailored to one observation.\n",
+    "\n",
+    "`sbi` also implements vector-field methods, `FMPE` and `NPSE`, which estimate the posterior with flow matching or score matching instead of a normalizing flow. Their sampling and training trade-offs differ; see [how to use FMPE and NPSE](25_choosing_vector_field_options.ipynb)."
    ]
   },
   {

--- a/docs/how_to_guide/06_choosing_inference_method.ipynb
+++ b/docs/how_to_guide/06_choosing_inference_method.ipynb
@@ -19,7 +19,7 @@
     "- `NLE` (Neural Likelihood Estimation), and\n",
     "- `NRE` (Neural Ratio Estimation).\n",
     "\n",
-    "Each family learns a different probability distribution from simulations, which affects how posterior samples are obtained and which data types are easiest to handle."
+    "Each family learns a different probability distribution from simulations, which affects how posterior samples are obtained and which data types are easiest to handle. The neural estimators are usually amortized: they are trained across observations and can be reused for new observations. They can also be used in sequential workflows tailored to one observation."
    ]
   },
   {

--- a/docs/how_to_guide/06_choosing_inference_method.ipynb
+++ b/docs/how_to_guide/06_choosing_inference_method.ipynb
@@ -13,12 +13,13 @@
    "id": "ad7e9441",
    "metadata": {},
    "source": [
-    "`sbi` implements three sets of methods for inferring the posterior:\n",
+    "`sbi` implements three main neural inference families:\n",
+    "\n",
     "- `NPE` (Neural Posterior Estimation),\n",
     "- `NLE` (Neural Likelihood Estimation), and\n",
     "- `NRE` (Neural Ratio Estimation).\n",
     "\n",
-    "For each of these methods, `sbi` implements an amortized version and a sequential version. Which algorithm should you choose?"
+    "Their neural estimators are normally trained amortized over observations. They can also be used in sequential workflows tailored to one observation. This is distinct from **amortized VI**, which trains a conditional variational posterior after an NLE or NRE estimator has been learned."
    ]
   },
   {
@@ -26,14 +27,14 @@
    "id": "ac034f8a",
    "metadata": {},
    "source": [
-    "## Explicit recommendations\n",
+    "## Recommendations\n",
     "\n",
-    "- If have high-dimensional simulation-outputs (images, time-series,...), use `NPE` or `NRE`\n",
-    "- If you want fast sampling, use `NPE`\n",
-    "- If you have iid observations across many trials (and simulations are relatively expensive), use `NRE` or `NLE`\n",
-    "- If you want to perform inference for many observations, use amortized methods (which is the default of the `sbi` package).\n",
-    "- If you want to perform inference for few observations (<10), then start with amortized methods and switch to sequential methods only if the simulation cost is too high.\n",
-    "- Do not use `SNPE_A` or `SNPE_B` unless you are an expert user and know what you are doing."
+    "- For high-dimensional simulation outputs such as images or time series, start with NPE or NRE and use an [embedding network](04_embedding_networks.ipynb).\n",
+    "- If low sampling latency is important, NPE directly produces posterior samples after training.\n",
+    "- For IID observations across trials, NLE or NRE can be especially useful; see the [IID-data guide](11_iid_sampling_with_nle_or_nre.ipynb).\n",
+    "- Use amortized neural-estimator training when the same learned estimator should support many observations. Consider a [multiround method](02_multiround_inference.ipynb) when tailoring simulations to one observation is worth the additional rounds.\n",
+    "- For NLE and NRE, choose the downstream sampler using target geometry, computational budget, repeated-observation needs, and diagnostics; see the [sampler guide](09_sampler_interface.ipynb).\n",
+    "- Do not use `SNPE_A` or `SNPE_B` unless you specifically need these legacy methods and understand their constraints."
    ]
   },
   {
@@ -41,9 +42,7 @@
    "id": "e620b560",
    "metadata": {},
    "source": [
-    "## Additional explanation\n",
-    "\n",
-    "### NPE vs NLE vs NRE"
+    "## NPE vs NLE vs NRE"
    ]
   },
   {
@@ -51,11 +50,11 @@
    "id": "f91955d8",
    "metadata": {},
    "source": [
-    "**`NPE`** is the only method which estimates the posterior directly. This means that it will not require further sampling steps (such as MCMC) _after_ training. This makes NPE the fastest to `.sample()` from the posterior estimate after training. In addition, it can use an embedding network to learn summary statistics (just like NRE, but unlike NLE), see the tutorial [here]().\n",
+    "**NPE** directly estimates the posterior. It does not require an additional sampler after training, so repeated `.sample()` calls are fast. NPE can use an embedding network to learn features of structured or high-dimensional observations.\n",
     "\n",
-    "**`NLE`** learns the likelihood. This allows NLE to emulate the simulator after training. To sample from the posterior, NLE is combined with MCMC or variational inference (see [here]()), which makes it slower to `.sample()`. An advantage of NLE is that, if you have multiple iid observations, then it can be much more simulation efficient than NPE (see tutorial [here]()).\n",
+    "**NLE** learns the likelihood and can emulate it after training. Posterior sampling combines the learned likelihood with the prior through MCMC, rejection sampling, VI, or importance sampling. NLE can be simulation-efficient for IID observations.\n",
     "\n",
-    "**`NRE`** learns the likelihood-to-evidence ratio. It trains only a classifier (unlike NPE and NLE, which train a generative model), which makes it fastest to train. Like NLE, NRE has to be combined MCMC or variational inference to run `.sample()`. Like NPE, NRE can use an embedding network to learn summary statistics."
+    "**NRE** learns the likelihood-to-evidence ratio with a classifier. Like NLE, it needs an additional posterior sampler. Like NPE, it can use an embedding network for structured observations."
    ]
   },
   {
@@ -63,7 +62,7 @@
    "id": "2112dce4",
    "metadata": {},
    "source": [
-    "### Amortized or sequential"
+    "## Amortized or sequential neural inference"
    ]
   },
   {
@@ -71,11 +70,9 @@
    "id": "727f1a67",
    "metadata": {},
    "source": [
-    "**Amortized** methods allow you to perform inference for _any_ observation without running new simulations or retraining. In contrast, **sequential** methods tailor inference to a single observation, which can make them more simulation efficient.\n",
+    "An **amortized neural estimator** is trained across simulated observations and can be reused for new observations without new simulations or estimator retraining. A **sequential** workflow concentrates later simulation rounds around a particular observation and can improve simulation efficiency for that observation. Choose based on how often the estimator will be reused, simulation cost, and the benefit of observation-specific simulations rather than a fixed observation-count threshold.\n",
     "\n",
-    "If you want to perform inference for many observations (>10), use amortized methods. If you have only few observations (or just a single on), then we still recommend you start with amortized methods. Only if simulation cost becomes too large, switch to sequential methods.\n",
-    "\n",
-    "The default behavior of `sbi` is to run each method in its amortized form. To run sequential methods, you have to build follow the tutorial [here](https://sbi.readthedocs.io/en/latest/advanced_tutorials/02_multiround_inference.html)."
+    "For NLE or NRE, downstream VI adds another choice. Fixed-observation VI trains $q(\\theta)$ for one observation; amortized VI trains $q(\\theta\\mid x)$ for repeated posterior queries. The [sampler guide](09_sampler_interface.ipynb) shows both through `VIPosterior`."
    ]
   }
  ],

--- a/docs/how_to_guide/06_choosing_inference_method.ipynb
+++ b/docs/how_to_guide/06_choosing_inference_method.ipynb
@@ -19,7 +19,7 @@
     "- `NLE` (Neural Likelihood Estimation), and\n",
     "- `NRE` (Neural Ratio Estimation).\n",
     "\n",
-    "Their neural estimators are normally trained amortized over observations. They can also be used in sequential workflows tailored to one observation. This is distinct from **amortized VI**, which trains a conditional variational posterior after an NLE or NRE estimator has been learned."
+    "Each family learns a different probability distribution from simulations, which affects how posterior samples are obtained and which data types are easiest to handle."
    ]
   },
   {
@@ -33,7 +33,6 @@
     "- If low sampling latency is important, NPE directly produces posterior samples after training.\n",
     "- For IID observations across trials, NLE or NRE can be especially useful; see the [IID-data guide](11_iid_sampling_with_nle_or_nre.ipynb).\n",
     "- Use amortized neural-estimator training when the same learned estimator should support many observations. Consider a [multiround method](02_multiround_inference.ipynb) when tailoring simulations to one observation is worth the additional rounds.\n",
-    "- For NLE and NRE, choose the downstream sampler using target geometry, computational budget, repeated-observation needs, and diagnostics; see the [sampler guide](09_sampler_interface.ipynb).\n",
     "- Do not use `SNPE_A` or `SNPE_B` unless you specifically need these legacy methods and understand their constraints."
    ]
   },
@@ -52,7 +51,7 @@
    "source": [
     "**NPE** directly estimates the posterior. It does not require an additional sampler after training, so repeated `.sample()` calls are fast. NPE can use an embedding network to learn features of structured or high-dimensional observations.\n",
     "\n",
-    "**NLE** learns the likelihood and can emulate it after training. Posterior sampling combines the learned likelihood with the prior through MCMC, rejection sampling, VI, or importance sampling. NLE can be simulation-efficient for IID observations.\n",
+    "**NLE** learns the conditional distribution of observations given parameters. After training, it can act as a fast emulator: for a chosen parameter value, synthetic observations can be generated without running the original simulator. Learning the full distribution of high-dimensional observations can be challenging, so data reduction or NPE/NRE may be more practical in that setting. To obtain posterior samples, combine the learned likelihood with the prior and a method from the [sampler guide](09_sampler_interface.ipynb). NLE can be simulation-efficient for IID observations.\n",
     "\n",
     "**NRE** learns the likelihood-to-evidence ratio with a classifier. Like NLE, it needs an additional posterior sampler. Like NPE, it can use an embedding network for structured observations."
    ]
@@ -70,9 +69,7 @@
    "id": "727f1a67",
    "metadata": {},
    "source": [
-    "An **amortized neural estimator** is trained across simulated observations and can be reused for new observations without new simulations or estimator retraining. A **sequential** workflow concentrates later simulation rounds around a particular observation and can improve simulation efficiency for that observation. Choose based on how often the estimator will be reused, simulation cost, and the benefit of observation-specific simulations rather than a fixed observation-count threshold.\n",
-    "\n",
-    "For NLE or NRE, downstream VI adds another choice. Fixed-observation VI trains $q(\\theta)$ for one observation; amortized VI trains $q(\\theta\\mid x)$ for repeated posterior queries. The [sampler guide](09_sampler_interface.ipynb) shows both through `VIPosterior`."
+    "An **amortized neural estimator** is trained across simulated observations and can be reused for new observations without new simulations or estimator retraining. A **sequential** workflow concentrates later simulation rounds around a particular observation and can improve simulation efficiency for that observation. Choose based on how often the estimator will be reused, simulation cost, and the benefit of observation-specific simulations rather than a fixed observation-count threshold."
    ]
   }
  ],

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -6,53 +6,31 @@
    "source": [
     "# How to choose sampling algorithms\n",
     "\n",
-    "`sbi` implements three methods: NPE, NLE, and NRE. When using NPE, the trained neural network directly approximates the posterior. Thus, sampling from the posterior can be done by sampling from the trained neural network. The neural networks trained in NLE and NRE approximate the likelihood(-ratio). Thus, in order to draw samples from the posterior, one has to perform additional sampling steps, e.g. Markov-chain Monte-Carlo (MCMC). In `sbi`, the implemented samplers are:\n",
+    "NPE usually samples directly from its learned posterior. NLE and NRE instead learn a likelihood or likelihood-to-evidence ratio, so they need an additional sampler to turn the learned potential into posterior samples. `sbi` provides MCMC, rejection sampling, variational inference (VI), and importance sampling for this purpose.\n",
     "\n",
-    "- Markov-chain Monte-Carlo (MCMC)\n",
-    "\n",
-    "- Rejection sampling\n",
-    "\n",
-    "- Variational inference (VI)\n",
-    "\n",
-    "- Importance sampling (IS)\n",
-    "\n",
-    "Which sampler should you choose? And how can you do this in the `sbi` toolbox?"
+    "Sampler choice depends on target geometry, proposal overlap, computational budget, sampling latency, and whether inference is repeated for new observations. Parameter dimension alone is not a reliable selection rule."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Explicit recommendations\n",
+    "## Recommendations\n",
     "\n",
-    "For NPE:\n",
-    "-  use the `DirectPosterior`. If you have a likelihood available, you can refine the posterior with importance sampling (see tutorial [here]())\n",
-    "\n",
-    "For NLE or NRE:\n",
-    "- If you have very few parameters (<3), use `RejectionPosterior` or `MCMCPosterior`\n",
-    "- If you have a medium number of parameters (3-10), use `MCMCPosterior`\n",
-    "- If you have many parameters (>10) and the `MCMCPosterior` is too slow, use the `VIPosterior`. Optionally combine the `VIPosterior` with an `ImportanceSamplingPosterior` to improve its accuracy.\n",
-    "\n",
-    "## Overview\n",
-    "\n",
-    "- `MCMCPosterior`: very accurate, but can be slow if you have many parameters.  \n",
-    "- `VIPosterior`: can be much faster if you have many parameter. May be inaccurate.  \n",
-    "- `RejectionPosterior`: accurate and fast, but only for very few parameters (typically less than 3). \n",
-    "- `ImportanceSamplingPosterior`: typically inaccurate, but can be very useful to improve the accuracy of a `VIPosterior` (see above)."
+    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE, then inspect convergence and mixing diagnostics.\n",
+    "- Use **rejection sampling** when the proposal has good overlap with the posterior. Monitor the observed acceptance rate: poor overlap can make rejection sampling impractical even in a low-dimensional problem, while strong overlap can make it practical across a range of dimensions.\n",
+    "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Validate it against MCMC or other diagnostics when possible.\n",
+    "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Validate accuracy on representative held-out observations.\n",
+    "- Use **importance sampling** when proposal quality and diagnostics indicate reliable weights. Refinement of a VI or NPE result is described in the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Main syntax"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we show how you can use these different sampling algorithms in the `sbi` toolbox. We begin with the `MCMCPosterior`:"
+    "## Build a sampler through the inference object\n",
+    "\n",
+    "After training an NLE estimator, `build_posterior()` constructs each sampler from the same learned potential. The same pattern applies to NRE."
    ]
   },
   {
@@ -60,170 +38,33 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from sbi.inference import MCMCPosterior, likelihood_estimator_based_potential\n",
+    "from sbi.inference import NLE\n",
     "\n",
-    "trainer = NLE()\n",
-    "likelihood_estimator = trainer.append_simulations(theta, x).train()\n",
-    "\n",
-    "potential_fn, parameter_transform = likelihood_estimator_based_potential(\n",
-    "    likelihood_estimator, prior, x_o\n",
-    ")\n",
-    "posterior = MCMCPosterior(\n",
-    "    potential_fn, proposal=prior, theta_transform=parameter_transform, warmup_steps=10\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you want to use variational inference or rejection sampling, you have to replace the last line with `VIPosterior` or `RejectionPosterior`:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "from sbi.inference import RejectionPosterior, VIPosterior\n",
-    "\n",
-    "# For VI, we have to train.\n",
-    "posterior = VIPosterior(\n",
-    "    potential_fn, prior=prior, theta_transform=parameter_transform\n",
-    ").train()\n",
-    "\n",
-    "posterior = RejectionPosterior(\n",
-    "    potential_fn, proposal=prior, theta_transform=parameter_transform\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally, it is also possible to improve the accuracy of a `VIPosterior` with importance sampling:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "from sbi.inference import ImportanceSamplingPosterior, VIPosterior\n",
-    "\n",
-    "vi_posterior = VIPosterior(\n",
-    "    potential_fn, prior=prior, theta_transform=parameter_transform\n",
-    ").train()\n",
-    "refined_posterior = ImportancerSamplingPosterior(\n",
-    "    potential_fn, vi_posterior, oversampling_factor=32\n",
-    ")\n",
-    "samples = refined_posterior.sample((1000,))\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "At this point, you could also plug the `potential_fn` into any sampler of your choice and not rely on any of the in-built `sbi`-samplers.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Further explanation\n",
-    "\n",
-    "The first lines are the same as always:\n",
-    "```python\n",
-    "inference = NLE()\n",
+    "inference = NLE(prior=prior)\n",
     "likelihood_estimator = inference.append_simulations(theta, x).train()\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we obtain the potential function. A potential function is a function of the parameter $f(\\theta)$. The posterior is proportional to the product of likelihood and prior: $p(\\theta | x_o) \\propto p(x_o | \\theta)p(\\theta)$. The potential function is the logarithm of the right-hand side of this equation: $f(\\theta) = \\log(p(x_o | \\theta)p(\\theta))$\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "potential_fn, parameter_transform = likelihood_estimator_based_potential(\n",
-    "    likelihood_estimator, prior, x_o\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By calling the `potential_fn`, you can evaluate the potential:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "# Assuming that your parameters are 1D.\n",
-    "potential = potential_fn(\n",
-    "    torch.zeros(1, num_dim)\n",
-    ")  # -> returns f(0) = log( p(x_o|0) p(0) )\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The other object that is returned by `likelihood_estimator_based_potential` is a `parameter_transform`. The `parameter_transform` is a [pytorch transform](https://github.com/pytorch/pytorch/blob/master/torch/distributions/transforms.py). The `parameter_transform` is a fixed transform that is can be applied to parameter `theta`. It transforms the parameters into unconstrained space (if the prior is bounded, e.g. `BoxUniform`), and standardizes the parameters (i.e. zero mean, one std). Using `parameter_transform` during sampling is optional, but it usually improves the performance of MCMC.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "theta_tf = parameter_transform(torch.zeros(1, num_dim))\n",
-    "theta_original = parameter_transform.inv(theta_tf)\n",
-    "print(theta_original)  # -> tensor([[0.0]])\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "After having obtained the `potential_fn`, we can sample from the posterior with MCMC or rejection sampling:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "posterior = MCMCPosterior(\n",
-    "    potential_fn, proposal=prior, theta_transform=parameter_transform\n",
-    ")\n",
-    "posterior = RejectionPosterior(potential_fn, proposal=prior)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## On the usage of NPE\n",
     "\n",
-    "NPE usually does not require MCMC or rejection sampling (if you still need it, you can use the same syntax as above with the `posterior_estimator_based_potential` function). Instead, NPE samples from the neural network. If the support of the prior is bounded, some samples can lie outside of the support of the prior. The `DirectPosterior` class automatically rejects these samples:\n"
+    "mcmc_posterior = inference.build_posterior(sample_with=\"mcmc\")\n",
+    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
+    "\n",
+    "rejection_posterior = inference.build_posterior(sample_with=\"rejection\")\n",
+    "rejection_samples = rejection_posterior.sample((1000,), x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For rejection sampling, the acceptance rate is the useful empirical signal: a low rate means that the proposal places too much mass where the posterior does not. Improve the proposal or choose another sampler rather than relying on a dimension cutoff."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fixed-observation VI\n",
+    "\n",
+    "A fixed-observation `VIPosterior` learns an unconditional approximation for one `x_o`. Building and training are separate steps:"
    ]
   },
   {
@@ -231,13 +72,100 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from sbi.inference import NPE, DirectPosterior\n",
+    "vi_posterior = inference.build_posterior(sample_with=\"vi\")\n",
+    "vi_posterior.train(x=x_o)\n",
+    "vi_samples = vi_posterior.sample((1000,), x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"` through `VIPosteriorParameters` when the posterior is built. Its `evaluate()` method can help compare approximation quality. These choices and `evaluate()` do not apply to amortized VI."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amortized VI\n",
     "\n",
-    "inference = NPE()\n",
+    "Amortized VI learns a conditional approximation $q(\\theta\\mid x)$ from simulation pairs. A small neural spline flow (NSF) keeps this documentation example concise:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference.posteriors import VIPosteriorParameters\n",
+    "\n",
+    "amortized_vi = inference.build_posterior(\n",
+    "    sample_with=\"vi\",\n",
+    "    posterior_parameters=VIPosteriorParameters(\n",
+    "        q=\"nsf\", num_transforms=2, hidden_features=32\n",
+    "    ),\n",
+    ")\n",
+    "amortized_vi.train_amortized(theta, x)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `sample()` for one observation, `sample_batched()` for several observations at once, and `log_prob()` to evaluate the learned normalized approximation:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "samples = amortized_vi.sample((1000,), x=x_o)\n",
+    "batched_samples = amortized_vi.sample_batched((1000,), x=x_batch)\n",
+    "log_probs = amortized_vi.log_prob(samples, x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amortized VI currently optimizes the evidence lower bound (ELBO), corresponding to reverse KL. Alternative `vi_method` choices are only used by fixed-observation VI.\n",
+    "\n",
+    "> `train()` and `train_amortized()` are distinct modes. Switching modes discards the representation learned in the previous mode, so use separate posterior objects when both results are needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Direct posterior sampling with NPE\n",
+    "\n",
+    "NPE directly learns $q(\\theta\\mid x)$, so it normally does not need MCMC, rejection sampling, or VI after training:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference import NPE\n",
+    "\n",
+    "inference = NPE(prior=prior)\n",
     "posterior_estimator = inference.append_simulations(theta, x).train()\n",
-    "\n",
-    "posterior = DirectPosterior(posterior_estimator, prior=prior)\n",
+    "posterior = inference.build_posterior(posterior_estimator)\n",
+    "samples = posterior.sample((1000,), x=x_o)\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you need lower-level control, `likelihood_estimator_based_potential`, `ratio_estimator_based_potential`, and `posterior_estimator_based_potential` expose the learned potential for constructing a sampler directly or integrating another sampling library."
    ]
   }
  ],

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "With NPE the trained network approximates the posterior directly, so samples are drawn from the network itself. NLE and NRE approximate the likelihood or the likelihood-to-evidence ratio, so obtaining posterior samples needs an additional algorithm: MCMC, rejection sampling, variational inference (VI), or importance sampling (IS). See [how to choose an inference method](06_choosing_inference_method.ipynb) for the differences between the three families.\n",
     "\n",
-    "The best choice depends on the problem: for example, whether the posterior has several separated regions or strong parameter correlations, how often a proposal finds high-probability parameters, how much computation is available, and whether inference will be repeated for new observations. The number of parameters alone is not a reliable selection rule."
+    "The best choice depends on the sampling problem rather than on the number of parameters: whether the posterior has several separated regions or strong parameter correlations, how often a proposal lands in high-probability regions, how much computation is available per observation, and whether one approximation must serve many observations, which decides between the fixed-observation and amortized VI options below."
    ]
   },
   {

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -48,6 +48,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Each class is configured with a matching `PosteriorParameters` dataclass, passed to `build_posterior()` as `posterior_parameters`:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference.posteriors import MCMCPosteriorParameters\n",
+    "\n",
+    "mcmc_posterior = inference.build_posterior(\n",
+    "    sample_with=\"mcmc\",\n",
+    "    posterior_parameters=MCMCPosteriorParameters(\n",
+    "        method=\"slice_np_vectorized\", num_chains=4, warmup_steps=100\n",
+    "    ),\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These dataclasses are typed, so editors and type checkers catch invalid or misspelled options, and they expose more settings than the older per-sampler dictionaries. Those dictionaries (`mcmc_parameters`, `vi_parameters`, `rejection_sampling_parameters` and their counterparts), along with `mcmc_method` and `vi_method`, are deprecated and raise a `FutureWarning`. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb) for the options each class accepts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Potentials and the sampler interface\n",
     "\n",
     "MCMC, rejection sampling, VI, and importance sampling do not need the normalized posterior density. They only need a **potential**: a score proportional to the log posterior. For NLE, this is the learned log likelihood plus the log prior; for NRE, it is the learned log likelihood-to-evidence ratio plus the log prior. `build_posterior()` constructs the appropriate potential automatically."

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# How to choose sampling algorithms\n",
     "\n",
-    "NPE directly learns a posterior and normally samples from that network. NLE and NRE instead learn how compatible parameters are with an observation. To obtain posterior samples, they combine the learned model with the prior and an additional sampler. `sbi` provides MCMC, rejection sampling, variational inference (VI), and importance sampling for this purpose.\n",
+    "`sbi` implements three neural inference methods: NPE, NLE, and NRE. With NPE, the trained neural network directly approximates the posterior, so posterior samples can be drawn from that network. NLE and NRE instead approximate the likelihood or likelihood-to-evidence ratio. Drawing posterior samples from them requires an additional method such as MCMC, rejection sampling, variational inference (VI), or importance sampling (IS).\n",
     "\n",
     "The best choice depends on the problem: for example, whether the posterior has several separated regions or strong parameter correlations, how often a proposal finds high-probability parameters, how much computation is available, and whether inference will be repeated for new observations. The number of parameters alone is not a reliable selection rule."
    ]
@@ -17,6 +17,7 @@
    "source": [
     "## Recommendations\n",
     "\n",
+    "- For **NPE**, use the `DirectPosterior`. If the likelihood can also be evaluated, importance sampling can refine the posterior; see the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb).\n",
     "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check whether independent chains explore the same regions and whether posterior summaries are stable.\n",
     "- Use **rejection sampling** when the proposal closely covers the posterior. The observed acceptance rate reports efficiency directly: a low rate means many proposal evaluations are needed for each retained sample. It is not, by itself, a measure of posterior accuracy.\n",
     "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Validate it against MCMC or other diagnostics when possible.\n",
@@ -101,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fixed-observation VI is observation-specific, or non-amortized, but it is not sequential SBI by itself: fitting it does not generate simulations or retrain the NLE/NRE estimator. In a sequential NLE or NRE workflow, each round uses the current posterior as a proposal for new simulations, appends those simulations, updates the neural estimator on the accumulated data, and then fits a new fixed-observation VI posterior. The preceding VI posterior can also initialize the next one.\n",
+    "Fixed-observation VI can be used as the sampler in sequential NLE. In each round, train or update the NLE, fit a `VIPosterior` to `x_o`, sample parameters from it for the next simulations, append those simulations, and repeat. This is SNLE with VI instead of MCMC.\n",
     "\n",
     "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Its `evaluate()` method can help compare approximation quality. These choices and `evaluate()` do not apply to amortized VI."
    ]

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# How to choose sampling algorithms\n",
     "\n",
-    "NPE usually samples directly from its learned posterior. NLE and NRE instead learn a likelihood or likelihood-to-evidence ratio, so they need an additional sampler to turn the learned potential into posterior samples. `sbi` provides MCMC, rejection sampling, variational inference (VI), and importance sampling for this purpose.\n",
+    "NPE directly learns a posterior and normally samples from that network. NLE and NRE instead learn how compatible parameters are with an observation. To obtain posterior samples, they combine the learned model with the prior and an additional sampler. `sbi` provides MCMC, rejection sampling, variational inference (VI), and importance sampling for this purpose.\n",
     "\n",
-    "Sampler choice depends on target geometry, proposal overlap, computational budget, sampling latency, and whether inference is repeated for new observations. Parameter dimension alone is not a reliable selection rule."
+    "The best choice depends on the problem: for example, whether the posterior has several separated regions or strong parameter correlations, how often a proposal finds high-probability parameters, how much computation is available, and whether inference will be repeated for new observations. The number of parameters alone is not a reliable selection rule."
    ]
   },
   {
@@ -17,20 +17,20 @@
    "source": [
     "## Recommendations\n",
     "\n",
-    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE, then inspect convergence and mixing diagnostics.\n",
-    "- Use **rejection sampling** when the proposal has good overlap with the posterior. Monitor the observed acceptance rate: poor overlap can make rejection sampling impractical even in a low-dimensional problem, while strong overlap can make it practical across a range of dimensions.\n",
+    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check whether independent chains explore the same regions and whether posterior summaries are stable.\n",
+    "- Use **rejection sampling** when the proposal closely covers the posterior. The observed acceptance rate reports efficiency directly: a low rate means many proposal evaluations are needed for each retained sample. It is not, by itself, a measure of posterior accuracy.\n",
     "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Validate it against MCMC or other diagnostics when possible.\n",
     "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Validate accuracy on representative held-out observations.\n",
-    "- Use **importance sampling** when proposal quality and diagnostics indicate reliable weights. Refinement of a VI or NPE result is described in the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb)."
+    "- Use **importance sampling** when the proposal gives reliable importance weights. Inspect weight diagnostics before relying on the result."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Build a sampler through the inference object\n",
+    "## Potentials and the sampler interface\n",
     "\n",
-    "After training an NLE estimator, `build_posterior()` constructs each sampler from the same learned potential. The same pattern applies to NRE."
+    "MCMC, rejection sampling, VI, and importance sampling do not need the normalized posterior density. They only need a **potential**: a score proportional to the log posterior. For NLE, this is the learned log likelihood plus the log prior; for NRE, it is the learned log likelihood-to-evidence ratio plus the log prior. `build_posterior()` constructs the appropriate potential automatically."
    ]
   },
   {
@@ -38,11 +38,32 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from sbi.inference import NLE\n",
+    "from sbi.inference import NLE, likelihood_estimator_based_potential\n",
     "\n",
     "inference = NLE(prior=prior)\n",
     "likelihood_estimator = inference.append_simulations(theta, x).train()\n",
     "\n",
+    "# Optional lower-level access to the potential and parameter transform.\n",
+    "potential_fn, theta_transform = likelihood_estimator_based_potential(\n",
+    "    likelihood_estimator=likelihood_estimator,\n",
+    "    prior=prior,\n",
+    "    x_o=x_o,\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The returned transform maps constrained parameters to coordinates that are easier for many samplers to use. Most workflows can stay with the higher-level interface:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
     "mcmc_posterior = inference.build_posterior(sample_with=\"mcmc\")\n",
     "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
     "\n",
@@ -55,16 +76,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For rejection sampling, the acceptance rate is the useful empirical signal: a low rate means that the proposal places too much mass where the posterior does not. Improve the proposal or choose another sampler rather than relying on a dimension cutoff."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Fixed-observation VI\n",
     "\n",
-    "A fixed-observation `VIPosterior` learns an unconditional approximation for one `x_o`. Building and training are separate steps:"
+    "A fixed-observation `VIPosterior` learns an approximation for one `x_o`. Building and training are separate steps. Pass `VIPosteriorParameters` when selecting a fixed-observation VI objective:"
    ]
   },
   {
@@ -72,7 +86,12 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "vi_posterior = inference.build_posterior(sample_with=\"vi\")\n",
+    "from sbi.inference.posteriors import VIPosteriorParameters\n",
+    "\n",
+    "vi_posterior = inference.build_posterior(\n",
+    "    sample_with=\"vi\",\n",
+    "    posterior_parameters=VIPosteriorParameters(vi_method=\"rKL\"),\n",
+    ")\n",
     "vi_posterior.train(x=x_o)\n",
     "vi_samples = vi_posterior.sample((1000,), x=x_o)\n",
     "```"
@@ -82,7 +101,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"` through `VIPosteriorParameters` when the posterior is built. Its `evaluate()` method can help compare approximation quality. These choices and `evaluate()` do not apply to amortized VI."
+    "Fixed-observation VI is observation-specific, or non-amortized, but it is not sequential SBI by itself: fitting it does not generate simulations or retrain the NLE/NRE estimator. In a sequential NLE or NRE workflow, each round uses the current posterior as a proposal for new simulations, appends those simulations, updates the neural estimator on the accumulated data, and then fits a new fixed-observation VI posterior. The preceding VI posterior can also initialize the next one.\n",
+    "\n",
+    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Its `evaluate()` method can help compare approximation quality. These choices and `evaluate()` do not apply to amortized VI."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Refine a fixed-observation VI posterior\n",
+    "\n",
+    "Sampling-importance-resampling (SIR) can use the trained VI posterior as a proposal. This workflow is fixed at `x_o`; it does not imply batched refinement of an amortized posterior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference import ImportanceSamplingPosterior\n",
+    "\n",
+    "refined_posterior = ImportanceSamplingPosterior(\n",
+    "    potential_fn=vi_posterior.potential_fn,\n",
+    "    proposal=vi_posterior,\n",
+    "    method=\"sir\",\n",
+    ").set_default_x(x_o)\n",
+    "refined_samples = refined_posterior.sample(\n",
+    "    (1000,), oversampling_factor=32\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the importance weights before relying on the refined result. See the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb) for details."
    ]
   },
   {
@@ -99,8 +154,6 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from sbi.inference.posteriors import VIPosteriorParameters\n",
-    "\n",
     "amortized_vi = inference.build_posterior(\n",
     "    sample_with=\"vi\",\n",
     "    posterior_parameters=VIPosteriorParameters(\n",
@@ -144,7 +197,7 @@
    "source": [
     "## Direct posterior sampling with NPE\n",
     "\n",
-    "NPE directly learns $q(\\theta\\mid x)$, so it normally does not need MCMC, rejection sampling, or VI after training:"
+    "NPE directly learns $q(\\theta\\mid x)$, so its direct sampler is normally the appropriate choice:"
    ]
   },
   {
@@ -165,7 +218,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you need lower-level control, `likelihood_estimator_based_potential`, `ratio_estimator_based_potential`, and `posterior_estimator_based_potential` expose the learned potential for constructing a sampler directly or integrating another sampling library."
+    "With a bounded prior, an NPE density can assign some probability outside the prior support, known as leakage. This can be especially relevant in multi-round NPE: if leakage is severe, correcting it during direct sampling can be inefficient, and MCMC targeting the NPE potential can be useful. Otherwise, adding MCMC to NPE is usually unnecessary:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "mcmc_posterior = inference.build_posterior(\n",
+    "    posterior_estimator, sample_with=\"mcmc\"\n",
+    ")\n",
+    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
+    "```"
    ]
   }
  ],

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -18,7 +18,7 @@
     "## Recommendations\n",
     "\n",
     "- For **NPE**, use the `DirectPosterior`, which `build_posterior()` returns by default. If the likelihood can also be evaluated, importance sampling can refine the posterior; see the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb).\n",
-    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check convergence with $\\hat{R}$ and the effective sample size, and check that independent chains explore the same regions; see [MCMC diagnostics with ArviZ](12_mcmc_diagnostics_with_arviz.ipynb).\n",
+    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check that independent chains explore the same regions, and compute standard convergence diagnostics such as $\\hat{R}$ and the effective sample size with ArviZ; see [how to visualize MCMC diagnostics with ArviZ](12_mcmc_diagnostics_with_arviz.ipynb) for getting `sbi` samples into an `InferenceData` container.\n",
     "- **Rejection sampling** draws from a proposal and accepts against the potential. Through `build_posterior(sample_with=\"rejection\")` the proposal is the prior, so it is practical when the posterior is not much more concentrated than the prior. If a better proposal is available, such as a trained NPE posterior or a distribution informed by an evaluable likelihood, construct a `RejectionPosterior` directly with it. Coverage cannot be checked in advance: run it and read the acceptance rate, which reports efficiency directly and which `sbi` warns about when it falls below 1%. A low rate means many proposal evaluations per retained sample; it is not itself a measure of posterior accuracy.\n",
     "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Check it with `evaluate()` (see below) and, where feasible, against MCMC on the same observation.\n",
     "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Check accuracy on representative held-out observations.\n",
@@ -41,7 +41,7 @@
     "| `\"vi\"` | `VIPosterior` |\n",
     "| `\"importance\"` | `ImportanceSamplingPosterior` |\n",
     "\n",
-    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. Every class can also be constructed directly from a potential function, as shown below."
+    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. The `MCMCPosterior`, `RejectionPosterior`, `VIPosterior`, and `ImportanceSamplingPosterior` classes can also be constructed directly from a potential function, as shown below; `DirectPosterior` instead wraps a trained density estimator."
    ]
   },
   {
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These dataclasses are typed, so editors and type checkers catch invalid or misspelled options, and they expose more settings than the older per-sampler dictionaries. Those dictionaries (`mcmc_parameters`, `vi_parameters`, `rejection_sampling_parameters` and their counterparts), along with `mcmc_method` and `vi_method`, are deprecated and raise a `FutureWarning`. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb) for the options each class accepts."
+    "These dataclasses are typed, so editors and type checkers catch invalid or misspelled options, and they expose more settings than the older per-sampler dictionaries. Those dictionaries (`mcmc_parameters`, `vi_parameters`, `rejection_sampling_parameters` and their counterparts) are deprecated and raise a `FutureWarning` whenever they are passed. The `mcmc_method` and `vi_method` arguments are deprecated as well, and warn when set to a non-default value. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb) for the options each class accepts."
    ]
   },
   {

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -105,7 +105,8 @@
    "source": [
     "## Setting the sampler\n",
     "\n",
-    "`build_posterior()` selects the posterior class with `sample_with`:\n",
+    "The simplest way is a single string. `build_posterior(sample_with=...)` selects the\n",
+    "posterior class:\n",
     "\n",
     "| `sample_with` | posterior class |\n",
     "| --- | --- |\n",
@@ -124,8 +125,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each class is configured with a matching `PosteriorParameters` dataclass, passed to\n",
-    "`build_posterior()` as `posterior_parameters`:"
+    "```python\n",
+    "mcmc_posterior = inference.build_posterior(sample_with=\"mcmc\")\n",
+    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To configure the sampler, pass a `PosteriorParameters` dataclass instead. Its type already\n",
+    "identifies the sampler, so `sample_with` is not needed alongside it:"
    ]
   },
   {
@@ -136,12 +147,10 @@
     "from sbi.inference.posteriors import MCMCPosteriorParameters\n",
     "\n",
     "mcmc_posterior = inference.build_posterior(\n",
-    "    sample_with=\"mcmc\",\n",
     "    posterior_parameters=MCMCPosteriorParameters(\n",
     "        method=\"slice_np_vectorized\", num_chains=4, warmup_steps=100\n",
     "    ),\n",
     ")\n",
-    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
     "```"
    ]
   },
@@ -155,7 +164,10 @@
     "their counterparts) are deprecated and raise a `FutureWarning` whenever they are passed.\n",
     "The `mcmc_method` and `vi_method` arguments are deprecated as well, and warn when set to a\n",
     "non-default value. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb)\n",
-    "for the options each class accepts."
+    "for the options each class accepts.\n",
+    "\n",
+    "FMPE and NPSE are the exception: `VectorFieldPosteriorParameters` does not encode the\n",
+    "integrator, so `sample_with=\"ode\"` or `\"sde\"` still selects it."
    ]
   },
   {

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# How to choose sampling algorithms\n",
     "\n",
-    "`sbi` implements three neural inference methods: NPE, NLE, and NRE. With NPE, the trained neural network directly approximates the posterior, so posterior samples can be drawn from that network. NLE and NRE instead approximate the likelihood or likelihood-to-evidence ratio. Drawing posterior samples from them requires an additional method such as MCMC, rejection sampling, variational inference (VI), or importance sampling (IS).\n",
+    "With NPE the trained network approximates the posterior directly, so samples are drawn from the network itself. NLE and NRE approximate the likelihood or the likelihood-to-evidence ratio, so obtaining posterior samples needs an additional algorithm: MCMC, rejection sampling, variational inference (VI), or importance sampling (IS). See [how to choose an inference method](06_choosing_inference_method.ipynb) for the differences between the three families.\n",
     "\n",
     "The best choice depends on the problem: for example, whether the posterior has several separated regions or strong parameter correlations, how often a proposal finds high-probability parameters, how much computation is available, and whether inference will be repeated for new observations. The number of parameters alone is not a reliable selection rule."
    ]
@@ -17,12 +17,31 @@
    "source": [
     "## Recommendations\n",
     "\n",
-    "- For **NPE**, use the `DirectPosterior`. If the likelihood can also be evaluated, importance sampling can refine the posterior; see the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb).\n",
-    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check whether independent chains explore the same regions and whether posterior summaries are stable.\n",
-    "- Use **rejection sampling** when the proposal closely covers the posterior. The observed acceptance rate reports efficiency directly: a low rate means many proposal evaluations are needed for each retained sample. It is not, by itself, a measure of posterior accuracy.\n",
-    "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Validate it against MCMC or other diagnostics when possible.\n",
-    "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Validate accuracy on representative held-out observations.\n",
-    "- Use **importance sampling** when the proposal gives reliable importance weights. Inspect weight diagnostics before relying on the result."
+    "- For **NPE**, use the `DirectPosterior`, which `build_posterior()` returns by default. If the likelihood can also be evaluated, importance sampling can refine the posterior; see the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb).\n",
+    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check convergence with $\\hat{R}$ and the effective sample size, and check that independent chains explore the same regions; see [MCMC diagnostics with ArviZ](12_mcmc_diagnostics_with_arviz.ipynb).\n",
+    "- **Rejection sampling** draws from a proposal and accepts against the potential. Through `build_posterior(sample_with=\"rejection\")` the proposal is the prior, so it is practical when the posterior is not much more concentrated than the prior. If a better proposal is available, such as a trained NPE posterior or a distribution informed by an evaluable likelihood, construct a `RejectionPosterior` directly with it. Coverage cannot be checked in advance: run it and read the acceptance rate, which reports efficiency directly and which `sbi` warns about when it falls below 1%. A low rate means many proposal evaluations per retained sample; it is not itself a measure of posterior accuracy.\n",
+    "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Check it with `evaluate()` (see below) and, where feasible, against MCMC on the same observation.\n",
+    "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Check accuracy on representative held-out observations.\n",
+    "- Use **importance sampling** when the proposal gives reliable importance weights. `sample(method=\"importance\")` returns samples together with their log-weights, so the effective sample size can be computed before relying on the result.\n",
+    "\n",
+    "For posterior accuracy in general, as opposed to sampler efficiency, see [how to choose a diagnostic tool](14_choose_diagnostic_tool.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`build_posterior()` picks the posterior class with `sample_with`:\n",
+    "\n",
+    "| `sample_with` | posterior class |\n",
+    "| --- | --- |\n",
+    "| `\"direct\"` | `DirectPosterior` |\n",
+    "| `\"mcmc\"` | `MCMCPosterior` |\n",
+    "| `\"rejection\"` | `RejectionPosterior` |\n",
+    "| `\"vi\"` | `VIPosterior` |\n",
+    "| `\"importance\"` | `ImportanceSamplingPosterior` |\n",
+    "\n",
+    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. Every class can also be constructed directly from a potential function, as shown below."
    ]
   },
   {
@@ -104,7 +123,7 @@
    "source": [
     "Fixed-observation VI can be used as the sampler in sequential NLE. In each round, train or update the NLE, fit a `VIPosterior` to `x_o`, sample parameters from it for the next simulations, append those simulations, and repeat. This is SNLE with VI instead of MCMC.\n",
     "\n",
-    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Its `evaluate()` method can help compare approximation quality. These choices and `evaluate()` do not apply to amortized VI."
+    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Its `evaluate()` method prints a quality score: by default the shape parameter $\\hat{k}$ of a generalized Pareto distribution fitted to the tail of the importance weights of $q$ against the potential, where below roughly 0.5 is good and above 1.0 indicates a poor approximation ([Yao et al., 2018](https://arxiv.org/abs/1802.02538)). Passing `quality_control_metric=\"prop\"` instead reports an $R^2$ of $q$ against the joint, where values above 0.5 are good. Neither the `vi_method` choices nor `evaluate()` apply to amortized VI."
    ]
   },
   {
@@ -147,7 +166,7 @@
    "source": [
     "## Amortized VI\n",
     "\n",
-    "Amortized VI learns a conditional approximation $q(\\theta\\mid x)$ from simulation pairs. A small neural spline flow (NSF) keeps this documentation example concise:"
+    "Amortized VI learns a conditional approximation $q(\\theta\\mid x)$ from simulation pairs. The variational family is set with `q`, which accepts the usual estimator strings:"
    ]
   },
   {
@@ -169,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use `sample()` for one observation, `sample_batched()` for several observations at once, and `log_prob()` to evaluate the learned normalized approximation:"
+    "Use `sample()` for one observation, `sample_batched()` for several observations at once, and `log_prob()` to evaluate the learned normalized approximation. There is no `log_prob_batched()` for VI posteriors, so evaluate one observation at a time."
    ]
   },
   {
@@ -187,9 +206,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Amortized VI currently optimizes the evidence lower bound (ELBO), corresponding to reverse KL. Alternative `vi_method` choices are only used by fixed-observation VI.\n",
+    "Amortized VI currently optimizes the evidence lower bound (ELBO), which corresponds to reverse KL. The alternative `vi_method` choices apply only to fixed-observation VI.\n",
     "\n",
-    "> `train()` and `train_amortized()` are distinct modes. Switching modes discards the representation learned in the previous mode, so use separate posterior objects when both results are needed."
+    "The two training entry points are mutually exclusive. `train()` fits an approximation for a single `x_o`, while `train_amortized()` fits the conditional approximation. Calling one on a posterior that was already trained in the other mode discards the earlier fit and raises a warning, so use separate `VIPosterior` objects when both results are needed."
    ]
   },
   {
@@ -210,6 +229,8 @@
     "\n",
     "inference = NPE(prior=prior)\n",
     "posterior_estimator = inference.append_simulations(theta, x).train()\n",
+    "\n",
+    "# Returns a DirectPosterior: sample_with=\"direct\" is the default for NPE.\n",
     "posterior = inference.build_posterior(posterior_estimator)\n",
     "samples = posterior.sample((1000,), x=x_o)\n",
     "```"

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -6,32 +6,106 @@
    "source": [
     "# How to choose sampling algorithms\n",
     "\n",
-    "With NPE the trained network approximates the posterior directly, so samples are drawn from the network itself. NLE and NRE approximate the likelihood or the likelihood-to-evidence ratio, so obtaining posterior samples needs an additional algorithm: MCMC, rejection sampling, variational inference (VI), or importance sampling (IS). See [how to choose an inference method](06_choosing_inference_method.ipynb) for the differences between the three families.\n",
+    "`sbi` implements several inference methods, and how you obtain posterior samples differs\n",
+    "between them.\n",
     "\n",
-    "The best choice depends on the sampling problem rather than on the number of parameters: whether the posterior has several separated regions or strong parameter correlations, how often a proposal lands in high-probability regions, how much computation is available per observation, and whether one approximation must serve many observations, which decides between the fixed-observation and amortized VI options below."
+    "With **NPE**, the trained network approximates the posterior directly, so drawing samples\n",
+    "is just a forward pass through the network: fast, and nothing to configure. The\n",
+    "vector-field methods **FMPE** and **NPSE** also target the posterior directly, but sample\n",
+    "by integrating an ODE or SDE.\n",
+    "\n",
+    "With **NLE** and **NRE**, the network approximates the likelihood or the\n",
+    "likelihood-to-evidence ratio. Combined with the prior, this gives a score proportional to\n",
+    "the log posterior, but not posterior samples, so an additional sampling algorithm is\n",
+    "needed. `sbi` implements four:\n",
+    "\n",
+    "- Markov-chain Monte Carlo (MCMC)\n",
+    "- Rejection sampling\n",
+    "- Variational inference (VI)\n",
+    "- Importance sampling (IS)\n",
+    "\n",
+    "Which one should you use, and how do you set it? This guide gives a recommendation per\n",
+    "inference method first, then shows how to configure the sampler, and finally covers the\n",
+    "low-level potential interface for full control. See\n",
+    "[how to choose an inference method](06_choosing_inference_method.ipynb) for the\n",
+    "differences between the inference families themselves."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Recommendations\n",
-    "\n",
-    "- For **NPE**, use the `DirectPosterior`, which `build_posterior()` returns by default. If the likelihood can also be evaluated, importance sampling can refine the posterior; see the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb).\n",
-    "- Start with **MCMC** as a general-purpose baseline for NLE and NRE. Check that independent chains explore the same regions, and compute standard convergence diagnostics such as $\\hat{R}$ and the effective sample size with ArviZ; see [how to visualize MCMC diagnostics with ArviZ](12_mcmc_diagnostics_with_arviz.ipynb) for getting `sbi` samples into an `InferenceData` container.\n",
-    "- **Rejection sampling** draws from a proposal and accepts against the potential. Through `build_posterior(sample_with=\"rejection\")` the proposal is the prior, so it is practical when the posterior is not much more concentrated than the prior. If a better proposal is available, such as a trained NPE posterior or a distribution informed by an evaluable likelihood, construct a `RejectionPosterior` directly with it. Coverage cannot be checked in advance: run it and read the acceptance rate, which reports efficiency directly and which `sbi` warns about when it falls below 1%. A low rate means many proposal evaluations per retained sample; it is not itself a measure of posterior accuracy.\n",
-    "- Use **fixed-observation VI** when MCMC cost or sampling latency is problematic and an approximate posterior is acceptable. Check it with `evaluate()` (see below) and, where feasible, against MCMC on the same observation.\n",
-    "- Use **amortized VI** when inference must be repeated for many observations and its up-front training cost is justified by fast subsequent sampling. Check accuracy on representative held-out observations.\n",
-    "- Use **importance sampling** when the proposal gives reliable importance weights. `sample(method=\"importance\")` returns samples together with their log-weights, so the effective sample size can be computed before relying on the result.\n",
-    "\n",
-    "For posterior accuracy in general, as opposed to sampler efficiency, see [how to choose a diagnostic tool](14_choose_diagnostic_tool.ipynb)."
+    "## Which sampler do you need?"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`build_posterior()` picks the posterior class with `sample_with`:\n",
+    "### With NPE, FMPE, or NPSE\n",
+    "\n",
+    "**There is nothing to choose.** `build_posterior()` returns a sampler that draws from the\n",
+    "trained network, and that is normally the right choice. For FMPE and NPSE, pick the\n",
+    "integrator with `sample_with=\"ode\"` or `sample_with=\"sde\"`; see\n",
+    "[how to use FMPE and NPSE](25_choosing_vector_field_options.ipynb).\n",
+    "\n",
+    "Two situations call for something more:\n",
+    "\n",
+    "- **Leakage.** With a bounded prior, an NPE density can place some mass outside the prior\n",
+    "  support. `DirectPosterior` rejects those samples automatically, but if leakage is\n",
+    "  severe — most often in multi-round NPE — this correction becomes inefficient, and MCMC\n",
+    "  targeting the NPE potential is the better option.\n",
+    "- **An evaluable likelihood.** If the likelihood can be evaluated, importance sampling can\n",
+    "  refine the posterior; see\n",
+    "  [how to refine a posterior with importance sampling](10_refine_posterior_with_importance_sampling.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With NLE or NRE\n",
+    "\n",
+    "**Start with MCMC.** It is the default and the accurate general-purpose choice. Check that\n",
+    "independent chains explore the same regions, and compute standard convergence diagnostics\n",
+    "such as $\\hat{R}$ and the effective sample size with ArviZ; see\n",
+    "[how to visualize MCMC diagnostics with ArviZ](12_mcmc_diagnostics_with_arviz.ipynb).\n",
+    "\n",
+    "If MCMC is not a good fit, pick by the problem you have:\n",
+    "\n",
+    "- **MCMC is too slow, or sampling latency matters** → try **variational inference**. VI\n",
+    "  fits a distribution you can then sample from cheaply, and it comes with an amortized\n",
+    "  variant that serves many observations from a single fit. VI is approximate, so check it\n",
+    "  before relying on it; see\n",
+    "  [how to use variational inference](26_variational_inference.ipynb).\n",
+    "- **The posterior is not much more concentrated than the prior** → **rejection sampling**\n",
+    "  is simple and returns exact samples from the learned target.\n",
+    "  `build_posterior(sample_with=\"rejection\")` proposes from the prior, which is what makes\n",
+    "  the concentration comparison the relevant one. Coverage cannot be checked in advance, so\n",
+    "  the practical test is to run it: `sbi` logs a warning when the acceptance rate falls\n",
+    "  below 1%, which is the signal that the prior is a poor proposal here. A low rate means\n",
+    "  many proposal evaluations per retained sample; it is not itself a measure of posterior\n",
+    "  accuracy. `RejectionPosterior.sample()` does not return the rate, so call\n",
+    "  `sbi.samplers.rejection.rejection_sample()` directly if the number itself is needed. If\n",
+    "  a better proposal is available, such as a trained NPE posterior, construct a\n",
+    "  `RejectionPosterior` directly with it.\n",
+    "- **A good proposal is already available** — a trained NPE posterior, a VI fit, or a\n",
+    "  distribution informed by an evaluable likelihood → **importance sampling**.\n",
+    "  `sample(method=\"importance\")` returns samples together with their log-weights, so the\n",
+    "  effective sample size can be computed before relying on the result.\n",
+    "\n",
+    "All of this concerns sampler efficiency and fidelity to the learned target. For posterior\n",
+    "accuracy in general, see\n",
+    "[how to choose a diagnostic tool](14_choose_diagnostic_tool.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting the sampler\n",
+    "\n",
+    "`build_posterior()` selects the posterior class with `sample_with`:\n",
     "\n",
     "| `sample_with` | posterior class |\n",
     "| --- | --- |\n",
@@ -40,17 +114,18 @@
     "| `\"rejection\"` | `RejectionPosterior` |\n",
     "| `\"vi\"` | `VIPosterior` |\n",
     "| `\"importance\"` | `ImportanceSamplingPosterior` |\n",
+    "| `\"ode\"` / `\"sde\"` | `VectorFieldPosterior` |\n",
     "\n",
-    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. The `MCMCPosterior`, `RejectionPosterior`, `VIPosterior`, and `ImportanceSamplingPosterior` classes can also be constructed directly from a potential function, as shown below; `DirectPosterior` instead wraps a trained density estimator.\n",
-    "\n",
-    "Vector-field methods (`FMPE`, `NPSE`) instead sample by integrating an ODE or SDE, selected with `sample_with=\"ode\"` or `\"sde\"`; see [how to use FMPE and NPSE](25_choosing_vector_field_options.ipynb)."
+    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`.\n",
+    "FMPE and NPSE use `\"ode\"` and `\"sde\"`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each class is configured with a matching `PosteriorParameters` dataclass, passed to `build_posterior()` as `posterior_parameters`:"
+    "Each class is configured with a matching `PosteriorParameters` dataclass, passed to\n",
+    "`build_posterior()` as `posterior_parameters`:"
    ]
   },
   {
@@ -66,6 +141,7 @@
     "        method=\"slice_np_vectorized\", num_chains=4, warmup_steps=100\n",
     "    ),\n",
     ")\n",
+    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
     "```"
    ]
   },
@@ -73,16 +149,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These dataclasses are typed, so editors and type checkers catch invalid or misspelled options, and they expose more settings than the older per-sampler dictionaries. Those dictionaries (`mcmc_parameters`, `vi_parameters`, `rejection_sampling_parameters` and their counterparts) are deprecated and raise a `FutureWarning` whenever they are passed. The `mcmc_method` and `vi_method` arguments are deprecated as well, and warn when set to a non-default value. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb) for the options each class accepts."
+    "These dataclasses are typed, so editors and type checkers catch invalid or misspelled\n",
+    "options, and they expose more settings than the older per-sampler dictionaries. Those\n",
+    "dictionaries (`mcmc_parameters`, `vi_parameters`, `rejection_sampling_parameters` and\n",
+    "their counterparts) are deprecated and raise a `FutureWarning` whenever they are passed.\n",
+    "The `mcmc_method` and `vi_method` arguments are deprecated as well, and warn when set to a\n",
+    "non-default value. See [how to use `PosteriorParameters`](19_posterior_parameters.ipynb)\n",
+    "for the options each class accepts."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Potentials and the sampler interface\n",
+    "## Full control: potentials and the sampler interface\n",
     "\n",
-    "MCMC, rejection sampling, VI, and importance sampling do not need the normalized posterior density. They only need a **potential**: a score proportional to the log posterior. For NLE, this is the learned log likelihood plus the log prior; for NRE, it is the learned log likelihood-to-evidence ratio plus the log prior. `build_posterior()` constructs the appropriate potential automatically."
+    "MCMC, rejection sampling, VI, and importance sampling do not need the normalized posterior\n",
+    "density. They only need a **potential**: a score proportional to the log posterior. For\n",
+    "NLE, this is the learned log likelihood plus the log prior; for NRE, it is the learned log\n",
+    "likelihood-to-evidence ratio plus the log prior. `build_posterior()` constructs the\n",
+    "appropriate potential automatically, so most workflows never need to touch it.\n",
+    "\n",
+    "Building the potential yourself is the most flexible entry point: the posterior classes\n",
+    "can be constructed from it directly, and it can also be handed to any external sampler."
    ]
   },
   {
@@ -95,12 +184,14 @@
     "inference = NLE(prior=prior)\n",
     "likelihood_estimator = inference.append_simulations(theta, x).train()\n",
     "\n",
-    "# Optional lower-level access to the potential and parameter transform.\n",
     "potential_fn, theta_transform = likelihood_estimator_based_potential(\n",
     "    likelihood_estimator=likelihood_estimator,\n",
     "    prior=prior,\n",
     "    x_o=x_o,\n",
     ")\n",
+    "\n",
+    "# f(theta) = log( p(x_o | theta) p(theta) ), up to a constant.\n",
+    "potential = potential_fn(theta_candidates)\n",
     "```"
    ]
   },
@@ -108,7 +199,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The returned transform maps constrained parameters to coordinates that are easier for many samplers to use. Most workflows can stay with the higher-level interface:"
+    "The returned `theta_transform` maps constrained parameters to unconstrained coordinates\n",
+    "that are easier for many samplers to explore. Passing it is optional, but it usually\n",
+    "improves MCMC performance with bounded priors.\n",
+    "\n",
+    "Any of the sampler classes can then be built on the potential, which is how to use a\n",
+    "proposal other than the prior:"
    ]
   },
   {
@@ -116,36 +212,12 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "mcmc_posterior = inference.build_posterior(sample_with=\"mcmc\")\n",
-    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
+    "from sbi.inference import MCMCPosterior, RejectionPosterior\n",
     "\n",
-    "rejection_posterior = inference.build_posterior(sample_with=\"rejection\")\n",
-    "rejection_samples = rejection_posterior.sample((1000,), x=x_o)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Fixed-observation VI\n",
-    "\n",
-    "A fixed-observation `VIPosterior` learns an approximation for one `x_o`. Building and training are separate steps. Pass `VIPosteriorParameters` when selecting a fixed-observation VI objective:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "from sbi.inference.posteriors import VIPosteriorParameters\n",
-    "\n",
-    "vi_posterior = inference.build_posterior(\n",
-    "    sample_with=\"vi\",\n",
-    "    posterior_parameters=VIPosteriorParameters(vi_method=\"rKL\"),\n",
+    "mcmc_posterior = MCMCPosterior(\n",
+    "    potential_fn, proposal=prior, theta_transform=theta_transform, warmup_steps=100\n",
     ")\n",
-    "vi_posterior.train(x=x_o)\n",
-    "vi_samples = vi_posterior.sample((1000,), x=x_o)\n",
+    "rejection_posterior = RejectionPosterior(potential_fn, proposal=better_proposal)\n",
     "```"
    ]
   },
@@ -153,138 +225,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fixed-observation VI can be used as the sampler in sequential NLE. In each round, train or update the NLE, fit a `VIPosterior` to `x_o`, sample parameters from it for the next simulations, append those simulations, and repeat. This is SNLE with VI instead of MCMC.\n",
-    "\n",
-    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Its `evaluate()` method prints a quality score: by default the shape parameter $\\hat{k}$ of a generalized Pareto distribution fitted to the tail of the importance weights of $q$ against the potential, where below roughly 0.5 is good and above 1.0 indicates a poor approximation ([Yao et al., 2018](https://arxiv.org/abs/1802.02538)). Passing `quality_control_metric=\"prop\"` instead reports an $R^2$ of $q$ against the joint, where values above 0.5 are good. Neither the `vi_method` choices nor `evaluate()` apply to amortized VI."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Refine a fixed-observation VI posterior\n",
-    "\n",
-    "Sampling-importance-resampling (SIR) can use the trained VI posterior as a proposal. This workflow is fixed at `x_o`; it does not imply batched refinement of an amortized posterior."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "from sbi.inference import ImportanceSamplingPosterior\n",
-    "\n",
-    "refined_posterior = ImportanceSamplingPosterior(\n",
-    "    potential_fn=vi_posterior.potential_fn,\n",
-    "    proposal=vi_posterior,\n",
-    "    method=\"sir\",\n",
-    ").set_default_x(x_o)\n",
-    "refined_samples = refined_posterior.sample(\n",
-    "    (1000,), oversampling_factor=32\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Check the importance weights before relying on the refined result. See the [dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb) for details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Amortized VI\n",
-    "\n",
-    "Amortized VI learns a conditional approximation $q(\\theta\\mid x)$ from simulation pairs. The variational family is set with `q`, which accepts the usual estimator strings:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "amortized_vi = inference.build_posterior(\n",
-    "    sample_with=\"vi\",\n",
-    "    posterior_parameters=VIPosteriorParameters(\n",
-    "        q=\"nsf\", num_transforms=2, hidden_features=32\n",
-    "    ),\n",
-    ")\n",
-    "amortized_vi.train_amortized(theta, x)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Use `sample()` for one observation, `sample_batched()` for several observations at once, and `log_prob()` to evaluate the learned normalized approximation. There is no `log_prob_batched()` for VI posteriors, so evaluate one observation at a time."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "samples = amortized_vi.sample((1000,), x=x_o)\n",
-    "batched_samples = amortized_vi.sample_batched((1000,), x=x_batch)\n",
-    "log_probs = amortized_vi.log_prob(samples, x=x_o)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Amortized VI currently optimizes the evidence lower bound (ELBO), which corresponds to reverse KL. The alternative `vi_method` choices apply only to fixed-observation VI.\n",
-    "\n",
-    "The two training entry points are mutually exclusive. `train()` fits an approximation for a single `x_o`, while `train_amortized()` fits the conditional approximation. Calling one on a posterior that was already trained in the other mode discards the earlier fit and raises a warning, so use separate `VIPosterior` objects when both results are needed."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Direct posterior sampling with NPE\n",
-    "\n",
-    "NPE directly learns $q(\\theta\\mid x)$, so its direct sampler is normally the appropriate choice:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "from sbi.inference import NPE\n",
-    "\n",
-    "inference = NPE(prior=prior)\n",
-    "posterior_estimator = inference.append_simulations(theta, x).train()\n",
-    "\n",
-    "# Returns a DirectPosterior: sample_with=\"direct\" is the default for NPE.\n",
-    "posterior = inference.build_posterior(posterior_estimator)\n",
-    "samples = posterior.sample((1000,), x=x_o)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "With a bounded prior, an NPE density can assign some probability outside the prior support, known as leakage. This can be especially relevant in multi-round NPE: if leakage is severe, correcting it during direct sampling can be inefficient, and MCMC targeting the NPE potential can be useful. Otherwise, adding MCMC to NPE is usually unnecessary:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "mcmc_posterior = inference.build_posterior(\n",
-    "    posterior_estimator, sample_with=\"mcmc\"\n",
-    ")\n",
-    "mcmc_samples = mcmc_posterior.sample((1000,), x=x_o)\n",
-    "```"
+    "The equivalent function for NPE and NRE estimators is\n",
+    "`posterior_estimator_based_potential` and `ratio_estimator_based_potential`,\n",
+    "respectively. See [the abstraction levels guide](24_abstraction_levels.ipynb) for how this\n",
+    "interface relates to the higher-level ones."
    ]
   }
  ],

--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -41,7 +41,9 @@
     "| `\"vi\"` | `VIPosterior` |\n",
     "| `\"importance\"` | `ImportanceSamplingPosterior` |\n",
     "\n",
-    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. The `MCMCPosterior`, `RejectionPosterior`, `VIPosterior`, and `ImportanceSamplingPosterior` classes can also be constructed directly from a potential function, as shown below; `DirectPosterior` instead wraps a trained density estimator."
+    "`\"direct\"` is available for NPE only, and is its default. NLE and NRE default to `\"mcmc\"`. The `MCMCPosterior`, `RejectionPosterior`, `VIPosterior`, and `ImportanceSamplingPosterior` classes can also be constructed directly from a potential function, as shown below; `DirectPosterior` instead wraps a trained density estimator.\n",
+    "\n",
+    "Vector-field methods (`FMPE`, `NPSE`) instead sample by integrating an ODE or SDE, selected with `sample_with=\"ode\"` or `\"sde\"`; see [how to use FMPE and NPSE](25_choosing_vector_field_options.ipynb)."
    ]
   },
   {

--- a/docs/how_to_guide/10_refine_posterior_with_importance_sampling.ipynb
+++ b/docs/how_to_guide/10_refine_posterior_with_importance_sampling.ipynb
@@ -13,9 +13,7 @@
    "id": "f91df50c",
    "metadata": {},
    "source": [
-    "The `sbi` toolbox does not require that the simulator can **evaluate** the likelihood (it only requires samples). If the likelihood can be evaluated, then one can refine the posterior estimate _after training_ with likelihood evaluations. This is typically done with importance sampling (using the posterior estimate as proposal).\n",
-    "\n",
-    "In `sbi`, this can be implemented as follows:"
+    "The `sbi` toolbox only requires samples from a simulator. When the likelihood can also be evaluated, importance sampling can refine a fixed-observation posterior estimate by using it as the proposal. Check importance-weight diagnostics before relying on the refined result."
    ]
   },
   {
@@ -32,19 +30,21 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from sbi.inference import ImportanceSamplingPosterior\n",
+    "from sbi.inference import DirectPosterior, ImportanceSamplingPosterior\n",
     "\n",
-    "log_prob_fn = lambda theta, x_o: simulator.log_likelihood(theta, x_o) + prior.log_prob(theta)\n",
+    "log_prob_fn = lambda theta, x_o: (\n",
+    "    simulator.log_likelihood(theta, x_o) + prior.log_prob(theta)\n",
+    ")\n",
     "\n",
-    "# Obtian posterior with NPE, NLE, or NRE.\n",
+    "# Obtain a fixed-observation posterior with NPE, NLE, or NRE.\n",
     "posterior_estimate = DirectPosterior(posterior_net, prior).set_default_x(x_o)\n",
     "\n",
-    "# Importance sampling for refining the posterior_estimate.\n",
+    "# Refine that posterior with sampling-importance-resampling (SIR).\n",
     "posterior_sir = ImportanceSamplingPosterior(\n",
     "    potential_fn=log_prob_fn,\n",
     "    proposal=posterior_estimate,\n",
     "    method=\"sir\",\n",
-    ")\n",
+    ").set_default_x(x_o)\n",
     "theta_inferred_sir = posterior_sir.sample(\n",
     "    (1000,),\n",
     "    oversampling_factor=32,\n",
@@ -57,7 +57,7 @@
    "id": "9c480c4f",
    "metadata": {},
    "source": [
-    "## Example"
+    "This refinement workflow is for a posterior fixed at `x_o`; it does not describe batched refinement of an amortized posterior."
    ]
   },
   {
@@ -65,7 +65,7 @@
    "id": "a10d9afc",
    "metadata": {},
    "source": [
-    "More details can be found in the [tutorial on importance sampling for refining the posterior estimate](https://sbi.readthedocs.io/en/latest/advanced_tutorials/15_importance_sampled_posteriors.html)."
+    "More details can be found in the [tutorial on importance sampling for refining posterior estimates](../advanced_tutorials/15_importance_sampled_posteriors.ipynb)."
    ]
   }
  ],

--- a/docs/how_to_guide/19_posterior_parameters.ipynb
+++ b/docs/how_to_guide/19_posterior_parameters.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "- `VectorFieldPosteriorParameters`: : used with VectorFieldPosterior\n",
     "\n",
-    "- `VIPosteriorParameters`: used with VIPosterior"
+    "- `VIPosteriorParameters`: used with VIPosterior (see [how to use variational inference](26_variational_inference.ipynb))"
    ]
   },
   {

--- a/docs/how_to_guide/24_abstraction_levels.ipynb
+++ b/docs/how_to_guide/24_abstraction_levels.ipynb
@@ -362,7 +362,7 @@
     "**Available sampling methods**:\n",
     "- `\"mcmc\"`: Markov chain Monte Carlo (default)\n",
     "- `\"rejection\"`: Rejection sampling from a proposal\n",
-    "- `\"vi\"`: A trained variational approximation, either fixed-observation or amortized\n",
+    "- `\"vi\"`: A trained variational approximation, either fixed-observation or amortized (see [how to use variational inference](26_variational_inference.ipynb))\n",
     "- `\"importance\"`: Importance sampling or sampling-importance-resampling from a proposal\n",
     "\n",
     "**Usage**: Simply change `sample_with=\"rejection\"` to `sample_with=\"vi\"` or any other method.\n",

--- a/docs/how_to_guide/24_abstraction_levels.ipynb
+++ b/docs/how_to_guide/24_abstraction_levels.ipynb
@@ -348,7 +348,7 @@
    "outputs": [],
    "source": [
     "# Sampling Level 2: Choose sampling method\n",
-    "# Use rejection sampling instead of default MCMC (fast for few parameters)\n",
+    "# Select rejection sampling explicitly.\n",
     "posterior_rejection = inference_nle.build_posterior(sample_with=\"rejection\")\n",
     "samples_rejection = posterior_rejection.sample((1000,), x=x_o)\n",
     "\n",
@@ -360,14 +360,14 @@
    "metadata": {},
    "source": [
     "**Available sampling methods**:\n",
-    "- `\"mcmc\"`: Markov Chain Monte Carlo (default) - accurate but can be slow\n",
-    "- `\"rejection\"`: Rejection sampling - fast and accurate for few parameters (<3)\n",
-    "- `\"vi\"`: Variational inference - faster for many parameters (>10), may be less accurate\n",
-    "- `\"importance\"`: Importance sampling - useful for refining VI posteriors\n",
+    "- `\"mcmc\"`: Markov chain Monte Carlo (default)\n",
+    "- `\"rejection\"`: Rejection sampling from a proposal\n",
+    "- `\"vi\"`: A trained variational approximation, either fixed-observation or amortized\n",
+    "- `\"importance\"`: Importance sampling or sampling-importance-resampling from a proposal\n",
     "\n",
     "**Usage**: Simply change `sample_with=\"rejection\"` to `sample_with=\"vi\"` or any other method.\n",
     "\n",
-    "**See also**: [how_to_guide/09_sampler_interface.ipynb](https://sbi.readthedocs.io/en/latest/how_to_guide/09_sampler_interface.html) for detailed guidance on choosing sampling algorithms."
+    "Selection depends on the target, proposal overlap, computational budget, and diagnostics. See [How to choose sampling algorithms](09_sampler_interface.ipynb) for guidance."
    ]
   },
   {
@@ -409,13 +409,13 @@
     "- `\"hmc_pyro\"`: Hamiltonian Monte Carlo (requires `pip install \"sbi[pyro]\"`)\n",
     "- `\"slice_pymc\"`, `\"hmc_pymc\"`, `\"nuts_pymc\"`: PyMC samplers (require `pip install \"sbi[pymc]\"`)\n",
     "\n",
-    "**Available VI methods** (use with `vi_method=`):\n",
+    "**Available fixed-observation VI methods** (use with `vi_method=`):\n",
     "- `\"rKL\"`: Reverse KL divergence (mode-seeking, **default**)\n",
     "- `\"fKL\"`: Forward KL divergence (mass-covering)\n",
     "- `\"IW\"`: Importance weighted\n",
     "- `\"alpha\"`: Alpha divergence\n",
     "\n",
-    "**Usage**: Change `mcmc_method=\"nuts_pyro\"` to any other MCMC method, or use `vi_method=\"fKL\"` when `sample_with=\"vi\"`."
+    "**Usage**: Change `mcmc_method=\"nuts_pyro\"` to any other MCMC method, or use `vi_method=\"fKL\"` for fixed-observation VI. Amortized VI currently uses the ELBO (reverse KL)."
    ]
   },
   {
@@ -522,22 +522,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Guide 2: Which Sampling Level? (NLE and NRE only)\n",
+    "## Sampling control overview (NLE and NRE only)\n",
     "\n",
-    "| Situation | Sampling Level | Example |\n",
-    "|-----------|----------------|----------|\n",
-    "| Starting out, need good defaults | **1** | `build_posterior()` |\n",
-    "| Very few parameters (<3) | **2** | `sample_with=\"rejection\"` |\n",
-    "| Many parameters (>10), speed is critical | **2** | `sample_with=\"vi\"` |\n",
-    "| Want to use NUTS or HMC | **3** | `mcmc_method=\"nuts_pyro\"` |\n",
-    "| MCMC not converging, need more warmup | **4** | `mcmc_parameters={\"warmup_steps\": 500}` |\n",
-    "| Want type checking and validation | **4** | `MCMCPosteriorParameters(...)` |\n",
-    "| Troubleshooting sampling issues | **4** | Tune `num_chains`, `init_strategy`, etc. |\n",
+    "| Control | Level | Example |\n",
+    "|---------|-------|---------|\n",
+    "| Use the default sampler | **1** | `build_posterior()` |\n",
+    "| Choose a sampler family | **2** | `sample_with=\"vi\"` |\n",
+    "| Choose an algorithm within a family | **3** | `mcmc_method=\"nuts_pyro\"` |\n",
+    "| Tune or validate method-specific parameters | **4** | `MCMCPosteriorParameters(...)` |\n",
     "\n",
-    "**Rule of thumb**: \n",
-    "- Start with default MCMC (Level 1)\n",
-    "- If too slow, try rejection (few params) or VI (many params) at Level 2\n",
-    "- Use Level 3-4 for optimization or troubleshooting"
+    "This overview describes where configuration happens. Defer sampler selection to [How to choose sampling algorithms](09_sampler_interface.ipynb), which discusses problem-dependent tradeoffs and diagnostics."
    ]
   },
   {

--- a/docs/how_to_guide/26_variational_inference.ipynb
+++ b/docs/how_to_guide/26_variational_inference.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to use variational inference\n",
+    "\n",
+    "Variational inference (VI) fits a tractable distribution $q$ to the posterior by\n",
+    "optimizing a divergence against the potential. In `sbi` it is a **sampler**: it works with\n",
+    "any potential, so it is available for NLE and NRE, and it is the option to reach for when\n",
+    "MCMC is too slow or when sampling latency matters. See\n",
+    "[how to choose sampling algorithms](09_sampler_interface.ipynb) for how it compares to the\n",
+    "alternatives.\n",
+    "\n",
+    "`VIPosterior` has two modes, and they are mutually exclusive:\n",
+    "\n",
+    "- **Fixed-observation VI** (`train()`) learns one approximation for one $x_o$.\n",
+    "- **Amortized VI** (`train_amortized()`) learns a conditional approximation\n",
+    "  $q(\\theta \\mid x)$ that serves many observations.\n",
+    "\n",
+    "Calling one on a posterior that was already trained in the other mode discards the earlier\n",
+    "fit and raises a warning, so use separate `VIPosterior` objects when both results are\n",
+    "needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fixed-observation VI\n",
+    "\n",
+    "Building and training are separate steps. Pass `VIPosteriorParameters` to choose the\n",
+    "objective:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference.posteriors import VIPosteriorParameters\n",
+    "\n",
+    "vi_posterior = inference.build_posterior(\n",
+    "    sample_with=\"vi\",\n",
+    "    posterior_parameters=VIPosteriorParameters(vi_method=\"rKL\"),\n",
+    ")\n",
+    "vi_posterior.train(x=x_o)\n",
+    "vi_samples = vi_posterior.sample((1000,), x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fixed-observation VI supports `vi_method=\"rKL\"`, `\"fKL\"`, `\"IW\"`, or `\"alpha\"`. Some are\n",
+    "mode-seeking (`\"rKL\"`, `\"alpha\"` above 1) and some are mass-covering (`\"fKL\"`, `\"IW\"`,\n",
+    "`\"alpha\"` below 1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check the approximation\n",
+    "\n",
+    "VI is approximate, so verify the fit before relying on it. The `evaluate()` method prints a\n",
+    "quality score: by default the shape parameter $\\hat{k}$ of a generalized Pareto\n",
+    "distribution fitted to the tail of the importance weights of $q$ against the potential,\n",
+    "where below roughly 0.5 is good and above 1.0 indicates a poor approximation\n",
+    "([Yao et al., 2018](https://arxiv.org/abs/1802.02538)). Passing\n",
+    "`quality_control_metric=\"prop\"` instead reports an $R^2$ of $q$ against the joint, where\n",
+    "values above 0.5 are good."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "vi_posterior.evaluate()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where feasible, also compare against MCMC on the same observation. `evaluate()` and the\n",
+    "`vi_method` choices apply to fixed-observation VI only."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Refine a fixed-observation VI posterior\n",
+    "\n",
+    "Sampling-importance-resampling (SIR) can use the trained VI posterior as a proposal. This\n",
+    "workflow is fixed at `x_o`; it does not imply batched refinement of an amortized\n",
+    "posterior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.inference import ImportanceSamplingPosterior\n",
+    "\n",
+    "refined_posterior = ImportanceSamplingPosterior(\n",
+    "    potential_fn=vi_posterior.potential_fn,\n",
+    "    proposal=vi_posterior,\n",
+    "    method=\"sir\",\n",
+    ").set_default_x(x_o)\n",
+    "refined_samples = refined_posterior.sample((1000,), oversampling_factor=32)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the importance weights before relying on the refined result. See the\n",
+    "[dedicated importance-sampling guide](10_refine_posterior_with_importance_sampling.ipynb)\n",
+    "for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sequential NLE with VI\n",
+    "\n",
+    "Fixed-observation VI can also act as the sampler in sequential NLE. In each round, train\n",
+    "or update the NLE, fit a `VIPosterior` to `x_o`, sample parameters from it for the next\n",
+    "simulations, append those simulations, and repeat. This is SNLE with VI instead of MCMC\n",
+    "([Glöckler et al., 2022](https://arxiv.org/abs/2203.04176))."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "proposal = prior\n",
+    "for _ in range(num_rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    inference.append_simulations(theta, x).train()\n",
+    "    posterior = inference.build_posterior(\n",
+    "        sample_with=\"vi\",\n",
+    "        posterior_parameters=VIPosteriorParameters(vi_method=\"fKL\"),\n",
+    "    ).set_default_x(x_o)\n",
+    "    proposal = posterior.train()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amortized VI\n",
+    "\n",
+    "Amortized VI learns a conditional approximation $q(\\theta \\mid x)$ from simulation pairs,\n",
+    "so one fit serves many observations. The variational family is set with `q`, which accepts\n",
+    "the usual estimator strings:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "amortized_vi = inference.build_posterior(\n",
+    "    sample_with=\"vi\",\n",
+    "    posterior_parameters=VIPosteriorParameters(\n",
+    "        q=\"nsf\", num_transforms=2, hidden_features=32\n",
+    "    ),\n",
+    ")\n",
+    "amortized_vi.train_amortized(theta, x)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `sample()` for one observation, `sample_batched()` for several observations at once,\n",
+    "and `log_prob()` to evaluate the learned normalized approximation. There is no\n",
+    "`log_prob_batched()` for VI posteriors, so evaluate one observation at a time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "samples = amortized_vi.sample((1000,), x=x_o)\n",
+    "batched_samples = amortized_vi.sample_batched((1000,), x=x_batch)\n",
+    "log_probs = amortized_vi.log_prob(samples, x=x_o)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amortized VI currently optimizes the evidence lower bound (ELBO), which corresponds to\n",
+    "reverse KL; the alternative `vi_method` choices do not apply. Check accuracy on\n",
+    "representative held-out observations, for example with\n",
+    "[expected coverage](15_expected_coverage.ipynb) or\n",
+    "[SBC](16_sbc.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/how_to_guide/26_variational_inference.ipynb
+++ b/docs/how_to_guide/26_variational_inference.ipynb
@@ -42,7 +42,6 @@
     "from sbi.inference.posteriors import VIPosteriorParameters\n",
     "\n",
     "vi_posterior = inference.build_posterior(\n",
-    "    sample_with=\"vi\",\n",
     "    posterior_parameters=VIPosteriorParameters(vi_method=\"rKL\"),\n",
     ")\n",
     "vi_posterior.train(x=x_o)\n",
@@ -150,7 +149,6 @@
     "    x = simulator(theta)\n",
     "    inference.append_simulations(theta, x).train()\n",
     "    posterior = inference.build_posterior(\n",
-    "        sample_with=\"vi\",\n",
     "        posterior_parameters=VIPosteriorParameters(vi_method=\"fKL\"),\n",
     "    ).set_default_x(x_o)\n",
     "    proposal = posterior.train()\n",
@@ -174,7 +172,6 @@
    "source": [
     "```python\n",
     "amortized_vi = inference.build_posterior(\n",
-    "    sample_with=\"vi\",\n",
     "    posterior_parameters=VIPosteriorParameters(\n",
     "        q=\"nsf\", num_transforms=2, hidden_features=32\n",
     "    ),\n",

--- a/docs/how_to_guide/sampling.rst
+++ b/docs/how_to_guide/sampling.rst
@@ -8,6 +8,7 @@ Sampling
    :maxdepth: 1
 
    09_sampler_interface.ipynb
+   26_variational_inference.ipynb
    10_refine_posterior_with_importance_sampling.ipynb
    11_iid_sampling_with_nle_or_nre.ipynb
    12_mcmc_diagnostics_with_arviz.ipynb

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,7 +27,8 @@ expected coverage, TARP, L-C2ST).
 - [Density Estimators](https://sbi.readthedocs.io/en/latest/how_to_guide/03_density_estimators.html): Choosing and configuring neural networks
 - [Embedding Networks](https://sbi.readthedocs.io/en/latest/how_to_guide/04_embedding_networks.html): FCEmbedding, CNNEmbedding, custom nn.Module
 - [Choosing Inference Method](https://sbi.readthedocs.io/en/latest/how_to_guide/06_choosing_inference_method.html): NPE vs NLE vs NRE decision guide
-- [Sampler Interface](https://sbi.readthedocs.io/en/latest/how_to_guide/09_sampler_interface.html): MCMC, VI, rejection for NLE/NRE posteriors
+- [Sampler Interface](https://sbi.readthedocs.io/en/latest/how_to_guide/09_sampler_interface.html): Choosing MCMC, rejection, VI or importance sampling for NLE/NRE posteriors
+- [Variational Inference](https://sbi.readthedocs.io/en/latest/how_to_guide/26_variational_inference.html): Fixed-observation and amortized VI, quality checks, SIR refinement
 - [i.i.d. Observations](https://sbi.readthedocs.io/en/latest/how_to_guide/11_iid_sampling_with_nle_or_nre.html): Multiple observations with NLE/NRE
 - [Hyperparameter Tuning](https://sbi.readthedocs.io/en/latest/how_to_guide/21_hyperparameter_tuning.html): Optuna integration for architecture search
 - [Abstraction Levels](https://sbi.readthedocs.io/en/latest/how_to_guide/24_abstraction_levels.html): Four levels of control over the density estimator (Trainer classes to custom `nn.Module`), plus sampling-control levels for NLE

--- a/docs/tutorials/16_implemented_methods.ipynb
+++ b/docs/tutorials/16_implemented_methods.ipynb
@@ -458,7 +458,9 @@
     "### Glöckler et al., 2022\n",
     "\n",
     "_Variational methods for simulation-based inference_ by Glöckler, Deistler, Macke\n",
-    "(ICLR 2022) [[Paper]](https://arxiv.org/abs/2203.04176)\n"
+    "(ICLR 2022) [[Paper]](https://arxiv.org/abs/2203.04176)\n",
+    "\n",
+    "See [how to use variational inference](../how_to_guide/26_variational_inference.ipynb) for an explanation of this workflow and of the amortized variant."
    ]
   },
   {


### PR DESCRIPTION
As discussed in #1765, the how-to guides around sampling methods and VI are a bit outdated and in parts misleading. This PR reworks them.

### Restructure the sampler guide

`09_sampler_interface` was accurate but hard to act on: it opened abruptly and mixed
recommendations, configuration and low-level API across a flat list of sections. It now
follows the path a stuck user actually takes:

1. **General context** — why sampling differs between methods at all: NPE approximates the
   posterior directly so sampling is a forward pass, while NLE and NRE give a score
   proportional to the log posterior and need an extra algorithm.
2. **Which sampler do you need?** — routing by the inference method used, not by sampler.
   NPE/FMPE/NPSE: nothing to choose, plus the two exceptions (leakage, evaluable
   likelihood). NLE/NRE: start with MCMC, then branch to VI, rejection or importance
   sampling by the symptom you have.
3. **Setting the sampler** — `build_posterior(sample_with=...)` with `PosteriorParameters`.
4. **Full control** — the potential-function API as the low-level, high-flexibility
   interface, including building the sampler classes on a potential directly to use a
   non-prior proposal.

### Give VI its own guide

VI had no guide of its own, so the sampler guide was the only place documenting
`train()` vs `train_amortized()`, the `vi_method` options and `evaluate()`. That content
moves to a new `26_variational_inference` guide, which covers fixed-observation VI, quality
control with $\hat{k}$, SIR refinement, sequential NLE with VI, and amortized VI. The
sampler guide now links to it, as do the abstraction-levels and `PosteriorParameters`
guides and the implemented-methods tutorial.

### Corrections

- Replace fixed parameter- and observation-count heuristics with guidance based on
  posterior geometry, proposal overlap, computational budget, repeated-observation needs
  and diagnostics.
- Fix the rejection-sampling acceptance-rate claim. `RejectionPosterior.sample()` discards
  the rate returned by `rejection_sample()`, so it cannot be read from the documented
  workflow; the sub-1% `logging.warning` is the only user-facing signal. Call
  `sbi.samplers.rejection.rejection_sample()` directly if the number itself is needed.
- Clarify the amortized ELBO/reverse-KL limitation and the mode-switching behaviour between
  `train()` and `train_amortized()`.
- Scope importance sampling and SIR refinement to fixed-observation posteriors.
- Repair related inference-method links, including a link with a blank target.
- Add the vector-field guide to the how-to landing page; it was registered in the sampling
  toctree but missing from the list.

Every API name, keyword argument, default and behavioural claim in the new text was checked
against the source rather than carried over on trust.

Docs-only change, so no CHANGELOG entry and no tests. Built locally with Sphinx; all
cross-references resolve.

Claude Code assisted with the restructure and with verifying the API claims.

Closes #1765
