### PR TITLE
fix: make VIPosterior serialization state-based

### DIFF
--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -61,10 +61,8 @@ QType = Union[VariationalFamily, Distribution, "VIPosterior", Callable]
 class _QSpec:
     """Serializable recipe for rebuilding the variational distribution.
 
-    Holds data only, so it pickles by value; the matching builder is
-    `VIPosterior._build_q_from_spec`, a method and therefore pickled by reference.
-    Storing a build *closure* on the instance instead is what made pickling
-    unrecoverable.
+    Must hold data only, so that it pickles by value; the builder that consumes it,
+    `VIPosterior._build_q_from_spec`, is a method and so pickles by reference.
 
     Attributes:
         kind: Which family `q` came from.
@@ -72,8 +70,7 @@ class _QSpec:
         full_covariance: Whether the Gaussian is full-rank, for `kind="gaussian"`.
         builder: The user's own builder, for `kind="callable"`.
         init_snapshot: Pre-training copy of a user distribution, for
-            `kind="distribution"`. sbi cannot re-randomize an opaque user object, so
-            returning to this snapshot is the only reproducible option.
+            `kind="distribution"`.
     """
 
     kind: Literal["flow", "gaussian", "callable", "distribution", "instance"]
@@ -392,9 +389,6 @@ class VIPosterior(NeuralPosterior):
             )
         if spec.kind == "distribution":
             assert spec.init_snapshot is not None
-            # Copy rather than hand out the stored snapshot itself, so callers cannot
-            # train on it. `set_q` re-snapshots anyway, but not relying on that keeps
-            # this method self-contained.
             return detach_and_deepcopy(spec.init_snapshot)
         raise ValueError(
             "Cannot rebuild `q`: it was passed as a pre-built distribution instance, "
@@ -512,14 +506,11 @@ class VIPosterior(NeuralPosterior):
             modules = []
         _flow_types = (ZukoUnconditionalFlow, TransformedZukoFlow, LearnableGaussian)
         if isinstance(q, _flow_types):
-            # A pre-built instance carries no recipe of its own. `train` restores the
-            # spec around its own rebuild, so keeping a stale one here would silently
-            # rebuild the wrong family for an external caller.
+            # A pre-built instance carries no recipe; `train` restores its own spec.
             self._q_spec = _QSpec(kind="instance")
             self._trained_on = None
         elif isinstance(q, Distribution):
-            # An already-adapted `q` comes back from `_build_q_from_spec`; re-wrapping
-            # it would apply `link_transform` a second time.
+            # Re-wrapping would apply `link_transform` twice.
             if not isinstance(q, AdaptedVariationalDistribution):
                 q = AdaptedVariationalDistribution(
                     q,
@@ -528,8 +519,6 @@ class VIPosterior(NeuralPosterior):
                     parameters=parameters,
                     modules=modules,
                 )
-            # sbi cannot re-randomize an opaque user distribution, so `retrain_from
-            # _scratch` returns to this pre-training snapshot.
             self._q_spec = _QSpec(
                 kind="distribution", init_snapshot=detach_and_deepcopy(q)
             )
@@ -855,8 +844,7 @@ class VIPosterior(NeuralPosterior):
 
         # Init q and the optimizer if necessary
         if retrain_from_scratch:
-            # The `q` setter reclassifies by type, which would downgrade the recipe to
-            # `kind="instance"`; keep ours so repeated retrains stay possible.
+            # The `q` setter reclassifies by type, so restore our recipe afterwards.
             spec = self._q_spec
             self.q = self._build_q_from_spec()
             self._q_spec = spec
@@ -1380,12 +1368,10 @@ class VIPosterior(NeuralPosterior):
         )
 
     def __getstate__(self) -> Dict:
-        """Return the state to pickle.
+        """Return the state to pickle, also used by `copy.deepcopy`.
 
-        Copies first and nulls in the copy, so serializing never mutates the live
-        object. `_optimizer` is dropped as transient training state; `train()` rebuilds
-        it on demand. `copy.deepcopy` routes through here too, so both protocols share
-        one path.
+        Must null in the copy rather than on `self`, so that serializing cannot mutate
+        the live posterior. `train()` rebuilds the dropped `_optimizer` on demand.
 
         Returns:
             The attributes to pickle.

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -3,7 +3,7 @@
 
 import warnings
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, Literal, Optional, Union
 
 import numpy as np
@@ -138,7 +138,9 @@ class VIPosterior(NeuralPosterior):
                 TorchTransform, device: str) -> Distribution` for custom flow
                 configurations. The
                 callable should return a distribution with `sample()` and `log_prob()`
-                methods. If q is already a `VIPosterior`, then the arguments will be
+                methods, and should be a module-level function: the posterior keeps it
+                in order to rebuild `q`, and a local function or lambda cannot be
+                pickled. If q is already a `VIPosterior`, then the arguments will be
                 copied from it (relevant for multi-round training).
             theta_transform: Maps form prior support to unconstrained space. The
                 inverse is used here to ensure that the posterior support is equal to
@@ -487,7 +489,9 @@ class VIPosterior(NeuralPosterior):
                 parameters (you can pass them within the parameters/modules attribute).
                 Additionally, we allow a `Callable` with signature
                 `(event_shape: torch.Size, link_transform: TorchTransform, device: str)
-                -> Distribution`, which builds a custom distribution. If q is already
+                -> Distribution`, which builds a custom distribution. It should be a
+                module-level function: the posterior keeps it in order to rebuild `q`,
+                and a local function or lambda cannot be pickled. If q is already
                 a `VIPosterior`, then the arguments will be copied from it (relevant
                 for multi-round training).
 
@@ -543,7 +547,8 @@ class VIPosterior(NeuralPosterior):
                 q = self._build_q_from_spec()
             self._trained_on = None
         elif isinstance(q, VIPosterior):
-            self._q_spec = q._q_spec
+            # A copy, so that later `set_q` calls on one posterior stay local to it.
+            self._q_spec = replace(q._q_spec)
             self._trained_on = q._trained_on
             self._mode = getattr(q, "_mode", None)  # Copy mode from source
             self.vi_method = q.vi_method  # type: ignore

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -59,17 +59,18 @@ QType = Union[VariationalFamily, Distribution, "VIPosterior", Callable]
 
 @dataclass
 class _QSpec:
-    """Serializable recipe for rebuilding the variational distribution.
+    """Stores how to rebuild the variational distribution.
 
-    Must hold data only, so that it pickles by value; the builder that consumes it,
-    `VIPosterior._build_q_from_spec`, is a method and so pickles by reference.
+    Must contain only data, never a function defined inside a method: those cannot be
+    pickled, which is why the construction itself lives in
+    `VIPosterior._build_q_from_spec`.
 
     Attributes:
-        kind: Which family `q` came from.
+        kind: Which variational family `q` was built from.
         flow_type: Zuko flow name, for `kind="flow"`.
         full_covariance: Whether the Gaussian is full-rank, for `kind="gaussian"`.
-        builder: The user's own builder, for `kind="callable"`.
-        init_snapshot: Pre-training copy of a user distribution, for
+        builder: The user's own builder function, for `kind="callable"`.
+        init_snapshot: Copy of the user's distribution before training, for
             `kind="distribution"`.
     """
 
@@ -368,8 +369,8 @@ class VIPosterior(NeuralPosterior):
             An untrained `q` of the family originally requested.
 
         Raises:
-            ValueError: If `q` was supplied as a pre-built flow instance, which carries
-                no recipe to rebuild from.
+            ValueError: If `q` was supplied as an already-built distribution, which does
+                not say how to build a new one.
         """
         spec = self._q_spec
         if spec.kind == "flow":
@@ -391,9 +392,9 @@ class VIPosterior(NeuralPosterior):
             assert spec.init_snapshot is not None
             return detach_and_deepcopy(spec.init_snapshot)
         raise ValueError(
-            "Cannot rebuild `q`: it was passed as a pre-built distribution instance, "
-            "which carries no construction recipe. Pass `q` as a family name, a "
-            "`Callable` builder, or a `Distribution` to use `retrain_from_scratch`."
+            "Cannot rebuild `q`: it was passed as an already-built distribution, which "
+            "does not say how to build a new one. To use `retrain_from_scratch`, pass "
+            "`q` as a variational family name, a `Callable`, or a `Distribution`."
         )
 
     def _build_conditional_flow(
@@ -506,7 +507,7 @@ class VIPosterior(NeuralPosterior):
             modules = []
         _flow_types = (ZukoUnconditionalFlow, TransformedZukoFlow, LearnableGaussian)
         if isinstance(q, _flow_types):
-            # A pre-built instance carries no recipe; `train` restores its own spec.
+            # A ready-made distribution says nothing about how to build a new one.
             self._q_spec = _QSpec(kind="instance")
             self._trained_on = None
         elif isinstance(q, Distribution):
@@ -797,8 +798,8 @@ class VIPosterior(NeuralPosterior):
                 For a family name or a `Callable` builder this re-initialises with fresh
                 random weights. For a user-supplied `Distribution` it restores the copy
                 taken when `q` was set, since sbi cannot re-randomize an opaque object.
-                Raises `ValueError` if `q` was given as a pre-built flow instance, which
-                carries no construction recipe.
+                Raises `ValueError` if `q` was given as an already-built distribution,
+                which does not say how to build a new one.
             reset_optimizer: Reset the divergence optimizer
             show_progress_bar: If any progress report should be displayed.
             quality_control: If False quality control is skipped.
@@ -844,7 +845,7 @@ class VIPosterior(NeuralPosterior):
 
         # Init q and the optimizer if necessary
         if retrain_from_scratch:
-            # The `q` setter reclassifies by type, so restore our recipe afterwards.
+            # Setting `q` forgets how to rebuild it, so keep our own copy.
             spec = self._q_spec
             self.q = self._build_q_from_spec()
             self._q_spec = spec
@@ -1368,20 +1369,21 @@ class VIPosterior(NeuralPosterior):
         )
 
     def __getstate__(self) -> Dict:
-        """Return the state to pickle, also used by `copy.deepcopy`.
+        """Returns the state of the object that is supposed to be pickled.
 
-        Must null in the copy rather than on `self`, so that serializing cannot mutate
-        the live posterior. `train()` rebuilds the dropped `_optimizer` on demand.
+        Also used by `copy.deepcopy`. Must clear entries on the copy and not on `self`,
+        so that saving a posterior leaves it unchanged. The optimizer is left out
+        because `train()` builds a new one when it is missing.
 
         Returns:
-            The attributes to pickle.
+            The attributes to be pickled.
         """
         state = self.__dict__.copy()
         state["_optimizer"] = None
         return state
 
     def __setstate__(self, state_dict: Dict) -> None:
-        """Restore from pickled state.
+        """Sets the state when being loaded from pickle.
 
         Args:
             state_dict: State produced by `__getstate__`.

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -61,10 +61,6 @@ QType = Union[VariationalFamily, Distribution, "VIPosterior", Callable]
 class _QSpec:
     """Stores how to rebuild the variational distribution.
 
-    Must contain only data, never a function defined inside a method: those cannot be
-    pickled, which is why the construction itself lives in
-    `VIPosterior._build_q_from_spec`.
-
     Attributes:
         kind: Which variational family `q` was built from.
         flow_type: Zuko flow name, for `kind="flow"`.
@@ -507,11 +503,12 @@ class VIPosterior(NeuralPosterior):
             modules = []
         _flow_types = (ZukoUnconditionalFlow, TransformedZukoFlow, LearnableGaussian)
         if isinstance(q, _flow_types):
-            # A ready-made distribution says nothing about how to build a new one.
+            # Nothing records how to build another one, so retraining will refuse.
             self._q_spec = _QSpec(kind="instance")
             self._trained_on = None
         elif isinstance(q, Distribution):
-            # Re-wrapping would apply `link_transform` twice.
+            # Wrapping an already-wrapped `q`, as `retrain_from_scratch` hands back,
+            # would apply the link transform twice and break sampling.
             if not isinstance(q, AdaptedVariationalDistribution):
                 q = AdaptedVariationalDistribution(
                     q,

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -392,7 +392,10 @@ class VIPosterior(NeuralPosterior):
             )
         if spec.kind == "distribution":
             assert spec.init_snapshot is not None
