### PR TITLE
first attempt to remove potential.to and let the poeterior handle it

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -22,6 +22,7 @@ from sbi.sbi_types import Shape
 from sbi.utils.sbiutils import warn_if_outside_prior_support, within_support
 from sbi.utils.torchutils import ensure_theta_batched
 from sbi.utils.user_input_checks import check_prior
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class DirectPosterior(NeuralPosterior):
@@ -103,10 +104,7 @@ class DirectPosterior(NeuralPosterior):
             device: device where to move the posterior to.
         """
         self.device = device
-        if hasattr(self.prior, "to"):
-            self.prior.to(device)  # type: ignore
-        else:
-            raise ValueError("""Prior has no attribute to(device).""")
+        self.prior = move_distribution_to_device(self.prior, device)
         if hasattr(self.posterior_estimator, "to"):
             self.posterior_estimator.to(device)
         else:

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -14,6 +14,7 @@ from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils.sbiutils import gradient_ascent, mcmc_transform
 from sbi.utils.torchutils import ensure_theta_batched
 from sbi.utils.user_input_checks import process_x
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class EnsemblePosterior(NeuralPosterior):
@@ -108,7 +109,7 @@ class EnsemblePosterior(NeuralPosterior):
         self._device = device
         for i in range(len(self.posteriors)):
             self.posteriors[i].to(device)
-        self.prior.to(device)
+        self.prior = move_distribution_to_device(self.prior, device)
         self.theta_transform = mcmc_transform(self.prior, device=device)
         self._weights.to(device)
         self._build_potential_fns()
@@ -467,11 +468,13 @@ class EnsemblePotential(BasePotential):
             self.potential_fns[i]._move_estimator_to_device(device)  # type: ignore
             self.potential_fns[i].device = device
             if self.potential_fns[i].prior is not None:
-                self.potential_fns[i].prior = self.potential_fns[i].prior.to(device)
+                self.potential_fns[i].prior = move_distribution_to_device(
+                    self.potential_fns[i].prior, device
+                )
             if self.potential_fns[i]._x_o is not None:
                 self.potential_fns[i]._x_o = self.potential_fns[i]._x_o.to(device)
         self._weights = self._weights.to(device)
-        self.prior.to(device)  # type: ignore
+        self.prior = move_distribution_to_device(self.prior, device)
         if self._x_o is not None:
             self._x_o = self._x_o.to(device)
 

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -464,7 +464,12 @@ class EnsemblePotential(BasePotential):
         """
         self.device = device
         for i in range(len(self.potential_fns)):
-            self.potential_fns[i].to(device)
+            self.potential_fns[i]._move_estimator_to_device(device)  # type: ignore
+            self.potential_fns[i].device = device
+            if self.potential_fns[i].prior is not None:
+                self.potential_fns[i].prior = self.potential_fns[i].prior.to(device)
+            if self.potential_fns[i]._x_o is not None:
+                self.potential_fns[i]._x_o = self.potential_fns[i]._x_o.to(device)
         self._weights = self._weights.to(device)
         self.prior.to(device)  # type: ignore
         if self._x_o is not None:

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -88,7 +88,12 @@ class ImportanceSamplingPosterior(NeuralPosterior):
             device: Device on which to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
+        self.potential_fn._move_estimator_to_device(device)  # type: ignore
+        self.potential_fn.device = device
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -13,6 +13,7 @@ from sbi.samplers.importance.sir import sampling_importance_resampling
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils.sbiutils import mcmc_transform
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class ImportanceSamplingPosterior(NeuralPosterior):
@@ -91,7 +92,9 @@ class ImportanceSamplingPosterior(NeuralPosterior):
         self.potential_fn._move_estimator_to_device(device)  # type: ignore
         self.potential_fn.device = device
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -168,7 +168,12 @@ class MCMCPosterior(NeuralPosterior):
             device: Device to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
