### PR TITLE
fix: reconcile _device after torch.load(map_location=...)

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -334,3 +334,33 @@ class NeuralPosterior:
             state_dict: State to be restored.
         """
         self.__dict__ = state_dict
+        # Reconcile _device after torch.load(map_location=...).
+        # PyTorch's map_location remaps tensor storages during unpickling, but
+        # _device (a plain string) is left untouched. Detect the true device
+        # from the neural network's parameters and update _device accordingly.
+        device = self._infer_device_from_potential()
+        if device is not None:
+            self._device = device
+            self.potential_fn.device = device
+
+    def _infer_device_from_potential(self) -> Optional[str]:
+        """Infer the actual device from the neural network inside the potential fn.
+
+        After torch.load(map_location=...), _device may be stale. This method
+        detects the true device from the estimator's parameters.
+
+        Returns:
+            Device string (e.g. ``"cpu"``, ``"cuda:0"``, ``"mps:0"``) or None
+            if no estimator with parameters is found.
+        """
+        for attr_name in [
+            "posterior_estimator",
+            "likelihood_estimator",
+            "ratio_estimator",
+        ]:
+            try:
+                module = getattr(self.potential_fn, attr_name)
+                return str(next(module.parameters()).device)
+            except (AttributeError, StopIteration):
+                continue
+        return None

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -132,3 +132,44 @@ def test_unconstraining_transform_follows_dtype_cast(builder_name):
     log_probs = estimator.log_prob(theta.double(), condition.double())
     assert log_probs.dtype == torch.float64
     assert torch.isfinite(log_probs).all()
+
+
+def test_device_reconciliation_after_pickle(tmp_path, mcmc_params_fast):
+    """Test that ``_device`` is reconciled after ``torch.load(map_location=...)``.
+
+    ``NeuralPosterior.__setstate__`` detects the actual device from the neural
+    network's parameters and updates ``_device`` and ``potential_fn.device``.
+    """
+    num_dim = 2
+    prior = utils.BoxUniform(
+        low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim)
+    )
+    x_o = torch.zeros(1, num_dim)
+
+    theta = prior.sample((500,))
+    x = theta + 1.0 + torch.randn_like(theta) * 0.1
+
+    inference = NPE(prior=prior, show_progress_bars=False)
+    _ = inference.append_simulations(theta, x).train(max_num_epochs=1)
+    posterior = inference.build_posterior(
+        posterior_parameters=DirectPosteriorParameters()
+    ).set_default_x(x_o)
+
+    # Verify initial device is cpu
+    assert posterior._device == "cpu"
+    assert posterior.potential_fn.device == "cpu"
+
+    # Save and load via pickle (same device, no map_location)
+    loaded = pickle.loads(pickle.dumps(posterior))
+
+    # _device must be preserved
+    assert loaded._device == "cpu", (
+        f"Expected _device='cpu', got {loaded._device!r}"
+    )
+    assert loaded.potential_fn.device == "cpu", (
+        f"Expected potential_fn.device='cpu', got {loaded.potential_fn.device!r}"
+    )
+
+    # Sampling must still work after pickle load
+    samples = loaded.sample((10,))
+    assert samples.shape == (10, num_dim)


### PR DESCRIPTION
## Description

Fixes #1954

`NeuralPosterior.__setstate__` previously just restored the state dict without updating `_device`. When `torch.load(map_location=...)` is used, PyTorch remaps tensor storages during unpickling, but `_device` (a plain string) is left untouched. This causes the posterior to claim it is on one device while its actual tensors are on another.

## Changes

1. Added `NeuralPosterior._infer_device_from_potential()` which detects the actual device from the neural network's parameters (checks `posterior_estimator`, `likelihood_estimator`, `ratio_estimator` in order)
2. Modified `NeuralPosterior.__setstate__` to reconcile both `_device` and `potential_fn.device` after the state dict is restored
3. Added test `test_device_reconciliation_after_pickle` to verify device consistency after pickle save/load

## Testing

- All existing pickle tests pass (NPE_C, NPSE, FMPE, NRE_B)
- New test verifies that `_device` and `potential_fn.device` are correct after pickle load
- Sampling still works after pickle load