-            return spec.init_snapshot
+            # Copy rather than hand out the stored snapshot itself, so callers cannot
+            # train on it. `set_q` re-snapshots anyway, but not relying on that keeps
+            # this method self-contained.
+            return detach_and_deepcopy(spec.init_snapshot)
         raise ValueError(
             "Cannot rebuild `q`: it was passed as a pre-built distribution instance, "
             "which carries no construction recipe. Pass `q` as a family name, a "
@@ -509,23 +512,27 @@ class VIPosterior(NeuralPosterior):
             modules = []
         _flow_types = (ZukoUnconditionalFlow, TransformedZukoFlow, LearnableGaussian)
         if isinstance(q, _flow_types):
-            # Flow/Gaussian passed directly (e.g. from `_build_q_from_spec` during
-            # retrain). Keep any existing spec: the instance carries no recipe of its
-            # own, and overwriting it would make `retrain_from_scratch` a one-shot.
-            if getattr(self, "_q_spec", None) is None:
-                self._q_spec = _QSpec(kind="instance")
+            # A pre-built instance carries no recipe of its own. `train` restores the
+            # spec around its own rebuild, so keeping a stale one here would silently
+            # rebuild the wrong family for an external caller.
+            self._q_spec = _QSpec(kind="instance")
             self._trained_on = None
         elif isinstance(q, Distribution):
-            q = AdaptedVariationalDistribution(
-                q,
-                self._prior,
-                self.link_transform,
-                parameters=parameters,
-                modules=modules,
-            )
+            # An already-adapted `q` comes back from `_build_q_from_spec`; re-wrapping
+            # it would apply `link_transform` a second time.
+            if not isinstance(q, AdaptedVariationalDistribution):
+                q = AdaptedVariationalDistribution(
+                    q,
+                    self._prior,
+                    self.link_transform,
+                    parameters=parameters,
+                    modules=modules,
+                )
             # sbi cannot re-randomize an opaque user distribution, so `retrain_from
             # _scratch` returns to this pre-training snapshot.
-            self._q_spec = _QSpec(kind="distribution", init_snapshot=deepcopy(q))
+            self._q_spec = _QSpec(
+                kind="distribution", init_snapshot=detach_and_deepcopy(q)
+            )
             self._trained_on = None
         elif isinstance(q, (str, Callable)):
             if isinstance(q, str):
@@ -801,6 +808,8 @@ class VIPosterior(NeuralPosterior):
                 For a family name or a `Callable` builder this re-initialises with fresh
                 random weights. For a user-supplied `Distribution` it restores the copy
                 taken when `q` was set, since sbi cannot re-randomize an opaque object.
+                Raises `ValueError` if `q` was given as a pre-built flow instance, which
+                carries no construction recipe.
             reset_optimizer: Reset the divergence optimizer
             show_progress_bar: If any progress report should be displayed.
             quality_control: If False quality control is skipped.
@@ -846,7 +855,11 @@ class VIPosterior(NeuralPosterior):
 
         # Init q and the optimizer if necessary
         if retrain_from_scratch:
+            # The `q` setter reclassifies by type, which would downgrade the recipe to
+            # `kind="instance"`; keep ours so repeated retrains stay possible.
+            spec = self._q_spec
             self.q = self._build_q_from_spec()
+            self._q_spec = spec
             self._optimizer = self._optimizer_builder(
                 self.potential_fn,
                 self.q,

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -797,7 +797,10 @@ class VIPosterior(NeuralPosterior):
             clip_value: Gradient clipping value, decreasing may help if you see invalid
                 values.
             warm_up_rounds: Initialize the posterior as the prior.
-            retrain_from_scratch: Retrain the variational distributions from scratch.
+            retrain_from_scratch: Rebuild the variational distribution before training.
+                For a family name or a `Callable` builder this re-initialises with fresh
+                random weights. For a user-supplied `Distribution` it restores the copy
+                taken when `q` was set, since sbi cannot re-randomize an opaque object.
             reset_optimizer: Reset the divergence optimizer
             show_progress_bar: If any progress report should be displayed.
             quality_control: If False quality control is skipped.

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -30,9 +30,9 @@ from sbi.neural_nets.net_builders.flow import (
 from sbi.samplers.vi.vi_divergence_optimizers import get_VI_method
 from sbi.samplers.vi.vi_quality_control import get_quality_metric
 from sbi.samplers.vi.vi_utils import (
+    AdaptedVariationalDistribution,
     LearnableGaussian,
     TransformedZukoFlow,
-    adapt_variational_distribution,
     check_variational_distribution,
     make_object_deepcopy_compatible,
 )
@@ -518,18 +518,16 @@ class VIPosterior(NeuralPosterior):
             make_object_deepcopy_compatible(q)
             self._trained_on = None
         elif isinstance(q, Distribution):
-            q = adapt_variational_distribution(
+            q = AdaptedVariationalDistribution(
                 q,
                 self._prior,
                 self.link_transform,
                 parameters=parameters,
                 modules=modules,
             )
-            make_object_deepcopy_compatible(q)
-            self_custom_q_init_cache = deepcopy(q)
-            self._q_spec = _QSpec(
-                kind="distribution", init_snapshot=self_custom_q_init_cache
-            )
+            # sbi cannot re-randomize an opaque user distribution, so `retrain_from
+            # _scratch` returns to this pre-training snapshot.
+            self._q_spec = _QSpec(kind="distribution", init_snapshot=deepcopy(q))
             self._trained_on = None
         elif isinstance(q, (str, Callable)):
             if isinstance(q, str):

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-import copy
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass
@@ -34,7 +33,7 @@ from sbi.samplers.vi.vi_utils import (
     LearnableGaussian,
     TransformedZukoFlow,
     check_variational_distribution,
-    make_object_deepcopy_compatible,
+    detach_and_deepcopy,
 )
 from sbi.sbi_types import (
     Shape,
@@ -515,7 +514,6 @@ class VIPosterior(NeuralPosterior):
             # own, and overwriting it would make `retrain_from_scratch` a one-shot.
             if getattr(self, "_q_spec", None) is None:
                 self._q_spec = _QSpec(kind="instance")
-            make_object_deepcopy_compatible(q)
             self._trained_on = None
         elif isinstance(q, Distribution):
             q = AdaptedVariationalDistribution(
@@ -549,7 +547,6 @@ class VIPosterior(NeuralPosterior):
                 # Callable provided - use as-is
                 self._q_spec = _QSpec(kind="callable", builder=q)
                 q = self._build_q_from_spec()
-            make_object_deepcopy_compatible(q)
             self._trained_on = None
         elif isinstance(q, VIPosterior):
             self._q_spec = q._q_spec
@@ -558,8 +555,7 @@ class VIPosterior(NeuralPosterior):
             self.vi_method = q.vi_method  # type: ignore
             self._prior = q._prior
             self._x = q._x
-            make_object_deepcopy_compatible(q.q)
-            q = deepcopy(q.q)
+            q = detach_and_deepcopy(q.q)
             # Move copied q to self's device (source may be on a different device).
             if hasattr(q, "to"):
                 q.to(self._device)  # type: ignore[union-attr]
@@ -1367,57 +1363,25 @@ class VIPosterior(NeuralPosterior):
             force_update=force_update,
         )
 
-    def __deepcopy__(self, memo: Optional[Dict] = None) -> "VIPosterior":
-        """This method is called when using `copy.deepcopy` on the object.
-
-        It defines how the object is copied. We need to overwrite this method, since the
-        default implementation does use __getstate__ and __setstate__ which we overwrite
-        to enable pickling (and in particular the necessary modifications are
-        incompatible deep copying).
-
-        Args:
-            memo (Optional[Dict], optional): Deep copy internal memo. Defaults to None.
-
-        Returns:
-            VIPosterior: Deep copy of the VIPosterior.
-        """
-        if memo is None:
-            memo = {}
-
-        # Create a new instance of the class
-        cls = self.__class__
-        result = cls.__new__(cls)
-        # Add to memo
-        memo[id(self)] = result
-        # Copy attributes
-        for k, v in self.__dict__.items():
-            setattr(result, k, copy.deepcopy(v, memo))
-        return result
-
     def __getstate__(self) -> Dict:
-        """This method is called when pickling the object.
+        """Return the state to pickle.
 
-        It defines what is pickled. We need to overwrite this method, since some parts
-        do not support pickle protocols (e.g. due to local functions).
+        Copies first and nulls in the copy, so serializing never mutates the live
+        object. `_optimizer` is dropped as transient training state; `train()` rebuilds
+        it on demand. `copy.deepcopy` routes through here too, so both protocols share
+        one path.
 
         Returns:
-            Dict: All attributes of the VIPosterior.
+            The attributes to pickle.
         """
-        self._optimizer = None
-        self.__deepcopy__ = None  # type: ignore
-        self._q.__deepcopy__ = None  # type: ignore
         state = self.__dict__.copy()
+        state["_optimizer"] = None
         return state
 
-    def __setstate__(self, state_dict: Dict):
-        """This method is called when unpickling the object.
+    def __setstate__(self, state_dict: Dict) -> None:
+        """Restore from pickled state.
 
         Args:
-            state_dict: Given state dictionary, we will restore the object from it.
+            state_dict: State produced by `__getstate__`.
         """
         self.__dict__ = state_dict
-        make_object_deepcopy_compatible(self)
-        make_object_deepcopy_compatible(self.q)
-        # Handle amortized mode
-        if self._mode == "amortized" and self._amortized_q is not None:
-            make_object_deepcopy_compatible(self._amortized_q)

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -4,6 +4,7 @@
 import copy
 import warnings
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, Literal, Optional, Union
 
 import numpy as np
@@ -55,6 +56,32 @@ VariationalFamily = Literal[
 
 # Type for the q parameter in VIPosterior
 QType = Union[VariationalFamily, Distribution, "VIPosterior", Callable]
+
+
+@dataclass
+class _QSpec:
+    """Serializable recipe for rebuilding the variational distribution.
+
+    Holds data only, so it pickles by value; the matching builder is
+    `VIPosterior._build_q_from_spec`, a method and therefore pickled by reference.
+    Storing a build *closure* on the instance instead is what made pickling
+    unrecoverable.
+
+    Attributes:
+        kind: Which family `q` came from.
+        flow_type: Zuko flow name, for `kind="flow"`.
+        full_covariance: Whether the Gaussian is full-rank, for `kind="gaussian"`.
+        builder: The user's own builder, for `kind="callable"`.
+        init_snapshot: Pre-training copy of a user distribution, for
+            `kind="distribution"`. sbi cannot re-randomize an opaque user object, so
+            returning to this snapshot is the only reproducible option.
+    """
+
+    kind: Literal["flow", "gaussian", "callable", "distribution", "instance"]
+    flow_type: Optional[str] = None
+    full_covariance: Optional[bool] = None
+    builder: Optional[Callable] = None
+    init_snapshot: Optional[Distribution] = None
 
 
 class VIPosterior(NeuralPosterior):
@@ -338,6 +365,41 @@ class VIPosterior(NeuralPosterior):
 
         return transformed_flow.to(self._device)
 
+    def _build_q_from_spec(self) -> Distribution:
+        """Build a fresh variational distribution from `self._q_spec`.
+
+        Returns:
+            An untrained `q` of the family originally requested.
+
+        Raises:
+            ValueError: If `q` was supplied as a pre-built flow instance, which carries
+                no recipe to rebuild from.
+        """
+        spec = self._q_spec
+        if spec.kind == "flow":
+            assert spec.flow_type is not None
+            return self._build_unconditional_flow(spec.flow_type)
+        if spec.kind == "gaussian":
+            return LearnableGaussian(
+                dim=self._prior.event_shape[0],
+                full_covariance=bool(spec.full_covariance),
+                link_transform=self.link_transform,
+                device=self._device,
+            )
+        if spec.kind == "callable":
+            assert spec.builder is not None
+            return spec.builder(
+                self._prior.event_shape, self.link_transform, device=self._device
+            )
+        if spec.kind == "distribution":
+            assert spec.init_snapshot is not None
+            return spec.init_snapshot
+        raise ValueError(
+            "Cannot rebuild `q`: it was passed as a pre-built distribution instance, "
+            "which carries no construction recipe. Pass `q` as a family name, a "
+            "`Callable` builder, or a `Distribution` to use `retrain_from_scratch`."
+        )
+
     def _build_conditional_flow(
         self,
         theta: Tensor,
@@ -446,10 +508,13 @@ class VIPosterior(NeuralPosterior):
             parameters = []
         if modules is None:
             modules = []
-        self._q_arg = (q, parameters, modules)
         _flow_types = (ZukoUnconditionalFlow, TransformedZukoFlow, LearnableGaussian)
         if isinstance(q, _flow_types):
-            # Flow/Gaussian passed directly (e.g., from _q_build_fn during retrain)
+            # Flow/Gaussian passed directly (e.g. from `_build_q_from_spec` during
+            # retrain). Keep any existing spec: the instance carries no recipe of its
+            # own, and overwriting it would make `retrain_from_scratch` a one-shot.
+            if getattr(self, "_q_spec", None) is None:
+                self._q_spec = _QSpec(kind="instance")
             make_object_deepcopy_compatible(q)
             self._trained_on = None
         elif isinstance(q, Distribution):
@@ -462,37 +527,20 @@ class VIPosterior(NeuralPosterior):
             )
             make_object_deepcopy_compatible(q)
             self_custom_q_init_cache = deepcopy(q)
-            self._q_build_fn = lambda *args, **kwargs: self_custom_q_init_cache
+            self._q_spec = _QSpec(
+                kind="distribution", init_snapshot=self_custom_q_init_cache
+            )
             self._trained_on = None
-            self._zuko_flow_type = None
         elif isinstance(q, (str, Callable)):
             if isinstance(q, str):
                 if q in _ZUKO_FLOW_TYPES:
-                    q_flow = self._build_unconditional_flow(q)
-                    self._zuko_flow_type = q
-                    self._q_build_fn = lambda *args, ft=q, **kwargs: (
-                        self._build_unconditional_flow(ft)
-                    )
-                    q = q_flow
+                    self._q_spec = _QSpec(kind="flow", flow_type=q)
+                    q = self._build_unconditional_flow(q)
                 elif q in ("gaussian", "gaussian_diag"):
-                    self._zuko_flow_type = None
-                    full_cov = q == "gaussian"
-                    dim = self._prior.event_shape[0]
-                    q_dist = LearnableGaussian(
-                        dim=dim,
-                        full_covariance=full_cov,
-                        link_transform=self.link_transform,
-                        device=self._device,
+                    self._q_spec = _QSpec(
+                        kind="gaussian", full_covariance=q == "gaussian"
                     )
-                    self._q_build_fn = lambda *args, fc=full_cov, d=dim, **kwargs: (
-                        LearnableGaussian(
-                            dim=d,
-                            full_covariance=fc,
-                            link_transform=self.link_transform,
-                            device=self._device,
-                        )
-                    )
-                    q = q_dist
+                    q = self._build_q_from_spec()
                 else:
                     supported = sorted(_ZUKO_FLOW_TYPES) + ["gaussian", "gaussian_diag"]
                     raise ValueError(
@@ -501,24 +549,17 @@ class VIPosterior(NeuralPosterior):
                     )
             else:
                 # Callable provided - use as-is
-                self._zuko_flow_type = None
-                self._q_build_fn = q
-                q = self._q_build_fn(
-                    self._prior.event_shape,
-                    self.link_transform,
-                    device=self._device,
-                )
+                self._q_spec = _QSpec(kind="callable", builder=q)
+                q = self._build_q_from_spec()
             make_object_deepcopy_compatible(q)
             self._trained_on = None
         elif isinstance(q, VIPosterior):
-            self._q_build_fn = q._q_build_fn
+            self._q_spec = q._q_spec
             self._trained_on = q._trained_on
             self._mode = getattr(q, "_mode", None)  # Copy mode from source
-            self._zuko_flow_type = getattr(q, "_zuko_flow_type", None)
             self.vi_method = q.vi_method  # type: ignore
             self._prior = q._prior
             self._x = q._x
-            self._q_arg = q._q_arg
             make_object_deepcopy_compatible(q.q)
             q = deepcopy(q.q)
             # Move copied q to self's device (source may be on a different device).
@@ -808,7 +849,7 @@ class VIPosterior(NeuralPosterior):
 
         # Init q and the optimizer if necessary
         if retrain_from_scratch:
-            self.q = self._q_build_fn()  # type: ignore
+            self.q = self._build_q_from_spec()
             self._optimizer = self._optimizer_builder(
                 self.potential_fn,
                 self.q,
@@ -1366,7 +1407,6 @@ class VIPosterior(NeuralPosterior):
         """
         self._optimizer = None
         self.__deepcopy__ = None  # type: ignore
-        self._q_build_fn = None
         self._q.__deepcopy__ = None  # type: ignore
         state = self.__dict__.copy()
         return state
@@ -1374,17 +1414,10 @@ class VIPosterior(NeuralPosterior):
     def __setstate__(self, state_dict: Dict):
         """This method is called when unpickling the object.
 
-        Especially, we need to restore the removed attributes and ensure that the object
-        e.g. remains deep copy compatible.
-
         Args:
             state_dict: Given state dictionary, we will restore the object from it.
         """
         self.__dict__ = state_dict
-        q = deepcopy(self._q)
-        # Restore removed attributes
-        self.set_q(*self._q_arg)
-        self._q = q
         make_object_deepcopy_compatible(self)
         make_object_deepcopy_compatible(self.q)
         # Handle amortized mode

--- a/sbi/neural_nets/embedding_nets/lru.py
+++ b/sbi/neural_nets/embedding_nets/lru.py
@@ -11,6 +11,20 @@ from torch import Tensor, nn
 from torch._higher_order_ops.associative_scan import associative_scan  # type: ignore
 
 
+def _aggregate_last_step(x: Tensor) -> Tensor:
+    """Aggregate a sequence of hidden states by keeping the last one."""
+    return x[:, -1, :]
+
+
+def _aggregate_mean(x: Tensor) -> Tensor:
+    """Aggregate a sequence of hidden states by averaging over time."""
+    return x.mean(dim=1)
+
+
+# Module-level, so that an embedding net holding one of these can be pickled.
+_AGGREGATIONS = {"last_step": _aggregate_last_step, "mean": _aggregate_mean}
+
+
 class LRUEmbedding(nn.Module):
     """Embedding network backed by a stack of Linear Recurrent Unit (LRU) blocks.
     This type of embedding is intended to be used with sequential data, e.g.
@@ -95,12 +109,13 @@ class LRUEmbedding(nn.Module):
         ]
         self.lru_blocks = nn.Sequential(*lru_blocks)
 
-        if aggregate_fcn == "last_step":
-            self.aggregation = lambda x: x[:, -1, :]
-        elif aggregate_fcn == "mean":
-            self.aggregation = lambda x: x.mean(dim=1)
-        elif isinstance(aggregate_fcn, str):
-            raise ValueError(f"aggretate_func {aggregate_fcn} not implemented")
+        if isinstance(aggregate_fcn, str):
+            if aggregate_fcn not in _AGGREGATIONS:
+                raise ValueError(
+                    f"aggregate_fcn {aggregate_fcn} not implemented, use one of "
+                    f"{sorted(_AGGREGATIONS)} or pass a function."
+                )
+            self.aggregation = _AGGREGATIONS[aggregate_fcn]
         else:
             self.aggregation = aggregate_fcn
 

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -32,8 +31,8 @@ from sbi.neural_nets.estimators import ZukoUnconditionalFlow
 from sbi.samplers.vi.vi_utils import (
     LearnableGaussian,
     TransformedZukoFlow,
+    detach_and_deepcopy,
     filter_kwargs_for_func,
-    make_object_deepcopy_compatible,
 )
 from sbi.sbi_types import Array
 from sbi.utils.user_input_checks import check_prior
@@ -443,8 +442,7 @@ class ElboOptimizer(DivergenceOptimizer):
         super().__init__(*args, **kwargs)
 
         self.stick_the_landing = stick_the_landing
-        make_object_deepcopy_compatible(self.q)
-        self._surrogate_q = deepcopy(self.q)
+        self._surrogate_q = detach_and_deepcopy(self.q)
 
         self.eps = 1e-5
         self.HYPER_PARAMETERS += ["stick_the_landing"]

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     Iterable,
     Optional,
+    TypeVar,
     Union,
 )
 
@@ -25,6 +26,9 @@ from torch.nn import Module
 from sbi.neural_nets.estimators.zuko_flow import ZukoUnconditionalFlow
 from sbi.sbi_types import Shape, TorchTransform, VariationalDistribution
 from sbi.utils.torchutils import _base_recursor
+
+# Preserves the argument's concrete type through `detach_and_deepcopy`.
+_CopyableT = TypeVar("_CopyableT")
 
 
 class TransformedZukoFlow(nn.Module):
@@ -511,23 +515,18 @@ def detach_all_non_leaf_tensors(obj: object) -> None:
         _base_recursor(obj, check=check, action=action)
 
 
-def make_object_deepcopy_compatible(obj: object):
-    """This function overwrites the `__deepcopy__` attribute. This is required if e.g.
-    the object contains non leaf PyTorch tensors.
+def detach_and_deepcopy(obj: _CopyableT) -> _CopyableT:
+    """Deep-copy `obj`, detaching any non-leaf tensors it caches first.
+
+    Only needed for objects built from `torch.distributions` constructors, which call
+    `.expand()` internally and cache non-leaf tensors that `deepcopy` refuses to touch.
+    `nn.Module`-based variational families hold only leaf parameters and copy fine.
 
     Args:
-        obj: An object where a corresponding `__deepcopy__` attributed is added.
+        obj: Object to copy.
 
+    Returns:
+        An independent copy of `obj`.
     """
-
-    def __deepcopy__(memo):
-        detach_all_non_leaf_tensors(obj)
-        cls = obj.__class__
-        result = cls.__new__(cls)
-        memo[id(obj)] = result
-        for k, v in obj.__dict__.items():
-            setattr(result, k, deepcopy(v, memo))
-        return result
-
-    obj.__deepcopy__ = __deepcopy__  # type: ignore
-    return obj
+    detach_all_non_leaf_tensors(obj)
+    return deepcopy(obj)

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -370,9 +370,10 @@ class AdaptedVariationalDistribution(Distribution):
     Makes the support match the prior's, and defines `parameters` and `modules` as
     methods on the class so that the distribution can be pickled.
 
-    Must offer the same methods as a `TransformedDistribution` and no more: it is not an
-    `nn.Module` and defines neither `to` nor `sample_and_log_prob`, because
-    `DivergenceOptimizer` checks for all three and behaves differently if they exist.
+    Must offer the same methods as a `TransformedDistribution`: it is not an
+    `nn.Module` and does not define `sample_and_log_prob`, because
+    `DivergenceOptimizer` checks for both and behaves differently if they exist. It
+    does define `to`, so that moving the posterior across devices reaches `q`.
     """
 
     arg_constraints: Dict = {}
@@ -449,6 +450,21 @@ class AdaptedVariationalDistribution(Distribution):
         if hasattr(self._source, "modules"):
             return self._source.modules()  # type: ignore[attr-defined]
         return iter(())
+
+    def to(self, device: Union[str, torch.device]) -> None:
+        """Move the trainable tensors to `device`, in place.
+
+        In place, so that every object holding a reference to them, such as the
+        optimizer, keeps seeing the same tensors.
+        """
+        for parameter in self._user_parameters:
+            parameter.data = parameter.data.to(device)
+            if parameter.grad is not None:
+                parameter.grad.data = parameter.grad.data.to(device)
+        for module in self._user_modules:
+            module.to(device)
+        if hasattr(self._source, "to"):
+            self._source.to(device)
 
     @property
     def support(self):  # type: ignore[override]

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -27,7 +27,6 @@ from sbi.neural_nets.estimators.zuko_flow import ZukoUnconditionalFlow
 from sbi.sbi_types import Shape, TorchTransform, VariationalDistribution
 from sbi.utils.torchutils import _base_recursor
 
-# Preserves the argument's concrete type through `detach_and_deepcopy`.
 _CopyableT = TypeVar("_CopyableT")
 
 
@@ -402,11 +401,10 @@ class AdaptedVariationalDistribution(Distribution):
     """Wraps a user-supplied distribution for use with `DivergenceOptimizer`s.
 
     Ensures the support matches the prior's, and exposes `parameters`/`modules` as real
-    methods. Attaching them as per-instance closures instead is what made a custom-`q`
-    posterior unpicklable, since instance attributes are pickled by value.
+    methods so that the wrapper pickles by reference.
 
-    Deliberately mirrors the surface of `TransformedDistribution` and no more: it is not
-    an `nn.Module` and defines neither `to` nor `sample_and_log_prob`, because
+    Must mirror the surface of `TransformedDistribution` and no more: it is not an
+    `nn.Module` and defines neither `to` nor `sample_and_log_prob`, because
     `DivergenceOptimizer` branches on all three.
     """
 
@@ -518,9 +516,9 @@ def detach_all_non_leaf_tensors(obj: object) -> None:
 def detach_and_deepcopy(obj: _CopyableT) -> _CopyableT:
     """Deep-copy `obj`, detaching any non-leaf tensors it caches first.
 
-    Only needed for objects built from `torch.distributions` constructors, which call
-    `.expand()` internally and cache non-leaf tensors that `deepcopy` refuses to touch.
-    `nn.Module`-based variational families hold only leaf parameters and copy fine.
+    Only needed for `torch.distributions` objects, whose constructors call `.expand()`
+    and cache non-leaf tensors that `deepcopy` refuses. `nn.Module`-based families hold
+    only leaf parameters and copy fine.
 
     Args:
         obj: Object to copy.

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -381,20 +381,27 @@ class AdaptedVariationalDistribution(Distribution):
             prior: Prior, used only to compare supports.
             link_transform: Applied when `q`'s support differs from the prior's.
             parameters: Trainable tensors, for a `q` that does not expose them itself.
+                Required if the tensors live anywhere other than `q` or, for a
+                `TransformedDistribution`, its base distribution.
             modules: Modules, for a `q` that does not expose them itself.
 
         Raises:
-            ValueError: If neither `parameters` nor `q.parameters()` provides tensors to
-                optimize.
+            ValueError: If no trainable tensors can be found.
         """
         self._user_parameters = list(parameters) if parameters is not None else []
         self._user_modules = list(modules) if modules is not None else []
+
         self._source = q
         if not self._user_parameters and not hasattr(q, "parameters"):
-            raise ValueError(
-                "The variational distribution has no parameters to optimize. Pass the "
-                "trainable tensors as `parameters` (and any modules as `modules`)."
-            )
+            # A `TransformedDistribution` holds its trainable tensors on the base.
+            base = getattr(q, "base_dist", None)
+            if base is None or not hasattr(base, "parameters"):
+                raise ValueError(
+                    "The variational distribution has no parameters to optimize. Pass "
+                    "the trainable tensors as `parameters` (and any modules as "
+                    "`modules`)."
+                )
+            self._source = base
 
         if hasattr(prior, "support") and q.support != prior.support:
             if isinstance(q, TransformedDistribution):

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -398,14 +398,14 @@ def check_variational_distribution(q: Distribution, prior: Distribution) -> None
 
 
 class AdaptedVariationalDistribution(Distribution):
-    """Wraps a user-supplied distribution for use with `DivergenceOptimizer`s.
+    """Wraps a user-supplied variational distribution for the `DivergenceOptimizer`s.
 
-    Ensures the support matches the prior's, and exposes `parameters`/`modules` as real
-    methods so that the wrapper pickles by reference.
+    Makes the support match the prior's, and defines `parameters` and `modules` as
+    methods on the class so that the distribution can be pickled.
 
-    Must mirror the surface of `TransformedDistribution` and no more: it is not an
+    Must offer the same methods as a `TransformedDistribution` and no more: it is not an
     `nn.Module` and defines neither `to` nor `sample_and_log_prob`, because
-    `DivergenceOptimizer` branches on all three.
+    `DivergenceOptimizer` checks for all three and behaves differently if they exist.
     """
 
     arg_constraints: Dict = {}

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -354,6 +354,16 @@ def check_variational_distribution(q: Distribution, prior: Distribution) -> None
     check_sample_shape_and_support(q, prior)
 
 
+def _owns_parameters(transform: TorchTransform) -> bool:
+    """Whether a transform, or one it is built from, holds trainable tensors."""
+    if hasattr(transform, "parameters"):
+        return True
+    parts = getattr(transform, "parts", None) or [
+        t for t in [getattr(transform, "base_transform", None)] if t is not None
+    ]
+    return any(_owns_parameters(part) for part in parts)
+
+
 class AdaptedVariationalDistribution(Distribution):
     """Wraps a user-supplied variational distribution for the `DivergenceOptimizer`s.
 
@@ -402,7 +412,7 @@ class AdaptedVariationalDistribution(Distribution):
                     "the trainable tensors as `parameters` (and any modules as "
                     "`modules`)."
                 )
-            if any(hasattr(t, "parameters") for t in getattr(q, "transforms", [])):
+            if any(_owns_parameters(t) for t in getattr(q, "transforms", [])):
                 raise ValueError(
                     "The variational distribution keeps trainable tensors in its "
                     "transforms, which sbi does not collect on its own. Pass all of "

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -457,14 +457,16 @@ class AdaptedVariationalDistribution(Distribution):
         In place, so that every object holding a reference to them, such as the
         optimizer, keeps seeing the same tensors.
         """
-        for parameter in self._user_parameters:
+        if hasattr(self._source, "to"):
+            self._source.to(device)
+        for module in self._user_modules:
+            module.to(device)
+        # Covers tensors passed as `parameters` or found on a plain-distribution
+        # source, which offer no `to` of their own.
+        for parameter in self.parameters():
             parameter.data = parameter.data.to(device)
             if parameter.grad is not None:
                 parameter.grad.data = parameter.grad.data.to(device)
-        for module in self._user_modules:
-            module.to(device)
-        if hasattr(self._source, "to"):
-            self._source.to(device)
 
     @property
     def support(self):  # type: ignore[override]

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -394,101 +394,101 @@ def check_variational_distribution(q: Distribution, prior: Distribution) -> None
     check_sample_shape_and_support(q, prior)
 
 
-def add_parameters_module_attributes(
-    q: Distribution, parameters: Callable, modules: Callable
-):
-    """Sets the attribute `parameters` and `modules` on q
+class AdaptedVariationalDistribution(Distribution):
+    """Wraps a user-supplied distribution for use with `DivergenceOptimizer`s.
 
-    Args:
-        q: Variational distribution which is checked
-        parameters: A function which returns an iterable of leaf tensors.
-        modules: A function which returns an iterable of nn.Module
+    Ensures the support matches the prior's, and exposes `parameters`/`modules` as real
+    methods. Attaching them as per-instance closures instead is what made a custom-`q`
+    posterior unpicklable, since instance attributes are pickled by value.
 
-
-    """
-    q.parameters = parameters  # type: ignore
-    q.modules = modules  # type: ignore
-
-
-def add_parameter_attributes_to_transformed_distribution(
-    q: TransformedDistribution,
-) -> None:
-    """A function that will add `parameters` and `modules` to q automatically, if q is a
-    TransformedDistribution.
-
-    Args:
-        q: Variational distribution instances TransformedDistribution.
-
-
+    Deliberately mirrors the surface of `TransformedDistribution` and no more: it is not
+    an `nn.Module` and defines neither `to` nor `sample_and_log_prob`, because
+    `DivergenceOptimizer` branches on all three.
     """
 
-    def parameters():
-        """Returns the parameters of the distribution."""
-        if hasattr(q.base_dist, "parameters"):
-            yield from q.base_dist.parameters()  # type: ignore[attr-defined]
-        for t in q.transforms:
-            yield from get_parameters(t)
+    arg_constraints: Dict = {}
 
-    def modules():
-        """Returns the modules of the distribution."""
-        if hasattr(q.base_dist, "modules"):
-            yield from q.base_dist.modules()  # type: ignore[attr-defined]
-        for t in q.transforms:
-            yield from get_modules(t)
+    def __init__(
+        self,
+        q: Distribution,
+        prior: Distribution,
+        link_transform: Callable,
+        parameters: Optional[Iterable] = None,
+        modules: Optional[Iterable] = None,
+    ) -> None:
+        """
+        Args:
+            q: The user's variational distribution.
+            prior: Prior, used only to compare supports.
+            link_transform: Applied when `q`'s support differs from the prior's.
+            parameters: Trainable tensors, for a `q` that does not expose them itself.
+            modules: Modules, for a `q` that does not expose them itself.
+        """
+        self._user_parameters = list(parameters) if parameters is not None else []
+        self._user_modules = list(modules) if modules is not None else []
 
-    add_parameters_module_attributes(q, parameters, modules)
-
-
-def adapt_variational_distribution(
-    q: VariationalDistribution,
-    prior: Distribution,
-    link_transform: Callable,
-    parameters: Optional[Iterable] = None,
-    modules: Optional[Iterable] = None,
-) -> Distribution:
-    """This will adapt a distribution to be compatible with DivergenceOptimizers.
-    Especially it will make sure that the distribution has parameters and that it
-    satisfies obvious contraints which a posterior must satisfy i.e. the support must be
-    equal to that of the prior.
-
-    Args:
-        q: Variational distribution.
-        prior: Prior distribution
-        theta_transform: Theta transformation.
-        parameters: List of parameters.
-        modules: List of modules.
-
-    Returns:
-        TransformedDistribution: Compatible variational distribution.
-
-    """
-    if parameters is None:
-        parameters = []
-    if modules is None:
-        modules = []
-
-    # Extract user define parameters
-    def parameters_fn():
-        """Returns the parameters of the distribution."""
-        return parameters
-
-    def modules_fn():
-        """Returns the modules of the distribution."""
-        return modules
-
-    if isinstance(q, TransformedDistribution):
-        if parameters == [] or modules_fn == []:
-            add_parameter_attributes_to_transformed_distribution(q)
-        else:
-            add_parameters_module_attributes(q, parameters_fn, modules_fn)
         if hasattr(prior, "support") and q.support != prior.support:
-            q = TransformedDistribution(q.base_dist, q.transforms + [link_transform])
-    else:
-        if hasattr(prior, "support") and q.support != prior.support:
-            q = TransformedDistribution(q, [link_transform])
-        add_parameters_module_attributes(q, parameters_fn, modules_fn)
+            if isinstance(q, TransformedDistribution):
+                q = TransformedDistribution(
+                    q.base_dist, list(q.transforms) + [link_transform]
+                )
+            else:
+                q = TransformedDistribution(q, [link_transform])
+        self._q = q
 
-    return q
+        super().__init__(
+            batch_shape=q.batch_shape,
+            event_shape=q.event_shape,
+            validate_args=False,
+        )
+
+    def parameters(self) -> Iterable:
+        """Yield trainable tensors: the user's if given, else `q`'s own."""
+        if self._user_parameters:
+            yield from self._user_parameters
+            return
+        base = self._q
+        if isinstance(base, TransformedDistribution):
+            if hasattr(base.base_dist, "parameters"):
+                yield from base.base_dist.parameters()  # type: ignore[attr-defined]
+            for transform in base.transforms:
+                yield from get_parameters(transform)
+        elif hasattr(base, "parameters"):
+            yield from base.parameters()  # type: ignore[attr-defined]
+
+    def modules(self) -> Iterable:
+        """Yield modules: the user's if given, else `q`'s own."""
+        if self._user_modules:
+            yield from self._user_modules
+            return
+        base = self._q
+        if isinstance(base, TransformedDistribution):
+            if hasattr(base.base_dist, "modules"):
+                yield from base.base_dist.modules()  # type: ignore[attr-defined]
+            for transform in base.transforms:
+                yield from get_modules(transform)
+        elif hasattr(base, "modules"):
+            yield from base.modules()  # type: ignore[attr-defined]
+
+    @property
+    def support(self):  # type: ignore[override]
+        return self._q.support
+
+    @property
+    def has_rsample(self) -> bool:  # type: ignore[override]
+        return self._q.has_rsample
+
+    def sample(self, sample_shape: Shape = torch.Size()) -> Tensor:
+        return self._q.sample(sample_shape)
+
+    def rsample(self, sample_shape: Shape = torch.Size()) -> Tensor:
+        return self._q.rsample(sample_shape)
+
+    def log_prob(self, value: Tensor) -> Tensor:
+        return self._q.log_prob(value)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._q})"
 
 
 def detach_all_non_leaf_tensors(obj: object) -> None:

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -20,7 +20,6 @@ from torch.distributions import (
     Normal,
     TransformedDistribution,
 )
-from torch.distributions.transforms import ComposeTransform, IndependentTransform
 from torch.nn import Module
 
 from sbi.neural_nets.estimators.zuko_flow import ZukoUnconditionalFlow
@@ -259,48 +258,6 @@ def filter_kwargs_for_func(f: Callable, kwargs: Dict) -> Dict:
     return new_kwargs
 
 
-def get_parameters(t: Union[TorchTransform, Module]) -> Iterable:
-    """Recursive helper function which can be used to extract parameters from
-    TransformedDistributions.
-
-    Args:
-        t: A TorchTransform object, which is scanned for the "parameters" attribute.
-
-    Yields:
-        Iterator[Iterable]: Generator of parameters.
-    """
-    if hasattr(t, "parameters"):
-        yield from t.parameters()  # type: ignore
-    elif isinstance(t, ComposeTransform):
-        for part in t.parts:
-            yield from get_parameters(part)
-    elif isinstance(t, IndependentTransform):
-        yield from get_parameters(t.base_transform)
-    else:
-        pass
-
-
-def get_modules(t: Union[TorchTransform, Module]) -> Iterable:
-    """Recursive helper function which can be used to extract modules from
-    TransformedDistributions.
-
-    Args:
-        t: A TorchTransform object, which is scanned for the "modules" attribute.
-
-    Yields:
-        Iterator[Iterable]: Generator of Modules
-    """
-    if isinstance(t, Module):
-        yield t
-    elif isinstance(t, ComposeTransform):
-        for part in t.parts:
-            yield from get_modules(part)
-    elif isinstance(t, IndependentTransform):
-        yield from get_modules(t.base_transform)
-    else:
-        pass
-
-
 def check_parameters_modules_attribute(q: VariationalDistribution) -> None:
     """Checks a parameterized distribution object for valid `parameters` and `modules`.
 
@@ -425,9 +382,19 @@ class AdaptedVariationalDistribution(Distribution):
             link_transform: Applied when `q`'s support differs from the prior's.
             parameters: Trainable tensors, for a `q` that does not expose them itself.
             modules: Modules, for a `q` that does not expose them itself.
+
+        Raises:
+            ValueError: If neither `parameters` nor `q.parameters()` provides tensors to
+                optimize.
         """
         self._user_parameters = list(parameters) if parameters is not None else []
         self._user_modules = list(modules) if modules is not None else []
+        self._source = q
+        if not self._user_parameters and not hasattr(q, "parameters"):
+            raise ValueError(
+                "The variational distribution has no parameters to optimize. Pass the "
+                "trainable tensors as `parameters` (and any modules as `modules`)."
+            )
 
         if hasattr(prior, "support") and q.support != prior.support:
             if isinstance(q, TransformedDistribution):
@@ -445,32 +412,18 @@ class AdaptedVariationalDistribution(Distribution):
         )
 
     def parameters(self) -> Iterable:
-        """Yield trainable tensors: the user's if given, else `q`'s own."""
+        """Yield the trainable tensors, as given or as `q` exposes them."""
         if self._user_parameters:
-            yield from self._user_parameters
-            return
-        base = self._q
-        if isinstance(base, TransformedDistribution):
-            if hasattr(base.base_dist, "parameters"):
-                yield from base.base_dist.parameters()  # type: ignore[attr-defined]
-            for transform in base.transforms:
-                yield from get_parameters(transform)
-        elif hasattr(base, "parameters"):
-            yield from base.parameters()  # type: ignore[attr-defined]
+            return iter(self._user_parameters)
+        return self._source.parameters()  # type: ignore[attr-defined]
 
     def modules(self) -> Iterable:
-        """Yield modules: the user's if given, else `q`'s own."""
+        """Yield the modules, as given or as `q` exposes them."""
         if self._user_modules:
-            yield from self._user_modules
-            return
-        base = self._q
-        if isinstance(base, TransformedDistribution):
-            if hasattr(base.base_dist, "modules"):
-                yield from base.base_dist.modules()  # type: ignore[attr-defined]
-            for transform in base.transforms:
-                yield from get_modules(transform)
-        elif hasattr(base, "modules"):
-            yield from base.modules()  # type: ignore[attr-defined]
+            return iter(self._user_modules)
+        if hasattr(self._source, "modules"):
+            return self._source.modules()  # type: ignore[attr-defined]
+        return iter(())
 
     @property
     def support(self):  # type: ignore[override]

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -386,7 +386,8 @@ class AdaptedVariationalDistribution(Distribution):
             modules: Modules, for a `q` that does not expose them itself.
 
         Raises:
-            ValueError: If no trainable tensors can be found.
+            ValueError: If no trainable tensors can be found, or if some sit somewhere
+                sbi does not look and were not passed as `parameters`.
         """
         self._user_parameters = list(parameters) if parameters is not None else []
         self._user_modules = list(modules) if modules is not None else []
@@ -400,6 +401,13 @@ class AdaptedVariationalDistribution(Distribution):
                     "The variational distribution has no parameters to optimize. Pass "
                     "the trainable tensors as `parameters` (and any modules as "
                     "`modules`)."
+                )
+            if any(hasattr(t, "parameters") for t in getattr(q, "transforms", [])):
+                raise ValueError(
+                    "The variational distribution keeps trainable tensors in its "
+                    "transforms, which sbi does not collect on its own. Pass all of "
+                    "them as `parameters` (and any modules as `modules`), so that none "
+                    "are silently left out of training."
                 )
             self._source = base
 

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -523,14 +523,14 @@ class OneDimPriorWrapper(Distribution):
     """
 
     def __init__(self, prior: Distribution, validate_args=None) -> None:
+        self.prior = prior
+        # The wrapped prior validates its own arguments; validating here would
+        # make torch look for them on the wrapper, which only delegates.
         super().__init__(
             batch_shape=prior.batch_shape,
             event_shape=prior.event_shape,
-            validate_args=(
-                prior._validate_args if validate_args is None else validate_args
-            ),
+            validate_args=False,
         )
-        self.prior = prior
         self.device = None
 
     def to(self, device: Union[str, torch.device]) -> None:

--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+import pickle
 from typing import Callable
 
 import pytest
@@ -756,6 +757,19 @@ def test_lru_embedding_net_isolated(
     assert isinstance(x_embed, Tensor)
     assert torch.is_floating_point(x_embed), "Output tensor is not a real tensor"
     assert x_embed.shape == (batch_size, output_dim)
+
+
+@pytest.mark.parametrize("aggregate_fcn", ["last_step", "mean"])
+def test_lru_embedding_net_is_picklable(aggregate_fcn: str):
+    """Every aggregation preset must survive pickling, since posteriors get pickled."""
+    embedding_net = LRUEmbedding(
+        input_dim=3, output_dim=4, num_blocks=1, aggregate_fcn=aggregate_fcn
+    )
+    x = torch.randn(2, 5, 3)
+
+    reloaded = pickle.loads(pickle.dumps(embedding_net))
+
+    assert torch.allclose(reloaded(x), embedding_net(x))
 
 
 def test_lru_pipeline(embedding_feat_dim: int = 17):

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -65,9 +65,7 @@ def test_picklability(
         loaded_posterior = pickle.load(handle)
 
     # A corrupted `theta_transform` unpickles fine and only fails on use (#1952).
-    # VIPosterior is skipped: `__setstate__` resets `_trained_on`, a separate gap.
-    if not isinstance(posterior, VIPosterior):
-        assert loaded_posterior.sample((1,)).shape == (1, num_dim)
+    assert loaded_posterior.sample((1,)).shape == (1, num_dim)
 
     with open(f"{tmp_path}/saved_inference.pickle", "wb") as handle:
         pickle.dump(inference, handle)

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -8,14 +8,39 @@ import torch
 
 from sbi import utils as utils
 from sbi.inference import FMPE, NLE, NPE, NPSE, NRE
+from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
 from sbi.inference.posteriors.posterior_parameters import (
     DirectPosteriorParameters,
+    ImportanceSamplingPosteriorParameters,
     MCMCPosteriorParameters,
     RejectionPosteriorParameters,
     VIPosteriorParameters,
     VectorFieldPosteriorParameters,
 )
 from sbi.inference.posteriors.vi_posterior import VIPosterior
+
+
+def _assert_survives_pickling(posterior, num_dim: int) -> None:
+    """Saving must leave the posterior unchanged and reload an equivalent one.
+
+    Compares seeded samples rather than their shape: a posterior that lost a weight, or
+    a `VIPosterior` that silently retrained, still returns correctly shaped samples.
+    """
+    torch.manual_seed(0)
+    expected = posterior.sample((3,))
+
+    attributes = {name: id(value) for name, value in vars(posterior).items()}
+    reloaded = pickle.loads(pickle.dumps(posterior))
+    assert {name: id(value) for name, value in vars(posterior).items()} == attributes, (
+        "pickling replaced attributes on the posterior it serialized"
+    )
+
+    torch.manual_seed(0)
+    samples = reloaded.sample((3,))
+    assert samples.shape == (3, num_dim)
+    if not isinstance(posterior, MCMCPosterior):
+        # MCMC drops its sampler on purpose (#1291) and so redraws a fresh chain.
+        assert torch.allclose(samples, expected)
 
 
 @pytest.mark.parametrize(
@@ -28,6 +53,7 @@ from sbi.inference.posteriors.vi_posterior import VIPosterior
         pytest.param(NRE, MCMCPosteriorParameters, marks=pytest.mark.mcmc),
         pytest.param(NRE, VIPosteriorParameters, marks=pytest.mark.mcmc),
         (NRE, RejectionPosteriorParameters),
+        (NRE, ImportanceSamplingPosteriorParameters),
     ),
 )
 def test_picklability(
@@ -66,6 +92,7 @@ def test_picklability(
 
     # A corrupted `theta_transform` unpickles fine and only fails on use (#1952).
     assert loaded_posterior.sample((1,)).shape == (1, num_dim)
+    _assert_survives_pickling(posterior, num_dim)
 
     with open(f"{tmp_path}/saved_inference.pickle", "wb") as handle:
         pickle.dump(inference, handle)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -137,6 +137,16 @@ def test_prior_wrappers(wrapper, prior, kwargs):
     assert len(prior.log_prob(prior.sample((10,))).shape) == 1
 
 
+def test_one_dim_wrapper_constructs_with_validation_on():
+    """With validation on (as here, or via torch's global default, which
+    `MultipleIndependent(validate_args=True)` flips), torch reads `arg_constraints`
+    during `__init__`, which used to dereference `self.prior` before it was set.
+    """
+    prior = OneDimPriorWrapper(Exponential(torch.tensor([3.0])), validate_args=True)
+
+    assert prior.log_prob(prior.sample((3,))).shape == (3,)
+
+
 def test_reinterpreted_batch_dim_prior():
     """Test whether the right warning and error are raised for reinterpreted priors."""
 

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -29,7 +29,7 @@ from sbi.inference.potentials.ratio_based_potential import (
     ratio_estimator_based_potential,
 )
 from sbi.neural_nets.factory import ZukoFlowType
-from sbi.samplers.vi.vi_utils import LearnableGaussian
+from sbi.samplers.vi.vi_utils import AdaptedVariationalDistribution, LearnableGaussian
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
@@ -389,7 +389,7 @@ def _make_posterior(kind: str, num_dim: int = 2, prior=None):
         prior if prior is not None else MultivariateNormal(zeros(num_dim), eye(num_dim))
     )
 
-    if kind == "distribution":
+    if kind in ("distribution", "transformed"):
         loc = zeros(num_dim, requires_grad=True)
         scale = ones(num_dim, requires_grad=True)
         if kind == "distribution":
@@ -508,6 +508,23 @@ def test_retrain_from_scratch_with_bounded_prior():
     samples = posterior.sample((20,))
     assert samples.shape == (20, num_dim)
     assert torch.isfinite(posterior.log_prob(samples)).all()
+
+
+def test_parameters_outside_q_and_its_base_must_be_passed():
+    """sbi only looks on `q` and its base, so anything else must fail loudly."""
+    num_dim = 2
+    transform = torch_tf.AffineTransform(zeros(num_dim), ones(num_dim))
+    transform.parameters = lambda: iter(())  # A transform owning trainable tensors.
+    q = torch.distributions.TransformedDistribution(
+        _ParamNormal(zeros(num_dim, requires_grad=True), ones(num_dim)), [transform]
+    )
+
+    with pytest.raises(ValueError, match="transforms"):
+        AdaptedVariationalDistribution(
+            q,
+            MultivariateNormal(zeros(num_dim), eye(num_dim)),
+            torch_tf.identity_transform,
+        )
 
 
 def test_retrain_fails_after_setting_an_already_built_q():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -360,27 +360,55 @@ def _build_diag_gaussian_q(event_shape, link_transform, device="cpu"):
     )
 
 
-def _make_posterior(kind: str, num_dim: int = 2):
-    """Build an untrained VIPosterior for each way of specifying `q`."""
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    extra = {}
+class _ParamNormal(torch.distributions.Independent):
+    """A base distribution that exposes its own trainable tensors."""
+
+    def __init__(self, loc, scale):
+        base = torch.distributions.Normal(loc, scale, validate_args=False)
+        super().__init__(base, 1, validate_args=False)
+        self._params = [loc, scale]
+
+    def parameters(self):
+        return iter(self._params)
+
+
+def _make_posterior(kind: str, num_dim: int = 2, prior=None):
+    """Build an untrained VIPosterior for each way of specifying `q`.
+
+    Args:
+        kind: One of `Q_KINDS`.
+        num_dim: Dimensionality of the problem.
+        prior: Overrides the default unbounded prior. When given, the link transform is
+            derived from it rather than forced to the identity, which is what makes a
+            bounded prior meaningful.
+    """
+    extra = (
+        {} if prior is not None else {"theta_transform": torch_tf.identity_transform}
+    )
+    prior = (
+        prior if prior is not None else MultivariateNormal(zeros(num_dim), eye(num_dim))
+    )
+
     if kind == "distribution":
-        mu = zeros(num_dim, requires_grad=True)
+        loc = zeros(num_dim, requires_grad=True)
         scale = ones(num_dim, requires_grad=True)
-        q = torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1)
-        extra = {"parameters": [mu, scale]}
+        if kind == "distribution":
+            q = torch.distributions.Independent(
+                torch.distributions.Normal(loc, scale), 1
+            )
+            extra["parameters"] = [loc, scale]
+        else:
+            # Trainable tensors sit on the base, so `parameters=` stays optional.
+            q = torch.distributions.TransformedDistribution(
+                _ParamNormal(loc, scale),
+                [torch_tf.AffineTransform(zeros(num_dim), ones(num_dim))],
+            )
     elif kind == "callable":
         q = _build_diag_gaussian_q
     else:
         q = "maf" if kind == "flow" else "gaussian"
 
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        theta_transform=torch_tf.identity_transform,
-        q=q,
-        **extra,
-    )
+    posterior = VIPosterior(FakePotential(prior=prior), prior, q=q, **extra)
     posterior.set_default_x(zeros(1, num_dim))
     return posterior
 
@@ -388,7 +416,7 @@ def _make_posterior(kind: str, num_dim: int = 2):
 TRAIN_KWARGS = dict(
     max_num_iters=10, check_for_convergence=False, quality_control=False
 )
-Q_KINDS = ["flow", "gaussian", "callable", "distribution"]
+Q_KINDS = ["flow", "gaussian", "callable", "distribution", "transformed"]
 
 
 @pytest.mark.parametrize("kind", Q_KINDS)
@@ -452,15 +480,10 @@ def test_multi_round_q_is_an_independent_warm_start():
 def test_amortized_posterior_survives_roundtrip():
     """Amortized mode had no serialization coverage."""
     num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        theta_transform=torch_tf.identity_transform,
-        q="maf",
-    )
+    posterior = _make_posterior("flow", num_dim)
+    theta = posterior._prior.sample((128,))
     posterior.train_amortized(
-        prior.sample((128,)), torch.randn(128, num_dim), max_num_iters=3, batch_size=16
+        theta, torch.randn(128, num_dim), max_num_iters=3, batch_size=16
     )
 
     x_o = zeros(1, num_dim)
@@ -477,15 +500,7 @@ def test_retrain_from_scratch_with_bounded_prior():
     """
     num_dim = 2
     prior = torch.distributions.Independent(Gamma(2 * ones(num_dim), ones(num_dim)), 1)
-    mu = zeros(num_dim, requires_grad=True)
-    scale = ones(num_dim, requires_grad=True)
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        q=torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1),
-        parameters=[mu, scale],
-    )
-    posterior.set_default_x(zeros(1, num_dim))
+    posterior = _make_posterior("distribution", num_dim, prior=prior)
     posterior.train(**TRAIN_KWARGS)
 
     posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
@@ -493,36 +508,6 @@ def test_retrain_from_scratch_with_bounded_prior():
     samples = posterior.sample((20,))
     assert samples.shape == (20, num_dim)
     assert torch.isfinite(posterior.log_prob(samples)).all()
-
-
-def test_transformed_distribution_q_finds_parameters_on_its_base():
-    """A `TransformedDistribution` keeps its trainable tensors on the base distribution.
-
-    Passing `parameters=` explicitly must stay optional for this shape of `q`.
-    """
-    num_dim = 2
-
-    class ParamNormal(torch.distributions.Normal):
-        def __init__(self, loc, scale):
-            super().__init__(loc, scale, validate_args=False)
-            self._params = [loc, scale]
-
-        def parameters(self):
-            return iter(self._params)
-
-    loc = zeros(num_dim, requires_grad=True)
-    scale = ones(num_dim, requires_grad=True)
-    q = torch.distributions.TransformedDistribution(
-        ParamNormal(loc, scale),
-        [torch_tf.AffineTransform(zeros(num_dim), ones(num_dim))],
-    )
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    posterior = VIPosterior(FakePotential(prior=prior), prior, q=q)
-    posterior.set_default_x(zeros(1, num_dim))
-
-    assert len(list(posterior._q.parameters())) == 2
-    posterior.train(**TRAIN_KWARGS)
-    assert posterior.sample((5,)).shape == (5, num_dim)
 
 
 def test_retrain_fails_after_setting_an_already_built_q():
@@ -539,16 +524,15 @@ def test_retrain_fails_after_setting_an_already_built_q():
         posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
 
 
-@pytest.mark.parametrize("kind", Q_KINDS)
+# One representative per side of the asymmetry; the round-trip test above covers
+# every kind, this only pins fresh-weights against restored-snapshot.
+@pytest.mark.parametrize("kind", ["flow", "distribution"])
 def test_retrain_from_scratch_semantics_per_kind(kind: str):
     """Pin the documented per-kind asymmetry of `retrain_from_scratch`."""
     posterior = _make_posterior(kind)
     initial = [p.detach().clone() for p in posterior._q.parameters()]
     posterior.train(**TRAIN_KWARGS)
     trained = [p.detach().clone() for p in posterior._q.parameters()]
-    assert any(
-        not torch.allclose(a, b) for a, b in zip(initial, trained, strict=True)
-    ), "training should move the parameters"
 
     # Not via `train(retrain_from_scratch=True)`: it would train over the rebuild.
     rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -12,7 +12,6 @@ This module tests both:
 from __future__ import annotations
 
 import pickle
-import tempfile
 from copy import deepcopy
 
 import numpy as np
@@ -277,74 +276,6 @@ def test_c2st_vi_external_distributions_on_Gaussian(num_dim: int):
     check_c2st(samples, target_samples, alg="slice_np")
 
 
-@pytest.mark.parametrize("q", FLOWS)
-def test_deepcopy_support(q: str):
-    """Test that VIPosterior supports deepcopy for all flow types."""
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    potential_fn = FakePotential(prior=prior)
-    theta_transform = torch_tf.identity_transform
-
-    posterior = VIPosterior(potential_fn, prior, theta_transform=theta_transform, q=q)
-    posterior_copy = deepcopy(posterior)
-    posterior.set_default_x(torch.tensor(np.zeros((num_dim,)).astype(np.float32)))
-    assert posterior._x != posterior_copy._x, "Deepcopy should create independent copy"
-
-    posterior_copy = deepcopy(posterior)
-    assert (posterior._x == posterior_copy._x).all(), "Deepcopy should preserve values"
-
-    # Verify samples are reproducible
-    torch.manual_seed(0)
-    if hasattr(posterior._q, "rsample"):
-        s1 = posterior._q.rsample()
-    else:
-        s1 = posterior._q.sample((1,)).squeeze(0)
-    torch.manual_seed(0)
-    if hasattr(posterior_copy._q, "rsample"):
-        s2 = posterior_copy._q.rsample()
-    else:
-        s2 = posterior_copy._q.sample((1,)).squeeze(0)
-    assert torch.allclose(s1, s2), "Samples should match after deepcopy"
-
-    # Test deepcopy after sampling (can produce nonleaf tensors in cache)
-    if hasattr(posterior.q, "rsample"):
-        posterior.q.rsample()
-    else:
-        posterior.q.sample((1,))
-    deepcopy(posterior)  # Should not raise
-
-
-@pytest.mark.parametrize("q", FLOWS)
-def test_pickle_support(q: str):
-    """Test that VIPosterior can be saved and loaded via pickle."""
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    potential_fn = FakePotential(prior=prior)
-    theta_transform = torch_tf.identity_transform
-
-    posterior = VIPosterior(potential_fn, prior, theta_transform=theta_transform, q=q)
-    posterior.set_default_x(torch.tensor(np.zeros((num_dim,)).astype(np.float32)))
-
-    with tempfile.NamedTemporaryFile(suffix=".pt") as f:
-        torch.save(posterior, f.name)
-        posterior_loaded = torch.load(f.name, weights_only=False)
-        assert (posterior._x == posterior_loaded._x).all()
-
-    # Verify samples are reproducible
-    torch.manual_seed(0)
-    if hasattr(posterior._q, "rsample"):
-        s1 = posterior._q.rsample()
-    else:
-        s1 = posterior._q.sample((1,)).squeeze(0)
-    torch.manual_seed(0)
-    if hasattr(posterior_loaded._q, "rsample"):
-        s2 = posterior_loaded._q.rsample()
-    else:
-        s2 = posterior_loaded._q.sample((1,)).squeeze(0)
-
-    assert torch.allclose(s1, s2), "Samples should match after unpickling"
-
-
 # =============================================================================
 # Serialization
 # =============================================================================
@@ -448,15 +379,19 @@ Q_KINDS = ["flow", "gaussian", "callable", "distribution", "transformed"]
 
 @pytest.mark.parametrize("kind", Q_KINDS)
 def test_trained_posterior_survives_roundtrip(kind: str):
-    """Pickling preserves training and leaves the copy fully usable."""
+    """Pickling preserves training, leaves the original untouched, and the copy
+    stays fully usable."""
     num_dim = 2
     posterior = _make_posterior(kind, num_dim)
     posterior.train(**TRAIN_KWARGS)
+    trained_on, optimizer = posterior._trained_on, posterior._optimizer
 
     torch.manual_seed(0)
     expected = posterior.sample((5,))
     reloaded = pickle.loads(pickle.dumps(posterior))
 
+    assert posterior._trained_on is trained_on
+    assert posterior._optimizer is optimizer
     assert reloaded._trained_on is not None
     torch.manual_seed(0)
     assert torch.allclose(reloaded.sample((5,)), expected)
@@ -464,17 +399,25 @@ def test_trained_posterior_survives_roundtrip(kind: str):
     assert reloaded.sample((5,)).shape == (5, num_dim)
 
 
-def test_pickling_does_not_mutate_the_original():
-    """`pickle.dumps` must leave the posterior it serializes untouched."""
-    posterior = _make_posterior("gaussian")
-    posterior.train(**TRAIN_KWARGS)
-    trained_on, optimizer = posterior._trained_on, posterior._optimizer
+# Deepcopy shares the pickle path, so one seeded compare per family suffices.
+@pytest.mark.parametrize("q", FLOWS)
+def test_every_flow_family_pickles(q: str):
+    """Each family builds different modules, which all must survive pickling."""
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        q=q,
+        theta_transform=torch_tf.identity_transform,
+    )
 
-    pickle.dumps(posterior)  # Discard the bytes; the original is what matters.
+    reloaded = pickle.loads(pickle.dumps(posterior))
 
-    assert posterior._trained_on is trained_on
-    assert posterior._optimizer is optimizer
-    posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
+    torch.manual_seed(0)
+    expected = posterior._q.sample((3,))
+    torch.manual_seed(0)
+    assert torch.allclose(reloaded._q.sample((3,)), expected)
 
 
 def test_deepcopy_of_trained_posterior_rewires_optimizer():
@@ -605,27 +548,6 @@ def test_retrain_fails_after_setting_an_already_built_q():
     assert posterior.q is replacement
     with pytest.raises(ValueError, match="Cannot rebuild"):
         posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
-
-
-# One representative per side of the asymmetry; the round-trip test above covers
-# every kind, this only pins fresh-weights against restored-snapshot.
-@pytest.mark.parametrize("kind", ["flow", "distribution"])
-def test_retrain_from_scratch_semantics_per_kind(kind: str):
-    """Pin the documented per-kind asymmetry of `retrain_from_scratch`."""
-    posterior = _make_posterior(kind)
-    initial = [p.detach().clone() for p in posterior._q.parameters()]
-    posterior.train(**TRAIN_KWARGS)
-    trained = [p.detach().clone() for p in posterior._q.parameters()]
-
-    # Not via `train(retrain_from_scratch=True)`: it would train over the rebuild.
-    rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]
-
-    if kind == "distribution":
-        assert all(torch.allclose(a, b) for a, b in zip(initial, rebuilt, strict=True))
-    else:
-        assert any(
-            not torch.allclose(a, b) for a, b in zip(trained, rebuilt, strict=True)
-        )
 
 
 def test_vi_posterior_interface():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -372,6 +372,33 @@ class _ParamNormal(torch.distributions.Independent):
         return iter(self._params)
 
 
+class _ModuleNormal(torch.nn.Module, torch.distributions.Distribution):
+    """A trainable distribution built as a module, a natural way to write one."""
+
+    support = torch.distributions.constraints.real_vector
+    has_rsample = True
+    arg_constraints: dict = {}
+
+    def __init__(self, num_dim: int):
+        torch.nn.Module.__init__(self)
+        self.loc = torch.nn.Parameter(zeros(num_dim))
+        self.log_scale = torch.nn.Parameter(zeros(num_dim))
+        torch.distributions.Distribution.__init__(
+            self, torch.Size([]), torch.Size([num_dim]), validate_args=False
+        )
+
+    def _dist(self):
+        return torch.distributions.Independent(
+            torch.distributions.Normal(self.loc, self.log_scale.exp()), 1
+        )
+
+    def rsample(self, sample_shape=torch.Size()):
+        return self._dist().rsample(sample_shape)
+
+    def log_prob(self, value):
+        return self._dist().log_prob(value)
+
+
 def _make_posterior(kind: str, num_dim: int = 2, prior=None):
     """Build an untrained VIPosterior for each way of specifying `q`.
 
@@ -531,6 +558,25 @@ def test_parameters_outside_q_and_its_base_must_be_passed(nested: bool):
             MultivariateNormal(zeros(num_dim), eye(num_dim)),
             torch_tf.identity_transform,
         )