+        self.potential_fn._move_estimator_to_device(device)  # type: ignore
+        self.potential_fn.device = device
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -30,6 +30,7 @@ from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched, tensor2numpy
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class MCMCPosterior(NeuralPosterior):
@@ -171,7 +172,9 @@ class MCMCPosterior(NeuralPosterior):
         self.potential_fn._move_estimator_to_device(device)  # type: ignore
         self.potential_fn.device = device
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -14,6 +14,7 @@ from sbi.samplers.rejection.rejection import rejection_sample
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class RejectionPosterior(NeuralPosterior):
@@ -85,7 +86,9 @@ class RejectionPosterior(NeuralPosterior):
         self.potential_fn._move_estimator_to_device(device)  # type: ignore
         self.potential_fn.device = device
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -82,7 +82,12 @@ class RejectionPosterior(NeuralPosterior):
             device: The device to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
+        self.potential_fn._move_estimator_to_device(device)  # type: ignore
+        self.potential_fn.device = device
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self.proposal.to(device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -129,6 +129,10 @@ class VectorFieldPosterior(NeuralPosterior):
             x_o=None,
             enable_transform=self.enable_transform,
         )
+        # Copy neural_ode params from old potential to new potential to preserve
+        # runtime parameter modifications (e.g., exact, atol, rtol) set during training
+        if hasattr(self, "potential_fn") and hasattr(self.potential_fn, "neural_ode"):
+            potential_fn.neural_ode.params.update(self.potential_fn.neural_ode.params)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):
             x_o = self._x.to(device)

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -129,10 +129,6 @@ class VectorFieldPosterior(NeuralPosterior):
             x_o=None,
             enable_transform=self.enable_transform,
         )
-        # Copy neural_ode params from old potential to new potential to preserve
-        # runtime parameter modifications (e.g., exact, atol, rtol) set during training
-        if hasattr(self, "potential_fn") and hasattr(self.potential_fn, "neural_ode"):
-            potential_fn.neural_ode.params.update(self.potential_fn.neural_ode.params)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):
             x_o = self._x.to(device)

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -31,6 +31,7 @@ from sbi.utils.sbiutils import (
     within_support,
 )
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class VectorFieldPosterior(NeuralPosterior):
@@ -116,10 +117,7 @@ class VectorFieldPosterior(NeuralPosterior):
             device: device where to move the posterior to.
         """
         self.device = device
-        if hasattr(self.prior, "to"):
-            self.prior.to(device)  # type: ignore
-        else:
-            raise ValueError("""Prior has no attribute to(device).""")
+        self.prior = move_distribution_to_device(self.prior, device)
         if hasattr(self.vector_field_estimator, "to"):
             self.vector_field_estimator.to(device)
         else:

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -227,7 +227,9 @@ class VIPosterior(NeuralPosterior):
         self.potential_fn._move_estimator_to_device(device)  # type: ignore
         self.potential_fn.device = device
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self._prior = move_distribution_to_device(self._prior, device)
@@ -1116,7 +1118,9 @@ class VIPosterior(NeuralPosterior):
         # Ensure potential_fn is on the correct device for amortized training
         self.potential_fn._move_estimator_to_device(self._device)  # type: ignore
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(self._device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, self._device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(self._device)
 

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -156,7 +156,7 @@ class VIPosterior(NeuralPosterior):
         self.theta_transform = theta_transform
         self.x_shape = x_shape
         self.potential_fn.device = device
-        self.potential_fn.to(device)
+        self.potential_fn._move_estimator_to_device(device)  # type: ignore
 
         # Get prior and previous builds
         if prior is not None:
@@ -223,8 +223,13 @@ class VIPosterior(NeuralPosterior):
         """
         self._device = device
 
-        # Move potential (which moves prior, x_o, and estimator).
-        self.potential_fn.to(device)  # type: ignore
+        # Move potential components explicitly.
+        self.potential_fn._move_estimator_to_device(device)  # type: ignore
+        self.potential_fn.device = device
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(device)
         self._prior = move_distribution_to_device(self._prior, device)
 
         # Rebuild link_transform on new device (same logic as __init__).