+
+
+def test_adapted_q_moves_across_devices():
+    """`VIPosterior.to` only moves a `q` that offers `to`, so the wrapper must.
+
+    The meta device makes the move observable without a GPU.
+    """
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        q=_ModuleNormal(num_dim),
+        theta_transform=torch_tf.identity_transform,
+    )
+
+    posterior.to("meta")
+
+    assert all(p.device.type == "meta" for p in posterior.q.parameters())
 
 
 def test_retrain_fails_after_setting_an_already_built_q():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -29,6 +29,7 @@ from sbi.inference.potentials.ratio_based_potential import (
     ratio_estimator_based_potential,
 )
 from sbi.neural_nets.factory import ZukoFlowType
+from sbi.samplers.vi.vi_utils import LearnableGaussian
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
@@ -312,22 +313,6 @@ def test_deepcopy_support(q: str):
         posterior.q.sample((1,))
     deepcopy(posterior)  # Should not raise
 
-    # A *trained* posterior must survive deepcopy and stay usable through the public
-    # API. Sampling `_q` directly, as above, bypasses the `_trained_on` guard in
-    # `sample()` and so cannot see serialization damage.
-    posterior.train(
-        max_num_iters=10, check_for_convergence=False, quality_control=False
-    )
-    trained_copy = deepcopy(posterior)
-    assert trained_copy.sample((5,)).shape == (5, num_dim)
-    # The optimizer is transient and is rebuilt on demand, wired to the copy's own q
-    # rather than the original's.
-    trained_copy.train(
-        max_num_iters=1, check_for_convergence=False, quality_control=False
-    )
-    assert trained_copy._optimizer.q is trained_copy._q
-    assert trained_copy._optimizer.q is not posterior._q
-
 
 @pytest.mark.parametrize("q", FLOWS)
 def test_pickle_support(q: str):
@@ -359,107 +344,28 @@ def test_pickle_support(q: str):
 
     assert torch.allclose(s1, s2), "Samples should match after unpickling"
 
-    # A *trained* posterior must round-trip and stay usable through the public API.
-    posterior.train(
-        max_num_iters=10, check_for_convergence=False, quality_control=False
+
+# =============================================================================
+# Serialization
+#
+# VI used to store build closures and `__deepcopy__` overrides as instance
+# attributes, so `__getstate__` stripped them from `self` and `__setstate__`
+# rebuilt them by re-running the public `set_q`. These cover what that broke.
+# =============================================================================
+
+
+def _build_diag_gaussian_q(event_shape, link_transform, device="cpu"):
+    """A user-style `q` builder. Module-level, since pickling cannot capture a local."""
+    return LearnableGaussian(
+        dim=event_shape[0],
+        full_covariance=False,
+        link_transform=link_transform,
+        device=device,
     )
-    reloaded = pickle.loads(pickle.dumps(posterior))
-    assert reloaded._trained_on is not None
-    assert reloaded.sample((5,)).shape == (5, num_dim)
 
 
-def test_pickling_does_not_mutate_the_original():
-    """`pickle.dumps` must leave the posterior it serializes fully usable.
-
-    `__getstate__` used to strip `_optimizer` and the build closure from `self` rather
-    than from the copied state, so merely saving a posterior broke the live one.
-    """
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        theta_transform=torch_tf.identity_transform,
-        q="gaussian",
-    )
-    posterior.set_default_x(zeros(1, num_dim))
-    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
-    posterior.train(**kwargs)
-    trained_on, optimizer = posterior._trained_on, posterior._optimizer
-
-    pickle.dumps(posterior)  # Discard the bytes: the original is what matters here.
-
-    assert posterior._trained_on is trained_on
-    assert posterior._optimizer is optimizer
-    assert posterior.sample((5,)).shape == (5, num_dim)
-    posterior.train(**kwargs, retrain_from_scratch=True)
-
-
-@pytest.mark.parametrize("q", ["maf", "gaussian"])
-def test_retrain_from_scratch_survives_pickle(q: str):
-    """`retrain_from_scratch` still works after a round trip.
-
-    The rebuild recipe used to be a closure that pickling had to discard, and the
-    branch handling a pre-built flow never restored it.
-    """
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        theta_transform=torch_tf.identity_transform,
-        q=q,
-    )
-    posterior.set_default_x(zeros(1, num_dim))
-    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
-    posterior.train(**kwargs)
-    # Retraining swaps `q` for a fresh instance, which is the state that used to make
-    # the recipe unrecoverable.
-    posterior.train(**kwargs, retrain_from_scratch=True)
-
-    reloaded = pickle.loads(pickle.dumps(posterior))
-    reloaded.train(**kwargs, retrain_from_scratch=True)
-
-    assert reloaded.sample((5,)).shape == (5, num_dim)
-
-
-def test_custom_distribution_q_survives_pickle():
-    """A user-supplied `Distribution` q must pickle; its accessors are now methods."""
-    num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    mu = zeros(num_dim, requires_grad=True)
-    scale = ones(num_dim, requires_grad=True)
-    q = torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1)
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        theta_transform=torch_tf.identity_transform,
-        q=q,
-        parameters=[mu, scale],
-    )
-    posterior.set_default_x(zeros(1, num_dim))
-    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
-    posterior.train(**kwargs)
-    # The user's parameters must reach the optimizer, not just any parameters.
-    assert len(list(posterior._q.parameters())) == 2
-
-    torch.manual_seed(0)
-    expected = posterior.sample((5,))
-    reloaded = pickle.loads(pickle.dumps(posterior))
-    torch.manual_seed(0)
-    assert torch.allclose(reloaded.sample((5,)), expected)
-
-    reloaded.train(**kwargs, retrain_from_scratch=True)
-
-
-@pytest.mark.parametrize("kind", ["flow", "gaussian", "distribution"])
-def test_retrain_from_scratch_semantics_per_kind(kind: str):
-    """Pin the deliberate per-kind asymmetry of `retrain_from_scratch`.
-
-    sbi builds its own families fresh, but cannot re-randomize an opaque user
-    `Distribution`, so that kind returns to the snapshot taken when `q` was set.
-    """
-    num_dim = 2
+def _make_posterior(kind: str, num_dim: int = 2):
+    """Build an untrained VIPosterior for each way of specifying `q`."""
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     extra = {}
     if kind == "distribution":