@@ -1109,7 +1114,11 @@ class VIPosterior(NeuralPosterior):
             )
 
         # Ensure potential_fn is on the correct device for amortized training
-        self.potential_fn.to(self._device)
+        self.potential_fn._move_estimator_to_device(self._device)  # type: ignore
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(self._device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(self._device)
 
         # Setup optimizer
         optimizer = Adam(self._amortized_q.parameters(), lr=learning_rate)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -120,13 +120,13 @@ class BasePotential(metaclass=ABCMeta):
         issues = []
 
         try:
-            est_device = next(self._get_estimator_parameters_device())
+            est_device = self._get_estimator_parameters_device()
             if est_device != torch.device(device):
                 issues.append(
                     f"estimator is on {est_device}, expected {device}. "
                     "Move it explicitly: estimator.to(device)"
                 )
-        except (NotImplementedError, StopIteration):
+        except NotImplementedError:
             pass
 
         if self.prior is not None and hasattr(self.prior, "sample"):
@@ -197,6 +197,7 @@ class CustomPotentialWrapper(BasePotential):
 
         Note, x_o is re-used from the initialization of the potential function.
         """
+        self._check_on_device(self.device)
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)
 

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -9,7 +9,6 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 from sbi.utils.user_input_checks import process_x
-from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class BasePotential(metaclass=ABCMeta):
@@ -91,24 +90,73 @@ class BasePotential(metaclass=ABCMeta):
         """
         return self._x_o
 
-    def to(self, device: Union[str, torch.device]) -> "BasePotential":
-        """Move prior and x_o to the given device.
+    def _move_estimator_to_device(
+        self, device: Union[str, torch.device]
+    ) -> "BasePotential":
+        """Move the neural estimator to the given device.
 
-        It also sets the device attribute to the given device.
+        Subclasses must override this if they have an estimator attribute.
 
         Args:
-            device: Device to move the prior and x_o to.
+            device: Device to move the estimator to.
 
         Returns:
             Self for method chaining.
         """
-
-        self.device = device
-        if self.prior is not None:
-            self.prior = move_distribution_to_device(self.prior, device)
-        if self._x_o is not None:
-            self._x_o = self._x_o.to(device)
         return self
+
+    def _check_on_device(self, device: Union[str, torch.device]) -> None:
+        """Check that estimator, prior and x_o are on the expected device.
+
+        Raises an informative error if any component is on a different device,
+        guiding users to move components explicitly before creating the potential.
+
+        Args:
+            device: Expected device.
+
+        Raises:
+            RuntimeError: If any component is on a different device.
+        """
+        issues = []
+
+        try:
+            est_device = next(self._get_estimator_parameters_device())
+            if est_device != torch.device(device):
+                issues.append(
+                    f"estimator is on {est_device}, expected {device}. "
+                    "Move it explicitly: estimator.to(device)"
+                )
+        except (NotImplementedError, StopIteration):
+            pass
+
+        if self.prior is not None and hasattr(self.prior, "sample"):
+            try:
+                prior_device = self.prior.sample((1,)).device
+                if prior_device != torch.device(device):
+                    issues.append(
+                        f"prior is on {prior_device}, expected {device}. "
+                        "Move it explicitly: prior = prior.to(device)"
+                    )
+            except Exception:
+                pass
+
+        if self._x_o is not None:
+            x_o_device = self._x_o.device
+            if x_o_device != torch.device(device):
+                issues.append(
+                    f"x_o is on {x_o_device}, expected {device}. "
+                    "Move it explicitly: x_o = x_o.to(device)"
+                )
+
+        if issues:
+            raise RuntimeError(
+                "Device mismatch detected. Move components explicitly before creating "
+                "the potential:\n  " + "\n  ".join(issues)
+            )
+
+    def _get_estimator_parameters_device(self):
+        """Yield device of estimator parameters. Subclasses override."""
+        raise NotImplementedError
 
 
 class CustomPotential(Protocol):
@@ -143,18 +191,6 @@ class CustomPotentialWrapper(BasePotential):
         super().__init__(prior, x_o, device)
 
         self.potential_fn = potential_fn
-
-    def to(self, device: Union[str, torch.device]) -> "CustomPotentialWrapper":
-        """Move prior and x_o to the given device.
-
-        Args:
-            device: Device to move the prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        return self
 
     def __call__(self, theta, track_gradients: bool = True):
         """Calls the custom potential function on given theta.

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -105,59 +105,6 @@ class BasePotential(metaclass=ABCMeta):
         """
         return self
 
-    def _check_on_device(self, device: Union[str, torch.device]) -> None:
-        """Check that estimator, prior and x_o are on the expected device.
-
-        Raises an informative error if any component is on a different device,
-        guiding users to move components explicitly before creating the potential.
-
-        Args:
-            device: Expected device.
-
-        Raises:
-            RuntimeError: If any component is on a different device.
-        """
-        issues = []
-
-        try:
-            est_device = self._get_estimator_parameters_device()
-            if est_device != torch.device(device):
-                issues.append(
-                    f"estimator is on {est_device}, expected {device}. "
-                    "Move it explicitly: estimator.to(device)"
-                )
-        except NotImplementedError:
-            pass
-
-        if self.prior is not None and hasattr(self.prior, "sample"):
-            try:
-                prior_device = self.prior.sample((1,)).device
-                if prior_device != torch.device(device):
-                    issues.append(
-                        f"prior is on {prior_device}, expected {device}. "
-                        "Move it explicitly: prior = prior.to(device)"
-                    )
-            except Exception:
-                pass
-
-        if self._x_o is not None:
-            x_o_device = self._x_o.device
-            if x_o_device != torch.device(device):
-                issues.append(
-                    f"x_o is on {x_o_device}, expected {device}. "
-                    "Move it explicitly: x_o = x_o.to(device)"
-                )
-
-        if issues:
-            raise RuntimeError(
-                "Device mismatch detected. Move components explicitly before creating "
-                "the potential:\n  " + "\n  ".join(issues)
-            )
-
-    def _get_estimator_parameters_device(self):
-        """Yield device of estimator parameters. Subclasses override."""
-        raise NotImplementedError
-
 
 class CustomPotential(Protocol):
     """Protocol for custom potential functions."""
@@ -197,7 +144,6 @@ class CustomPotentialWrapper(BasePotential):
 
         Note, x_o is re-used from the initialization of the potential function.
         """
-        self._check_on_device(self.device)
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)
 

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -87,9 +87,6 @@ class LikelihoodBasedPotential(BasePotential):
         self.likelihood_estimator = self.likelihood_estimator.to(device)
         return self
 
-    def _get_estimator_parameters_device(self):
-        return next(self.likelihood_estimator.parameters()).device
-
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "LikelihoodBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = LikelihoodBasedPotential(
@@ -111,7 +108,6 @@ class LikelihoodBasedPotential(BasePotential):
         Returns:
             The potential $\log(p(x_o|\theta)p(\theta))$.
         """
-        self._check_on_device(self.device)
         if self.x_is_iid:
             # For each theta, calculate the likelihood sum over all x in batch.
             log_likelihood_trial_sum = _log_likelihoods_over_trials(

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -111,6 +111,7 @@ class LikelihoodBasedPotential(BasePotential):
         Returns:
             The potential $\log(p(x_o|\theta)p(\theta))$.
         """
+        self._check_on_device(self.device)
         if self.x_is_iid:
             # For each theta, calculate the likelihood sum over all x in batch.
             log_likelihood_trial_sum = _log_likelihoods_over_trials(

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -81,18 +81,14 @@ class LikelihoodBasedPotential(BasePotential):
         self.likelihood_estimator = likelihood_estimator
         self.likelihood_estimator.eval()
 
-    def to(self, device: Union[str, torch.device]) -> "LikelihoodBasedPotential":
-        """Move likelihood estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the likelihood_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.likelihood_estimator.to(device)
+    def _move_estimator_to_device(
+        self, device: Union[str, torch.device]
+    ) -> "LikelihoodBasedPotential":
+        self.likelihood_estimator = self.likelihood_estimator.to(device)
         return self
+
+    def _get_estimator_parameters_device(self):
+        return next(self.likelihood_estimator.parameters()).device
 
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "LikelihoodBasedPotential":
         """Create new potential with x bound, without mutable state."""

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -87,18 +87,14 @@ class PosteriorBasedPotential(BasePotential):
         self.posterior_estimator = posterior_estimator
         self.posterior_estimator.eval()
 
-    def to(self, device: Union[str, torch.device]) -> "PosteriorBasedPotential":
-        """Move posterior estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the posterior_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.posterior_estimator.to(device)
+    def _move_estimator_to_device(
+        self, device: Union[str, torch.device]
+    ) -> "PosteriorBasedPotential":
+        self.posterior_estimator = self.posterior_estimator.to(device)
         return self
+
+    def _get_estimator_parameters_device(self):
+        return next(self.posterior_estimator.parameters()).device
 
     def bind(self, x_o: Tensor, x_is_iid: bool = False) -> "PosteriorBasedPotential":
         """Create new potential with x bound, without mutable state."""

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -123,6 +123,7 @@ class PosteriorBasedPotential(BasePotential):
         Returns:
             The potential.
         """
+        self._check_on_device(self.device)
 
         if self._x_o is None:
             raise ValueError(

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -93,9 +93,6 @@ class PosteriorBasedPotential(BasePotential):
         self.posterior_estimator = self.posterior_estimator.to(device)
         return self
 
-    def _get_estimator_parameters_device(self):
-        return next(self.posterior_estimator.parameters()).device
-
     def bind(self, x_o: Tensor, x_is_iid: bool = False) -> "PosteriorBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = PosteriorBasedPotential(
@@ -123,8 +120,6 @@ class PosteriorBasedPotential(BasePotential):
         Returns:
             The potential.
         """
-        self._check_on_device(self.device)
-
         if self._x_o is None:
             raise ValueError(
                 "No observed data x_o is available. Please reinitialize \

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -69,18 +69,14 @@ class RatioBasedPotential(BasePotential):
         self.ratio_estimator = ratio_estimator
         self.ratio_estimator.eval()
 
-    def to(self, device: Union[str, torch.device]) -> "RatioBasedPotential":
-        """Move ratio estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the ratio_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.ratio_estimator.to(device)
+    def _move_estimator_to_device(
+        self, device: Union[str, torch.device]
+    ) -> "RatioBasedPotential":
+        self.ratio_estimator = self.ratio_estimator.to(device)
         return self
+
+    def _get_estimator_parameters_device(self):
+        return next(self.ratio_estimator.parameters()).device
 
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "RatioBasedPotential":
         """Create new potential with x bound, without mutable state."""

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -75,9 +75,6 @@ class RatioBasedPotential(BasePotential):
         self.ratio_estimator = self.ratio_estimator.to(device)
         return self
 
-    def _get_estimator_parameters_device(self):
-        return next(self.ratio_estimator.parameters()).device
-
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "RatioBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = RatioBasedPotential(
@@ -99,7 +96,6 @@ class RatioBasedPotential(BasePotential):
         Returns:
             The potential.
         """
-        self._check_on_device(self.device)
         if self.x_is_iid:
             # For each theta, calculate likelihood ratio sum over all x in batch.
             log_ratio_trial_sum = _log_ratios_over_trials(

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -99,6 +99,7 @@ class RatioBasedPotential(BasePotential):
         Returns:
             The potential.
         """
+        self._check_on_device(self.device)
         if self.x_is_iid:
             # For each theta, calculate likelihood ratio sum over all x in batch.
             log_ratio_trial_sum = _log_ratios_over_trials(

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -84,9 +84,6 @@ class VectorFieldBasedPotential(BasePotential):
         self.vector_field_estimator = self.vector_field_estimator.to(device)
         return self
 
-    def _get_estimator_parameters_device(self):
-        return next(self.vector_field_estimator.parameters()).device
-
     def set_x(
         self,
         x_o: Optional[Tensor],
@@ -170,8 +167,6 @@ class VectorFieldBasedPotential(BasePotential):
         Returns:
             The potential function, i.e., the log probability of the posterior.
         """
-        self._check_on_device(self.device)
-
         if self.guidance_method is not None:
             raise NotImplementedError(
                 "Potential evaluation for guidance is not supported yet."

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -78,22 +78,14 @@ class VectorFieldBasedPotential(BasePotential):
 
         super().__init__(prior, x_o, device=device)
 
-    def to(self, device: Union[str, torch.device]) -> None:
-        """
-        Moves score_estimator, prior and x_o to the given device.
+    def _move_estimator_to_device(
+        self, device: Union[str, torch.device]
+    ) -> "VectorFieldBasedPotential":
+        self.vector_field_estimator = self.vector_field_estimator.to(device)
+        return self
 
-        It also sets the device attribute to the given device.
-
-        Args:
-            device: Device to move the score_estimator, prior and x_o to.
-        """
-
-        self.device = device
-        self.vector_field_estimator.to(device)
-        if self.prior:
-            self.prior.to(device)  # type: ignore
-        if self._x_o is not None:
-            self._x_o = self._x_o.to(device)
+    def _get_estimator_parameters_device(self):
+        return next(self.vector_field_estimator.parameters()).device
 
     def set_x(
         self,

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -170,6 +170,7 @@ class VectorFieldBasedPotential(BasePotential):
         Returns:
             The potential function, i.e., the log probability of the posterior.
         """
+        self._check_on_device(self.device)
 
         if self.guidance_method is not None:
             raise NotImplementedError(

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -176,7 +176,9 @@ class DivergenceOptimizer(ABC):
         self.potential_fn._move_estimator_to_device(self.device)  # type: ignore
         self.potential_fn.device = self.device
         if self.potential_fn.prior is not None:
-            self.potential_fn.prior = self.potential_fn.prior.to(self.device)
+            self.potential_fn.prior = move_distribution_to_device(
+                self.potential_fn.prior, self.device
+            )
         if self.potential_fn._x_o is not None:
             self.potential_fn._x_o = self.potential_fn._x_o.to(self.device)
         if hasattr(self.q, "to"):

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -173,7 +173,12 @@ class DivergenceOptimizer(ABC):
         posterior"""
 
         self.device = device
-        self.potential_fn.to(self.device)
+        self.potential_fn._move_estimator_to_device(self.device)  # type: ignore
+        self.potential_fn.device = self.device
+        if self.potential_fn.prior is not None:
+            self.potential_fn.prior = self.potential_fn.prior.to(self.device)
+        if self.potential_fn._x_o is not None:
+            self.potential_fn._x_o = self.potential_fn._x_o.to(self.device)
         if hasattr(self.q, "to"):
             self.q.to(self.device)
         if self.prior is not None:


### PR DESCRIPTION
first attempt to remove potential.to and let the poeterior handle it.

The idea for the usage is that there are 2 ways of setting this up:

Option 1: Move components _before_ creating potential:
```python
estimator.to(device)
prior = prior.to(device)
x = x.to(device)
potential = SomePotential)estimator, prior).bind(x)
```

Option 2: Use posterior.to(device)
```python
posterior = inference.build_posterior()
posterior.to(device)
```

Note: the `_move_estimator_to_device` seems a bit unintuitive at first, b/c its definition inside BasePotential just returns self, however for the other potentials there is runs the estimator removal. This feels a bit off, however I can't think of any other way of doing this