@@ -467,6 +373,8 @@ def test_retrain_from_scratch_semantics_per_kind(kind: str):
         scale = ones(num_dim, requires_grad=True)
         q = torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1)
         extra = {"parameters": [mu, scale]}
+    elif kind == "callable":
+        q = _build_diag_gaussian_q
     else:
         q = "maf" if kind == "flow" else "gaussian"
 
@@ -478,31 +386,88 @@ def test_retrain_from_scratch_semantics_per_kind(kind: str):
         **extra,
     )
     posterior.set_default_x(zeros(1, num_dim))
-    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
-
-    initial = [p.detach().clone() for p in posterior._q.parameters()]
-    posterior.train(**kwargs)
-    trained = [p.detach().clone() for p in posterior._q.parameters()]
-    assert any(
-        not torch.allclose(a, b) for a, b in zip(initial, trained, strict=True)
-    ), "training should move the parameters"
-
-    # Inspect the rebuild itself: `train(retrain_from_scratch=True)` would immediately
-    # move the parameters again, hiding what the rebuild produced.
-    rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]
-
-    if kind == "distribution":
-        # Restored from the pre-training snapshot.
-        assert all(torch.allclose(a, b) for a, b in zip(initial, rebuilt, strict=True))
-    else:
-        # Freshly initialised, so no longer the trained values.
-        assert any(
-            not torch.allclose(a, b) for a, b in zip(trained, rebuilt, strict=True)
-        )
+    return posterior
 
 
-def test_amortized_posterior_survives_pickle_and_deepcopy():
-    """Amortized mode had no serialization coverage at all."""
+TRAIN_KWARGS = dict(
+    max_num_iters=10, check_for_convergence=False, quality_control=False
+)
+Q_KINDS = ["flow", "gaussian", "callable", "distribution"]
+
+
+@pytest.mark.parametrize("kind", Q_KINDS)
+def test_trained_posterior_survives_roundtrip(kind: str):
+    """Pickling preserves training and leaves the copy fully usable.
+
+    Covers every way of specifying `q`: a custom `Distribution` could not be pickled
+    at all, and `retrain_from_scratch` afterwards had a separate failure per kind.
+    """
+    num_dim = 2
+    posterior = _make_posterior(kind, num_dim)
+    posterior.train(**TRAIN_KWARGS)
+
+    torch.manual_seed(0)
+    expected = posterior.sample((5,))
+    reloaded = pickle.loads(pickle.dumps(posterior))
+
+    assert reloaded._trained_on is not None
+    torch.manual_seed(0)
+    assert torch.allclose(reloaded.sample((5,)), expected)
+    # The rebuild recipe must survive too, including a second retrain.
+    reloaded.train(**TRAIN_KWARGS, retrain_from_scratch=True)
+    assert reloaded.sample((5,)).shape == (5, num_dim)
+
+
+def test_pickling_does_not_mutate_the_original():
+    """`pickle.dumps` must leave the posterior it serializes untouched.
+
+    `__getstate__` used to strip state from `self` rather than from the copy, so
+    merely saving a posterior broke the live one.
+    """
+    posterior = _make_posterior("gaussian")
+    posterior.train(**TRAIN_KWARGS)
+    trained_on, optimizer = posterior._trained_on, posterior._optimizer
+
+    pickle.dumps(posterior)  # Discard the bytes; the original is what matters.
+
+    assert posterior._trained_on is trained_on
+    assert posterior._optimizer is optimizer
+    posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
+
+
+def test_deepcopy_of_trained_posterior_rewires_optimizer():
+    """A copy must own its `q`, not share the original's.
+
+    The old per-instance `__deepcopy__` closed over the source object, so a copy's
+    optimizer stepped a different `q` than its `sample()` read.
+    """
+    posterior = _make_posterior("gaussian")
+    posterior.train(**TRAIN_KWARGS)
+
+    copied = deepcopy(posterior)
+    copied.train(**TRAIN_KWARGS)
+
+    assert copied._optimizer.q is copied._q
+    assert copied._optimizer.q is not posterior._q
+
+
+def test_multi_round_q_is_an_independent_warm_start():
+    """Passing a trained posterior as `q` copies its flow rather than aliasing it."""
+    first = _make_posterior("flow")
+    first.train(**TRAIN_KWARGS)
+
+    prior = MultivariateNormal(zeros(2), eye(2))
+    second = VIPosterior(FakePotential(prior=prior), prior, q=first)
+
+    assert second._q is not first._q
+    assert all(
+        torch.allclose(a, b)
+        for a, b in zip(second._q.parameters(), first._q.parameters(), strict=True)
+    )
+
+
+def test_amortized_posterior_survives_roundtrip():
+    """Amortized mode had no serialization coverage."""
     num_dim = 2
     prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
     posterior = VIPosterior(
@@ -511,13 +476,41 @@ def test_amortized_posterior_survives_pickle_and_deepcopy():
         theta_transform=torch_tf.identity_transform,
         q="maf",
     )
-    theta, x = prior.sample((128,)), torch.randn(128, num_dim)
-    posterior.train_amortized(theta, x, max_num_iters=3, batch_size=16)
+    posterior.train_amortized(
+        prior.sample((128,)), torch.randn(128, num_dim), max_num_iters=3, batch_size=16
+    )
 
-    x_o = torch.zeros(1, num_dim)
+    x_o = zeros(1, num_dim)
     for candidate in (pickle.loads(pickle.dumps(posterior)), deepcopy(posterior)):
         assert candidate._mode == "amortized"
         assert candidate.sample((5,), x=x_o).shape == (5, num_dim)
+
+
+@pytest.mark.parametrize("kind", Q_KINDS)
+def test_retrain_from_scratch_semantics_per_kind(kind: str):
+    """Pin the documented per-kind asymmetry of `retrain_from_scratch`.
+
+    sbi rebuilds its own families fresh, but cannot re-randomize an opaque user
+    `Distribution`, so that kind returns to the snapshot taken when `q` was set.
+    """
+    posterior = _make_posterior(kind)
+    initial = [p.detach().clone() for p in posterior._q.parameters()]
+    posterior.train(**TRAIN_KWARGS)
+    trained = [p.detach().clone() for p in posterior._q.parameters()]
+    assert any(
+        not torch.allclose(a, b) for a, b in zip(initial, trained, strict=True)
+    ), "training should move the parameters"
+
+    # Inspect the rebuild directly: `train(retrain_from_scratch=True)` would move the
+    # parameters again, hiding what the rebuild produced.
+    rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]
+
+    if kind == "distribution":
+        assert all(torch.allclose(a, b) for a, b in zip(initial, rebuilt, strict=True))
+    else:
+        assert any(
+            not torch.allclose(a, b) for a, b in zip(trained, rebuilt, strict=True)
+        )
 
 
 def test_vi_posterior_interface():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -347,10 +347,6 @@ def test_pickle_support(q: str):
 
 # =============================================================================
 # Serialization
-#
-# VI used to store build closures and `__deepcopy__` overrides as instance
-# attributes, so `__getstate__` stripped them from `self` and `__setstate__`
-# rebuilt them by re-running the public `set_q`. These cover what that broke.
 # =============================================================================
 
 
@@ -397,11 +393,7 @@ Q_KINDS = ["flow", "gaussian", "callable", "distribution"]
 
 @pytest.mark.parametrize("kind", Q_KINDS)
 def test_trained_posterior_survives_roundtrip(kind: str):
-    """Pickling preserves training and leaves the copy fully usable.
-
-    Covers every way of specifying `q`: a custom `Distribution` could not be pickled
-    at all, and `retrain_from_scratch` afterwards had a separate failure per kind.
-    """
+    """Pickling preserves training and leaves the copy fully usable."""
     num_dim = 2
     posterior = _make_posterior(kind, num_dim)
     posterior.train(**TRAIN_KWARGS)
@@ -413,17 +405,12 @@ def test_trained_posterior_survives_roundtrip(kind: str):
     assert reloaded._trained_on is not None
     torch.manual_seed(0)
     assert torch.allclose(reloaded.sample((5,)), expected)
-    # The rebuild recipe must survive too, including a second retrain.
     reloaded.train(**TRAIN_KWARGS, retrain_from_scratch=True)
     assert reloaded.sample((5,)).shape == (5, num_dim)
 
 
 def test_pickling_does_not_mutate_the_original():
-    """`pickle.dumps` must leave the posterior it serializes untouched.
-
-    `__getstate__` used to strip state from `self` rather than from the copy, so
-    merely saving a posterior broke the live one.
-    """
+    """`pickle.dumps` must leave the posterior it serializes untouched."""
     posterior = _make_posterior("gaussian")
     posterior.train(**TRAIN_KWARGS)
     trained_on, optimizer = posterior._trained_on, posterior._optimizer
@@ -436,11 +423,7 @@ def test_pickling_does_not_mutate_the_original():
 
 
 def test_deepcopy_of_trained_posterior_rewires_optimizer():
-    """A copy must own its `q`, not share the original's.
-
-    The old per-instance `__deepcopy__` closed over the source object, so a copy's
-    optimizer stepped a different `q` than its `sample()` read.
-    """
+    """A copy's optimizer must step the copy's own `q`, not the original's."""
     posterior = _make_posterior("gaussian")
     posterior.train(**TRAIN_KWARGS)
 
@@ -489,13 +472,10 @@ def test_amortized_posterior_survives_roundtrip():
 def test_retrain_from_scratch_with_bounded_prior():
     """Retraining must not re-apply `link_transform` to an already-adapted `q`.
 
-    Goes through the public `train()` and uses a bounded prior, so the link transform
-    is non-trivial. With an unbounded prior it is the identity and applying it twice
-    would be harmless.
+    Needs a bounded prior: with an unbounded one the link transform is the identity
+    and applying it twice is unobservable.
     """
     num_dim = 2
-    # Gamma gives positive support, so the link transform is a real transform and its
-    # constraint does not compare equal to the adapted `q`'s.
     prior = torch.distributions.Independent(Gamma(2 * ones(num_dim), ones(num_dim)), 1)
     mu = zeros(num_dim, requires_grad=True)
     scale = ones(num_dim, requires_grad=True)
@@ -516,10 +496,7 @@ def test_retrain_from_scratch_with_bounded_prior():
 
 
 def test_set_q_with_instance_clears_the_rebuild_recipe():
-    """A hand-built `q` has no recipe, so retraining must fail loudly.
-
-    Silently keeping the previous recipe would rebuild the wrong family.
-    """
+    """A hand-built `q` has no rebuild recipe, so retraining must fail loudly."""
     posterior = _make_posterior("flow")
     replacement = LearnableGaussian(
         dim=2, full_covariance=False, link_transform=posterior.link_transform
@@ -534,11 +511,7 @@ def test_set_q_with_instance_clears_the_rebuild_recipe():
 
 @pytest.mark.parametrize("kind", Q_KINDS)
 def test_retrain_from_scratch_semantics_per_kind(kind: str):
-    """Pin the documented per-kind asymmetry of `retrain_from_scratch`.
-
-    sbi rebuilds its own families fresh, but cannot re-randomize an opaque user
-    `Distribution`, so that kind returns to the snapshot taken when `q` was set.
-    """
+    """Pin the documented per-kind asymmetry of `retrain_from_scratch`."""
     posterior = _make_posterior(kind)
     initial = [p.detach().clone() for p in posterior._q.parameters()]
     posterior.train(**TRAIN_KWARGS)
@@ -547,8 +520,7 @@ def test_retrain_from_scratch_semantics_per_kind(kind: str):
         not torch.allclose(a, b) for a, b in zip(initial, trained, strict=True)
     ), "training should move the parameters"
 
-    # Inspect the rebuild directly: `train(retrain_from_scratch=True)` would move the
-    # parameters again, hiding what the rebuild produced.
+    # Not via `train(retrain_from_scratch=True)`: it would train over the rebuild.
     rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]
 
     if kind == "distribution":

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -560,23 +560,37 @@ def test_parameters_outside_q_and_its_base_must_be_passed(nested: bool):
         )
 
 
-def test_adapted_q_moves_across_devices():
+# The three wrapper shapes: parameters passed explicitly, auto-detected from the
+# base, and exposed by a module.
+@pytest.mark.parametrize("kind", ["distribution", "transformed", "module"])
+def test_adapted_q_moves_across_devices(kind: str):
     """`VIPosterior.to` only moves a `q` that offers `to`, so the wrapper must.
 
-    The meta device makes the move observable without a GPU.
+    A module moves to the meta device, observable without a GPU. Plain tensors move
+    by `.data` reassignment, which meta refuses, so those kinds need real hardware.
     """
     num_dim = 2
-    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
-    posterior = VIPosterior(
-        FakePotential(prior=prior),
-        prior,
-        q=_ModuleNormal(num_dim),
-        theta_transform=torch_tf.identity_transform,
-    )
+    if kind == "module":
+        device = "meta"
+        prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+        posterior = VIPosterior(
+            FakePotential(prior=prior),
+            prior,
+            q=_ModuleNormal(num_dim),
+            theta_transform=torch_tf.identity_transform,
+        )
+    else:
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+        else:
+            pytest.skip("Moving plain tensors needs a real second device.")
+        posterior = _make_posterior(kind, num_dim)
 
-    posterior.to("meta")
+    posterior.to(device)
 
-    assert all(p.device.type == "meta" for p in posterior.q.parameters())
+    assert all(p.device.type == device for p in posterior.q.parameters())
 
 
 def test_retrain_fails_after_setting_an_already_built_q():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -495,6 +495,36 @@ def test_retrain_from_scratch_with_bounded_prior():
     assert torch.isfinite(posterior.log_prob(samples)).all()
 
 
+def test_transformed_distribution_q_finds_parameters_on_its_base():
+    """A `TransformedDistribution` keeps its trainable tensors on the base distribution.
+
+    Passing `parameters=` explicitly must stay optional for this shape of `q`.
+    """
+    num_dim = 2
+
+    class ParamNormal(torch.distributions.Normal):
+        def __init__(self, loc, scale):
+            super().__init__(loc, scale, validate_args=False)
+            self._params = [loc, scale]
+
+        def parameters(self):
+            return iter(self._params)
+
+    loc = zeros(num_dim, requires_grad=True)
+    scale = ones(num_dim, requires_grad=True)
+    q = torch.distributions.TransformedDistribution(
+        ParamNormal(loc, scale),
+        [torch_tf.AffineTransform(zeros(num_dim), ones(num_dim))],
+    )
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(FakePotential(prior=prior), prior, q=q)
+    posterior.set_default_x(zeros(1, num_dim))
+
+    assert len(list(posterior._q.parameters())) == 2
+    posterior.train(**TRAIN_KWARGS)
+    assert posterior.sample((5,)).shape == (5, num_dim)
+
+
 def test_retrain_fails_after_setting_an_already_built_q():
     """An already-built `q` cannot be rebuilt, so retraining must fail loudly."""
     posterior = _make_posterior("flow")

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -11,6 +11,7 @@ This module tests both:
 
 from __future__ import annotations
 
+import pickle
 import tempfile
 from copy import deepcopy
 
@@ -311,6 +312,22 @@ def test_deepcopy_support(q: str):
         posterior.q.sample((1,))
     deepcopy(posterior)  # Should not raise
 
+    # A *trained* posterior must survive deepcopy and stay usable through the public
+    # API. Sampling `_q` directly, as above, bypasses the `_trained_on` guard in
+    # `sample()` and so cannot see serialization damage.
+    posterior.train(
+        max_num_iters=10, check_for_convergence=False, quality_control=False
+    )
+    trained_copy = deepcopy(posterior)
+    assert trained_copy.sample((5,)).shape == (5, num_dim)
+    # The optimizer is transient and is rebuilt on demand, wired to the copy's own q
+    # rather than the original's.
+    trained_copy.train(
+        max_num_iters=1, check_for_convergence=False, quality_control=False
+    )
+    assert trained_copy._optimizer.q is trained_copy._q
+    assert trained_copy._optimizer.q is not posterior._q
+
 
 @pytest.mark.parametrize("q", FLOWS)
 def test_pickle_support(q: str):
@@ -341,6 +358,117 @@ def test_pickle_support(q: str):
         s2 = posterior_loaded._q.sample((1,)).squeeze(0)
 
     assert torch.allclose(s1, s2), "Samples should match after unpickling"
+
+    # A *trained* posterior must round-trip and stay usable through the public API.
+    posterior.train(
+        max_num_iters=10, check_for_convergence=False, quality_control=False
+    )
+    reloaded = pickle.loads(pickle.dumps(posterior))
+    assert reloaded._trained_on is not None
+    assert reloaded.sample((5,)).shape == (5, num_dim)
+
+
+def test_pickling_does_not_mutate_the_original():
+    """`pickle.dumps` must leave the posterior it serializes fully usable.
+
+    `__getstate__` used to strip `_optimizer` and the build closure from `self` rather
+    than from the copied state, so merely saving a posterior broke the live one.
+    """
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        theta_transform=torch_tf.identity_transform,
+        q="gaussian",
+    )
+    posterior.set_default_x(zeros(1, num_dim))
+    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
+    posterior.train(**kwargs)
+    trained_on, optimizer = posterior._trained_on, posterior._optimizer
+
+    pickle.dumps(posterior)  # Discard the bytes: the original is what matters here.
+
+    assert posterior._trained_on is trained_on
+    assert posterior._optimizer is optimizer
+    assert posterior.sample((5,)).shape == (5, num_dim)
+    posterior.train(**kwargs, retrain_from_scratch=True)
+
+
+@pytest.mark.parametrize("q", ["maf", "gaussian"])
+def test_retrain_from_scratch_survives_pickle(q: str):
+    """`retrain_from_scratch` still works after a round trip.
+
+    The rebuild recipe used to be a closure that pickling had to discard, and the
+    branch handling a pre-built flow never restored it.
+    """
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        theta_transform=torch_tf.identity_transform,
+        q=q,
+    )
+    posterior.set_default_x(zeros(1, num_dim))
+    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
+    posterior.train(**kwargs)
+    # Retraining swaps `q` for a fresh instance, which is the state that used to make
+    # the recipe unrecoverable.
+    posterior.train(**kwargs, retrain_from_scratch=True)
+
+    reloaded = pickle.loads(pickle.dumps(posterior))
+    reloaded.train(**kwargs, retrain_from_scratch=True)
+
+    assert reloaded.sample((5,)).shape == (5, num_dim)
+
+
+def test_custom_distribution_q_survives_pickle():
+    """A user-supplied `Distribution` q must pickle; its accessors are now methods."""
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    mu = zeros(num_dim, requires_grad=True)
+    scale = ones(num_dim, requires_grad=True)
+    q = torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1)
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        theta_transform=torch_tf.identity_transform,
+        q=q,
+        parameters=[mu, scale],
+    )
+    posterior.set_default_x(zeros(1, num_dim))
+    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
+    posterior.train(**kwargs)
+    # The user's parameters must reach the optimizer, not just any parameters.
+    assert len(list(posterior._q.parameters())) == 2
+
+    torch.manual_seed(0)
+    expected = posterior.sample((5,))
+    reloaded = pickle.loads(pickle.dumps(posterior))
+    torch.manual_seed(0)
+    assert torch.allclose(reloaded.sample((5,)), expected)
+
+    reloaded.train(**kwargs, retrain_from_scratch=True)
+
+
+def test_amortized_posterior_survives_pickle_and_deepcopy():
+    """Amortized mode had no serialization coverage at all."""
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        theta_transform=torch_tf.identity_transform,
+        q="maf",
+    )
+    theta, x = prior.sample((128,)), torch.randn(128, num_dim)
+    posterior.train_amortized(theta, x, max_num_iters=3, batch_size=16)
+
+    x_o = torch.zeros(1, num_dim)
+    for candidate in (pickle.loads(pickle.dumps(posterior)), deepcopy(posterior)):
+        assert candidate._mode == "amortized"
+        assert candidate.sample((5,), x=x_o).shape == (5, num_dim)
 
 
 def test_vi_posterior_interface():

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -510,13 +510,19 @@ def test_retrain_from_scratch_with_bounded_prior():
     assert torch.isfinite(posterior.log_prob(samples)).all()
 
 
-def test_parameters_outside_q_and_its_base_must_be_passed():
-    """sbi only looks on `q` and its base, so anything else must fail loudly."""
+@pytest.mark.parametrize("nested", [False, True])
+def test_parameters_outside_q_and_its_base_must_be_passed(nested: bool):
+    """sbi only looks on `q` and its base, so anything else must fail loudly.
+
+    Torch keeps a `ComposeTransform` as one entry in `q.transforms`, so a transform
+    nested inside one has to be found too.
+    """
     num_dim = 2
     transform = torch_tf.AffineTransform(zeros(num_dim), ones(num_dim))
     transform.parameters = lambda: iter(())  # A transform owning trainable tensors.
     q = torch.distributions.TransformedDistribution(
-        _ParamNormal(zeros(num_dim, requires_grad=True), ones(num_dim)), [transform]
+        _ParamNormal(zeros(num_dim, requires_grad=True), ones(num_dim)),
+        [torch_tf.ComposeTransform([transform]) if nested else transform],
     )
 
     with pytest.raises(ValueError, match="transforms"):

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -470,7 +470,7 @@ def test_amortized_posterior_survives_roundtrip():
 
 
 def test_retrain_from_scratch_with_bounded_prior():
-    """Retraining must not re-apply `link_transform` to an already-adapted `q`.
+    """Retraining an already-wrapped `q` must not apply the link transform twice.
 
     Needs a bounded prior: with an unbounded one the link transform is the identity
     and applying it twice is unobservable.
@@ -495,8 +495,8 @@ def test_retrain_from_scratch_with_bounded_prior():
     assert torch.isfinite(posterior.log_prob(samples)).all()
 
 
-def test_set_q_with_instance_clears_the_rebuild_recipe():
-    """A hand-built `q` has no rebuild recipe, so retraining must fail loudly."""
+def test_retrain_fails_after_setting_an_already_built_q():
+    """An already-built `q` cannot be rebuilt, so retraining must fail loudly."""
     posterior = _make_posterior("flow")
     replacement = LearnableGaussian(
         dim=2, full_covariance=False, link_transform=posterior.link_transform
@@ -505,7 +505,7 @@ def test_set_q_with_instance_clears_the_rebuild_recipe():
     posterior.set_q(replacement)
 
     assert posterior.q is replacement
-    with pytest.raises(ValueError, match="no construction recipe"):
+    with pytest.raises(ValueError, match="Cannot rebuild"):
         posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
 
 

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -452,6 +452,55 @@ def test_custom_distribution_q_survives_pickle():
     reloaded.train(**kwargs, retrain_from_scratch=True)
 
 
+@pytest.mark.parametrize("kind", ["flow", "gaussian", "distribution"])
+def test_retrain_from_scratch_semantics_per_kind(kind: str):
+    """Pin the deliberate per-kind asymmetry of `retrain_from_scratch`.
+
+    sbi builds its own families fresh, but cannot re-randomize an opaque user
+    `Distribution`, so that kind returns to the snapshot taken when `q` was set.
+    """
+    num_dim = 2
+    prior = MultivariateNormal(zeros(num_dim), eye(num_dim))
+    extra = {}
+    if kind == "distribution":
+        mu = zeros(num_dim, requires_grad=True)
+        scale = ones(num_dim, requires_grad=True)
+        q = torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1)
+        extra = {"parameters": [mu, scale]}
+    else:
+        q = "maf" if kind == "flow" else "gaussian"
+
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        theta_transform=torch_tf.identity_transform,
+        q=q,
+        **extra,
+    )
+    posterior.set_default_x(zeros(1, num_dim))
+    kwargs = dict(max_num_iters=10, check_for_convergence=False, quality_control=False)
+
+    initial = [p.detach().clone() for p in posterior._q.parameters()]
+    posterior.train(**kwargs)
+    trained = [p.detach().clone() for p in posterior._q.parameters()]
+    assert any(
+        not torch.allclose(a, b) for a, b in zip(initial, trained, strict=True)
+    ), "training should move the parameters"
+
+    # Inspect the rebuild itself: `train(retrain_from_scratch=True)` would immediately
+    # move the parameters again, hiding what the rebuild produced.
+    rebuilt = [p.detach().clone() for p in posterior._build_q_from_spec().parameters()]
+
+    if kind == "distribution":
+        # Restored from the pre-training snapshot.
+        assert all(torch.allclose(a, b) for a, b in zip(initial, rebuilt, strict=True))
+    else:
+        # Freshly initialised, so no longer the trained values.
+        assert any(
+            not torch.allclose(a, b) for a, b in zip(trained, rebuilt, strict=True)
+        )
+
+
 def test_amortized_posterior_survives_pickle_and_deepcopy():
     """Amortized mode had no serialization coverage at all."""
     num_dim = 2

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -486,6 +486,52 @@ def test_amortized_posterior_survives_roundtrip():
         assert candidate.sample((5,), x=x_o).shape == (5, num_dim)
 
 
+def test_retrain_from_scratch_with_bounded_prior():
+    """Retraining must not re-apply `link_transform` to an already-adapted `q`.
+
+    Goes through the public `train()` and uses a bounded prior, so the link transform
+    is non-trivial. With an unbounded prior it is the identity and applying it twice
+    would be harmless.
+    """
+    num_dim = 2
+    # Gamma gives positive support, so the link transform is a real transform and its
+    # constraint does not compare equal to the adapted `q`'s.
+    prior = torch.distributions.Independent(Gamma(2 * ones(num_dim), ones(num_dim)), 1)
+    mu = zeros(num_dim, requires_grad=True)
+    scale = ones(num_dim, requires_grad=True)
+    posterior = VIPosterior(
+        FakePotential(prior=prior),
+        prior,
+        q=torch.distributions.Independent(torch.distributions.Normal(mu, scale), 1),
+        parameters=[mu, scale],
+    )
+    posterior.set_default_x(zeros(1, num_dim))
+    posterior.train(**TRAIN_KWARGS)
+
+    posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
+
+    samples = posterior.sample((20,))
+    assert samples.shape == (20, num_dim)
+    assert torch.isfinite(posterior.log_prob(samples)).all()
+
+
+def test_set_q_with_instance_clears_the_rebuild_recipe():
+    """A hand-built `q` has no recipe, so retraining must fail loudly.
+
+    Silently keeping the previous recipe would rebuild the wrong family.
+    """
+    posterior = _make_posterior("flow")
+    replacement = LearnableGaussian(
+        dim=2, full_covariance=False, link_transform=posterior.link_transform
+    )
+
+    posterior.set_q(replacement)
+
+    assert posterior.q is replacement
+    with pytest.raises(ValueError, match="no construction recipe"):
+        posterior.train(**TRAIN_KWARGS, retrain_from_scratch=True)
+
+
 @pytest.mark.parametrize("kind", Q_KINDS)
 def test_retrain_from_scratch_semantics_per_kind(kind: str):
     """Pin the documented per-kind asymmetry of `retrain_from_scratch`.


### PR DESCRIPTION
Follow-up to #1939, which fixed the same class of bug for estimator transforms.

`VIPosterior` stored build functions, `__deepcopy__` overrides and `parameters`/`modules`
accessors as instance attributes. When these are functions, they cannot be pickled and need to be handled extra in `__get_state__`, causing a lot of trouble in recent PRs: `__getstate__` stripped them from `self` and `__setstate__` rebuilt them by re-running the
public `set_q`. 
When reviewing the current state thoroughly, I discovered a lot of implicit bugs that where not covered in the tests.  

This PR changes this approach with class-level methods, so the serialization hooks become as trivial as every other
posterior's.

- store how to rebuild `q` in a `_QSpec` dataclass, built by `_build_q_from_spec`; drops
  `_q_build_fn`, `_zuko_flow_type` and `_q_arg`
- wrap user distributions in `AdaptedVariationalDistribution`, whose `parameters`/`modules`
  are methods on the class; drops `adapt_variational_distribution` and its two helpers
- replace `make_object_deepcopy_compatible` with an explicit `detach_and_deepcopy` at the
  two call sites that need it
- `__getstate__` clears entries on the copy, `__setstate__` is a plain assignment, and
  `__deepcopy__` is gone so deepcopy and pickle share one path
- `retrain_from_scratch` no longer applies the link transform twice, and refuses with a
  clear error when `q` came in as an already-built distribution, since that says nothing
  about how to build another one
- find a user `TransformedDistribution`'s parameters on its base distribution, and refuse
  instead of silently leaving out tensors that sit in its transforms

Two things outside VI, same bug class, found while checking where else we store functions
on instances:

- `LRUEmbedding` kept its aggregation as a lambda, so no posterior using that embedding
  net could be pickled at all - including with the default `aggregate_fcn="mean"`
- `save_and_load_test` only checked the *shape* of the reloaded posterior's samples, which
  is why the `_trained_on` bug survived: a posterior that silently retrains still returns
  correctly shaped samples. it now compares seeded samples, and checks that saving leaves
  the posterior it saved untouched. also covers `ImportanceSamplingPosterior`, which had
  no coverage
