### PR TITLE
fix: dead guards and broken messages found by the 0.27 audit sweep

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -928,13 +928,13 @@ def _validate_plotting_style(
         for i, val in enumerate(plotting_style):
             if val is not None and val not in allowed_styles:
                 raise ValueError(
-                    f"Expected {argument_name} at index {i} to be None or one",
-                    f" of {allowed_styles} but got {val}.",
+                    f"Expected {argument_name} at index {i} to be None or one"
+                    f" of {allowed_styles} but got {val}."
                 )
     elif plotting_style is not None and plotting_style not in allowed_styles:
         raise ValueError(
-            f"Expected {argument_name} to be None, a list or one",
-            f" of {allowed_styles} but got {plotting_style}.",
+            f"Expected {argument_name} to be None, a list or one"
+            f" of {allowed_styles} but got {plotting_style}."
         )
 
 
@@ -1740,7 +1740,7 @@ def _sbc_rank_plot(
 
     plot_types = ["hist", "cdf"]
     assert plot_type in plot_types, (
-        "plot type {plot_type} not implemented, use one in {plot_types}."
+        f"plot type {plot_type} not implemented, use one in {plot_types}."
     )
 
     if legend_kwargs is None:

--- a/sbi/analysis/tensorboard_output.py
+++ b/sbi/analysis/tensorboard_output.py
@@ -158,7 +158,10 @@ def plot_summary(
     elif isinstance(trainer, Path):
         log_dir = trainer
     else:
-        raise ValueError(f"trainer {trainer}")
+        raise ValueError(
+            f"Expected a NeuralInference object or a Path to a log directory, "
+            f"got {type(trainer).__name__}."
+        )
 
     all_event_data = _get_event_data_from_log_dir(log_dir, size_guidance)
     scalars = all_event_data["scalars"]

--- a/sbi/diagnostics/misspecification.py
+++ b/sbi/diagnostics/misspecification.py
@@ -141,17 +141,17 @@ def calc_misspecification_mmd(
     elif mode == "embedding":
         if inference is None:
             raise ValueError(
-                "inference should not be None if mode is 'embedding'."
-                "please provide an sbi inference object"
+                "inference should not be None if mode is 'embedding'. "
+                "Please provide an sbi inference object."
             )
-        if not hasattr(inference, "_neural_net"):
+        if getattr(inference, "_neural_net", None) is None:
             raise ValueError(
-                "no neural net found,"
-                "neural_net should not be None when mode is 'embedding'"
+                "No neural net found. The inference object must be trained before "
+                "computing the MMD in mode 'embedding'."
             )
         if isinstance(inference._neural_net.embedding_net, nn.modules.linear.Identity):
             warnings.warn(
-                "The embedding net might be the identity function,"
+                "The embedding net might be the identity function, "
                 "in that case the MMD is computed in the x-space.",
                 stacklevel=2,
             )

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -103,7 +103,7 @@ class SMCABC(ABCBASE):
         algorithm_variants = ("A", "B", "C")
         assert algorithm_variant in algorithm_variants, (
             f"SMCABC variant '{algorithm_variant}' not supported, choose one from"
-            " {algorithm_variants}."
+            f" {algorithm_variants}."
         )
         self.algorithm_variant = algorithm_variant
         self.distance_to_x0 = None
@@ -247,13 +247,13 @@ class SMCABC(ABCBASE):
         )
         log_weights = torch.log(1 / num_particles * torch.ones(num_particles))
 
-        self.logger.info((
+        self.logger.info(
             "population=%s, eps=%s, ess=%s, num_sims=%s",
             pop_idx,
             epsilon,
             1.0,
             num_initial_pop,
-        ))
+        )
 
         all_particles = [particles]
         all_log_weights = [log_weights]
@@ -295,12 +295,12 @@ class SMCABC(ABCBASE):
                     particles, log_weights, ess_min, pop_idx
                 )
 
-            self.logger.info((
-                "population=%s done: eps={epsilon:.6f}, num_sims=%s.",
+            self.logger.info(
+                "population=%s done: eps=%.6f, num_sims=%s.",
                 pop_idx,
                 epsilon,
                 self.simulation_counter,
-            ))
+            )
 
             # collect results
             all_particles.append(particles)
@@ -556,12 +556,12 @@ class SMCABC(ABCBASE):
         try:
             qidx = torch.where(distances_cdf >= quantile)[0][0]
         except IndexError:
-            self.logger.warning((
-                """Accepted unique distances=%s don't match quantile=%s. Selecting
-                    last distance.""",
+            self.logger.warning(
+                "Accepted unique distances=%s don't match quantile=%s. "
+                "Selecting last distance.",
                 distances,
                 quantile,
-            ))
+            )
             qidx = -1
 
         # The new epsilon is given by that distance.

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -136,6 +136,7 @@ class MCMCPosterior(NeuralPosterior):
         validate_target_accept(target_accept)
         self.target_accept = target_accept
         self._posterior_sampler = None
+        self._mcmc_init_params: Optional[Tensor] = None
 
         # Hardcode parameter name to reduce clutter kwargs.
         self.param_name = "theta"
@@ -546,11 +547,44 @@ class MCMCPosterior(NeuralPosterior):
                 proposal, potential_fn, transform=transform, **kwargs
             )
         elif init_strategy == "latest_sample":
-            latest_sample = IterateParameters(self._mcmc_init_params, **kwargs)
-            return latest_sample
+            # `getattr`: posteriors unpickled from older sbi versions lack the
+            # attribute entirely.
+            stored_params = getattr(self, "_mcmc_init_params", None)
+            if stored_params is None:
+                raise ValueError(
+                    "`init_strategy='latest_sample'` continues the chains of an "
+                    "earlier `sample()` call, but this posterior holds no chain "
+                    "states. Only `method='slice_np'` and "
+                    "`method='slice_np_vectorized'` record them, and only after a "
+                    "`sample()` or `sample_batched()` call. Use another init "
+                    "strategy, for example 'proposal' or 'sir'."
+                )
+            return IterateParameters(stored_params, **kwargs)
         else:
             raise NotImplementedError(
                 f"Init strategy {init_strategy} is not implemented."
+            )
+
+    def _check_latest_sample_supply(self, init_strategy: str, num_needed: int) -> None:
+        """Fail before sampling if `latest_sample` cannot supply enough chain states.
+
+        Args:
+            init_strategy: The requested init strategy.
+            num_needed: Number of initial parameters this call draws.
+
+        Raises:
+            ValueError: If the last run stored fewer states than this call needs.
+        """
+        stored_params = getattr(self, "_mcmc_init_params", None)
+        if init_strategy != "latest_sample" or stored_params is None:
+            return
+
+        stored = len(stored_params)
+        if num_needed > stored:
+            raise ValueError(
+                f"`init_strategy='latest_sample'` has {stored} chain state(s) from "
+                f"the last run, but this call needs {num_needed}. Run at most "
+                f"{stored} chain(s), or use another init strategy."
             )
 
     def _get_initial_params(
@@ -576,6 +610,8 @@ class MCMCPosterior(NeuralPosterior):
         Returns:
             Tensor: initial parameters, one for each chain
         """
+        self._check_latest_sample_supply(init_strategy, num_chains)
+
         # Build init function
         init_fn = self._build_mcmc_init_fn(
             self.proposal,
@@ -649,6 +685,9 @@ class MCMCPosterior(NeuralPosterior):
         Returns:
             Tensor: initial parameters, one for each chain
         """
+
+        # One init per chain per observation, all drawn from the same iterator.
+        self._check_latest_sample_supply(init_strategy, len(x) * num_chains_per_x)
 
         potential_ = deepcopy(self.potential_fn)
         initial_params = []

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -1,12 +1,14 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import os
 import time
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime
+from inspect import currentframe
 from pathlib import Path
 from typing import (
     Any,
@@ -81,6 +83,33 @@ from sbi.utils.user_input_checks import (
     process_prior,
     process_simulator,
 )
+
+_SBI_ROOT = str(Path(__file__).parents[2]) + os.sep
+
+
+def _stacklevel_to_caller(default: int = 2) -> int:
+    """Return the `warnings.warn` stacklevel of the first frame outside sbi.
+
+    Trainers reach the training loop through a different number of internal frames
+    each, so no constant is right for all of them. A constant also makes Python's
+    "once per location" filter collapse every training run in a process into one
+    warning. (`warn(skip_file_prefixes=...)` would do this, but needs Python 3.12.)
+
+    Args:
+        default: Stacklevel to fall back to if every frame is inside sbi.
+
+    Returns:
+        Stacklevel that attributes the warning to the caller's own code.
+    """
+    frame = currentframe()
+    frame = frame.f_back if frame is not None else None
+    level = 1
+    while frame is not None:
+        if not frame.f_code.co_filename.startswith(_SBI_ROOT):
+            return level
+        frame = frame.f_back
+        level += 1
+    return default
 
 
 def infer(
@@ -256,6 +285,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
         self._round = 0
         self._val_loss = float("Inf")
         self._best_val_loss = float("Inf")
+        self._best_model_state_dict = None
         self._epochs_since_last_improvement = 0
 
         if summary_writer is not None:
@@ -749,8 +779,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
             posterior_parameters = ImportanceSamplingPosteriorParameters(**params)
         else:
             raise NotImplementedError(
-                "Posterior parameter construction not implemented for",
-                f"'{sample_with}'",
+                f"Posterior parameter construction not implemented for '{sample_with}'"
             )
 
         return posterior_parameters
@@ -950,8 +979,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
                 )
             if sample_with not in ("ode", "sde"):
                 raise ValueError(
-                    "`sample_with` must be either",
-                    f" 'ode' or 'sde', got '{sample_with}'",
+                    f"`sample_with` must be either 'ode' or 'sde', got '{sample_with}'"
                 )
             posterior = VectorFieldPosterior(
                 vector_field_estimator=vector_field_estimator,
@@ -1000,8 +1028,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
                 )
             else:
                 raise NotImplementedError(
-                    "Sampling method not implemented for",
-                    f"'{posterior_parameters}'",
+                    f"Sampling method not implemented for '{posterior_parameters}'"
                 )
         return posterior
 
@@ -1039,7 +1066,7 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
                 list(self._neural_net.parameters()),
                 lr=train_config.learning_rate,
             )
-            self.epoch, self.val_loss = 0, float("Inf")
+            self.epoch, self._val_loss = 0, float("Inf")
 
         while self.epoch <= train_config.max_num_epochs and not self._converged(
             self.epoch, train_config.stop_after_epochs
@@ -1063,9 +1090,16 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
             self.epoch += 1
             self._maybe_show_progress(self._show_progress_bars, self.epoch)
 
-        self._report_convergence_at_end(
-            self.epoch, train_config.stop_after_epochs, train_config.max_num_epochs
-        )
+        if self.epoch > train_config.max_num_epochs:
+            # The `and` above short-circuits on the last check, so `_converged` never
+            # saw the final epoch. Score it here before choosing the weights to keep.
+            if self._val_loss < self._best_val_loss:
+                self._best_val_loss = self._val_loss
+                self._best_model_state_dict = deepcopy(self._neural_net.state_dict())
+            elif self._best_model_state_dict is not None:
+                self._neural_net.load_state_dict(self._best_model_state_dict)
+
+        self._report_convergence_at_end(self.epoch, train_config.max_num_epochs)
 
         # Update summary.
         self._summary["epochs_trained"].append(self.epoch)
@@ -1229,20 +1263,26 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
         )
         return TensorBoardTracker(SummaryWriter(logdir))
 
-    def _report_convergence_at_end(
-        self, epoch: int, stop_after_epochs: int, max_num_epochs: int
-    ) -> None:
-        if self._converged(epoch, stop_after_epochs):
+    def _report_convergence_at_end(self, epoch: int, max_num_epochs: int) -> None:
+        """Report why the training loop stopped.
+
+        Args:
+            epoch: Epoch counter as the training loop left it.
+            max_num_epochs: The epoch budget the loop was given.
+        """
+        # Not `_converged()`: it advances the counter it reads, so a second call can
+        # flip its own verdict.
+        if epoch <= max_num_epochs:
             print(
                 "\r",
                 f"Neural network successfully converged after {epoch} epochs.",
                 end="",
             )
-        elif max_num_epochs == epoch:
+        else:
             warn(
-                f"Maximum number of epochs `max_num_epochs={max_num_epochs}` reached,"
+                f"Maximum number of epochs `max_num_epochs={max_num_epochs}` reached, "
                 "but network has not yet fully converged. Consider increasing it.",
-                stacklevel=2,
+                stacklevel=_stacklevel_to_caller(),
             )
 
     def _summarize(

--- a/sbi/inference/trainers/marginal/marginal_base.py
+++ b/sbi/inference/trainers/marginal/marginal_base.py
@@ -16,6 +16,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard.writer import SummaryWriter
 
+from sbi.inference.trainers.base import _stacklevel_to_caller
 from sbi.neural_nets.estimators import UnconditionalDensityEstimator
 from sbi.neural_nets.estimators.shape_handling import (
     reshape_to_batch_event,
@@ -305,6 +306,20 @@ class MarginalTrainer:
             self._summary["epoch_durations_sec"].append(time.time() - epoch_start_time)
 
             self._maybe_show_progress(self._show_progress_bars, self.epoch)
+
+        if self.epoch > max_num_epochs:
+            # The `and` above short-circuits on the last check, so `_converged` never
+            # saw the final epoch. Score it here before choosing the weights to keep.
+            if self._val_loss < self._best_val_loss:
+                self._best_val_loss = self._val_loss
+                self._best_model_state_dict = deepcopy(self._neural_net.state_dict())
+            elif self._best_model_state_dict is not None:
+                self._neural_net.load_state_dict(self._best_model_state_dict)
+            warn(
+                f"Maximum number of epochs `max_num_epochs={max_num_epochs}` reached, "
+                "but network has not yet fully converged. Consider increasing it.",
+                stacklevel=_stacklevel_to_caller(),
+            )
 
         # Update summary.
         self._summary["epochs_trained"].append(self.epoch)

--- a/sbi/inference/trainers/nle/nle_base.py
+++ b/sbi/inference/trainers/nle/nle_base.py
@@ -389,7 +389,7 @@ class LikelihoodEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], A
             )
 
             assert len(x_shape_from_simulation(x.to("cpu"))) < 3, (
-                "SNLE cannot handle multi-dimensional simulator output."
+                "NLE cannot handle multi-dimensional simulator output."
             )
             del theta, x
 

--- a/sbi/inference/trainers/npe/npe_a.py
+++ b/sbi/inference/trainers/npe/npe_a.py
@@ -134,7 +134,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         # Catch invalid inputs.
         if not ((density_estimator == "mdn_snpe_a") or callable(density_estimator)):
             raise TypeError(
-                "The `density_estimator` passed to SNPE_A needs to be a "
+                "The `density_estimator` passed to NPE_A needs to be a "
                 "callable or the string 'mdn_snpe_a'!"
             )
 
@@ -203,7 +203,7 @@ class NPE_A(PosteriorEstimatorTrainer):
         """
 
         assert not retrain_from_scratch, """Retraining from scratch is not supported in
-            SNPE-A yet. The reason for this is that, if we reininitialized the density
+            NPE-A yet. The reason for this is that, if we reininitialized the density
             estimator, the z-scoring would change, which would break the posthoc
             correction. This is a pure implementation issue."""
 
@@ -262,14 +262,14 @@ class NPE_A(PosteriorEstimatorTrainer):
             default_x = proposal.default_x
             if default_x is None:
                 raise ValueError(
-                    "Proposal posterior must have a default_x set for SNPE-A "
+                    "Proposal posterior must have a default_x set for NPE-A "
                     "correction. Call posterior.set_default_x(x_o) before using "
                     "as proposal."
                 )
             if default_x.shape[0] != 1:
                 raise ValueError(
-                    f"SNPE-A requires default_x batch size of 1, got "
-                    f"{default_x.shape[0]}. SNPE-A only supports single "
+                    f"NPE-A requires default_x batch size of 1, got "
+                    f"{default_x.shape[0]}. NPE-A only supports single "
                     "observations for correction."
                 )
             return proposal.get_mog_params(default_x)
@@ -295,7 +295,7 @@ class NPE_A(PosteriorEstimatorTrainer):
                 )
             if default_x.shape[0] != 1:
                 raise ValueError(
-                    f"SNPE-A requires default_x batch size of 1, got "
+                    f"NPE-A requires default_x batch size of 1, got "
                     f"{default_x.shape[0]}."
                 )
             mog = proposal.get_mog_params(default_x)
@@ -308,7 +308,7 @@ class NPE_A(PosteriorEstimatorTrainer):
 
         # Unsupported type
         raise TypeError(
-            f"For multi-round SNPE-A, proposal must be one of: NPE_A_Posterior, "
+            f"For multi-round NPE-A, proposal must be one of: NPE_A_Posterior, "
             f"MultivariateNormal, MoG, or an object with get_mog_params() method. "
             f"Got {type(proposal).__name__}. For custom proposals, construct "
             f"NPE_A_Posterior directly with your proposal_mog parameter."
@@ -577,7 +577,7 @@ def _correct_for_proposal(
     except torch.linalg.LinAlgError as e:
         raise ValueError(
             "Posterior precision matrix is not positive definite. "
-            "This is a known issue with SNPE-A when the proposal and density "
+            "This is a known issue with NPE-A when the proposal and density "
             "estimator don't align well. Try different hyperparameters. "
             f"Original error: {e}"
         ) from e

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -234,8 +234,8 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
         if self._prior is None or isinstance(self._prior, ImproperEmpirical):
             if proposal is not None:
                 raise ValueError(
-                    "You did not passed a prior at initialization, but now you "
-                    "passed a proposal. If you want to run multi-round SNPE, you have "
+                    "You did not pass a prior at initialization, but now you "
+                    "passed a proposal. If you want to run multi-round NPE, you have "
                     "to specify a prior (set the `.prior` argument or re-initialize "
                     "the object with a prior distribution). If the samples you passed "
                     "to `append_simulations()` were sampled from the prior, you can "
@@ -555,7 +555,7 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
                         "proposal distribution it uses is not the prior (it can be "
                         "accessed via `RestrictedPrior._prior`). We do not "
                         "recommend to mix the `RestrictedPrior` with multi-round "
-                        "SNPE.",
+                        "NPE.",
                         stacklevel=2,
                     )
             elif (
@@ -571,12 +571,10 @@ class PosteriorEstimatorTrainer(NeuralInference[ConditionalDensityEstimator], AB
                 )
         elif self._round > 0:
             raise ValueError(
-                "A proposal was passed but no prior was passed at initialisation. When "
-                "running multi-round inference, a prior needs to be specified upon "
-                "initialisation. Potential fix: setting the `._prior` attribute or "
-                "re-initialisation. If the samples passed to `append_simulations()` "
-                "were sampled from the prior, single-round inference can be performed "
-                "with `append_simulations(..., proprosal=None)`."
+                "This trainer has already run multi-round inference, but no "
+                "`proposal` was passed for the new simulations. Pass the "
+                "distribution the simulations were sampled from. If they were "
+                "sampled from the prior, pass the prior object as `proposal`."
             )
 
     def _get_start_index(self, context: StartIndexContext) -> int:

--- a/sbi/inference/trainers/npe/npe_c.py
+++ b/sbi/inference/trainers/npe/npe_c.py
@@ -348,20 +348,8 @@ class NPE_C(PosteriorEstimatorTrainer):
         """
 
         if self.use_non_atomic_loss:
-            if not isinstance(self._neural_net, MixtureDensityEstimator):
-                raise ValueError(
-                    "The density estimator must be a MixtureDensityEstimator "
-                    "for non-atomic loss."
-                )
-
             return self._log_prob_proposal_posterior_mog(theta, x, proposal)
         else:
-            if not hasattr(self._neural_net, "log_prob"):
-                raise ValueError(
-                    "The neural estimator must have a log_prob method, for\
-                                 atomic loss. It should at best follow the \
-                                 sbi.neural_nets 'DensityEstiamtor' interface."
-                )
             return self._log_prob_proposal_posterior_atomic(theta, x, masks)
 
     def _log_prob_proposal_posterior_atomic(

--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -361,9 +361,9 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         assert self._neural_net is not None
         neural_net = self._neural_net
 
-        # Initialize tracking variables if not exists
-        if not hasattr(self, '_best_val_loss'):
-            self._best_val_loss = float('inf')
+        # A stale best-val-loss would stop this run early on the earlier run's weights.
+        if epoch == 0:
+            self._best_val_loss = float("inf")
             self._epochs_since_last_improvement = 0
             self._best_model_state_dict = None
 

--- a/sbi/neural_nets/embedding_nets/SC_embedding.py
+++ b/sbi/neural_nets/embedding_nets/SC_embedding.py
@@ -318,9 +318,9 @@ class SpectralConvEmbedding(nn.Module):
 
         else:
             raise ValueError(
-                'Input tensor should be 3D (batch_size, channels, n_points) '
-                'or 4D (batch_size, 2, channels, n_points). ',
-                f'The tensor that was passed has shape {x.shape}.',
+                "Input tensor should be 3D (batch_size, channels, n_points) "
+                "or 4D (batch_size, 2, channels, n_points). "
+                f"The tensor that was passed has shape {x.shape}."
             )
 
         n_points = x.shape[1]

--- a/sbi/neural_nets/embedding_nets/lru.py
+++ b/sbi/neural_nets/embedding_nets/lru.py
@@ -239,16 +239,16 @@ class LRU(nn.Module):
         # Check and store the inputs.
         if not isinstance(input_dim, int) or input_dim <= 0:
             raise ValueError("input_dim must be a positive integer.")
-        if not isinstance(state_dim, int) or input_dim <= 0:
+        if not isinstance(state_dim, int) or state_dim <= 0:
             raise ValueError("state_dim must be a positive integer.")
         if not (0 <= r_min < r_max <= 1):
             raise ValueError(
-                f"Invalid {r_min=} and/or {r_max: float = }. They must suffice "
+                f"Invalid {r_min=} and/or {r_max=}. They must satisfy "
                 "0 <= r_min < r_max <= 1."
             )
         if not (0 <= phase_max <= 2 * torch.pi):
             raise ValueError(
-                f"Invalid {phase_max: float = }. I must suffice 0 <= phase_max <= 2 pi."
+                f"Invalid {phase_max=}. It must satisfy 0 <= phase_max <= 2 pi."
             )
         if mode not in ("loop", "scan"):
             raise ValueError(f"Invalid {mode=}. Must be 'loop' or 'scan'.")
@@ -339,7 +339,7 @@ class LRU(nn.Module):
             state = state.to(device=input.device)
             assert state.shape == expected_state_shape, (
                 f"Invalid state shape {state.shape}, "  # fmt: skip
-                "expected {expected_state_shape}"  # fmt: skip
+                f"expected {expected_state_shape}"  # fmt: skip
             )
 
         # Detemine which mode to run the forward method with.
@@ -349,6 +349,8 @@ class LRU(nn.Module):
                 output = self._forward_scan(input, state)
             case "loop":
                 output = self._forward_loop(input, state)
+            case _:
+                raise ValueError(f"Invalid {mode=}. Must be 'loop' or 'scan'.")
         return output
 
     def _forward_loop(self, input: Tensor, state: Tensor) -> Tensor:

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -127,14 +127,14 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         # and std for the "base" distribution.
         # Create t on the correct device to avoid CPU/GPU mismatch
         t_tensor = torch.as_tensor([t_max], device=self.mean_0.device)
-        mean_t = self.approx_marginal_mean(t_tensor)
-        std_t = self.approx_marginal_std(t_tensor)
-        mean_t = torch.broadcast_to(mean_t, (1, *input_shape))
-        std_t = torch.broadcast_to(std_t, (1, *input_shape))
-
-        # Update the base distribution parameters
-        self._mean_base = mean_t
-        self._std_base = std_t
+        # `clone()`: these are buffers, and `load_state_dict` cannot write into the
+        # stride-0 view `broadcast_to` returns.
+        self._mean_base = torch.broadcast_to(
+            self.approx_marginal_mean(t_tensor), (1, *input_shape)
+        ).clone()
+        self._std_base = torch.broadcast_to(
+            self.approx_marginal_std(t_tensor), (1, *input_shape)
+        ).clone()
 
     def forward(self, input: Tensor, condition: Tensor, time: Tensor) -> Tensor:
         r"""Forward pass of the score estimator

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -331,9 +331,9 @@ def posterior_nn(
     if model == "mdn_snpe_a":
         if num_components != 10:
             raise ValueError(
-                "You set `num_components`. For SNPE-A, this has to be done at "
+                "You set `num_components`. For NPE-A, this has to be done at "
                 "instantiation of the inference object, i.e. "
-                "`inference = SNPE_A(..., num_components=20)`"
+                "`inference = NPE_A(..., num_components=20)`"
             )
         builder_kwargs.pop("num_components")
 

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -35,6 +35,7 @@ from sbi.samplers.vi.vi_utils import (
     filter_kwargs_for_func,
 )
 from sbi.sbi_types import Array
+from sbi.utils.torchutils import set_validate_args
 from sbi.utils.user_input_checks import check_prior
 from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
@@ -120,7 +121,7 @@ class DivergenceOptimizer(ABC):
         self._kwargs = kwargs
 
         if prior is not None:
-            self.prior.set_default_validate_args(False)  # type: ignore
+            set_validate_args(self.prior, False)  # type: ignore
 
         # Manage modules - only add q if it's an nn.Module (not for external dists)
         from torch.nn import Module as TorchModule
@@ -534,8 +535,6 @@ class IWElboOptimizer(ElboOptimizer):
         self.loss_name = "iwelbo"
         self.eps = 1e-7
         self.dreg = dreg
-        if not hasattr(self, 'HYPER_PARAMETERS'):
-            self.HYPER_PARAMETERS = []
         self.HYPER_PARAMETERS += ["K", "dreg"]
         if dreg:
             self.stick_the_landing = True
@@ -696,8 +695,6 @@ class RenyiDivergenceOptimizer(ElboOptimizer):
         self.alpha = alpha
         self.unbiased = unbiased
         super().__init__(*args, **kwargs)
-        if not hasattr(self, 'HYPER_PARAMETERS'):
-            self.HYPER_PARAMETERS = []
         self.HYPER_PARAMETERS += ["alpha", "unbiased", "dreg"]
         self.eps = 1e-5
         self.dreg = dreg

--- a/sbi/samplers/vi/vi_utils.py
+++ b/sbi/samplers/vi/vi_utils.py
@@ -176,9 +176,24 @@ class LearnableGaussian(nn.Module):
 
     def _base_dist(self) -> Distribution:
         """Get the base Gaussian distribution with current parameters."""
+        # `validate_args=False`: the parameters are unconstrained, so an optimizer step
+        # can leave the support. NaN log-probs beat a mid-training exception.
         if self._full_cov:
-            return MultivariateNormal(self.loc, scale_tril=self.scale_tril)
-        return Independent(Normal(self.loc, self.log_scale.exp()), 1)
+            return MultivariateNormal(
+                self.loc, scale_tril=self._cholesky(), validate_args=False
+            )
+        return Independent(
+            Normal(self.loc, self.log_scale.exp(), validate_args=False),
+            1,
+        )
+
+    def _cholesky(self) -> Tensor:
+        """Read the unconstrained `scale_tril` parameter as a lower-Cholesky factor.
+
+        The optimizer moves the upper triangle away from zero. `log_prob` ignores it,
+        `rsample` does not, which biases the ELBO. Dropping it makes the two agree.
+        """
+        return self.scale_tril.tril()
 
     def sample(self, sample_shape: Shape) -> Tensor:
         """Sample from the distribution.

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -29,6 +29,28 @@ from sbi.utils.typechecks import is_nonnegative_int, is_positive_int
 _HAS_WARNED_MPS_FALLBACK: bool = False
 
 
+def set_validate_args(
+    dist: torch.distributions.Distribution, validate_args: bool
+) -> None:
+    """Set argument and sample validation on this distribution instance only.
+
+    Torch only offers `set_default_validate_args`, which mutates the default for every
+    distribution constructed afterwards, globally. Validation runs at every layer of a
+    composed distribution, so this recurses into any nested distribution, including
+    private ones such as `Beta._dirichlet`.
+
+    Args:
+        dist: The distribution instance to configure.
+        validate_args: Whether the instance validates arguments and samples.
+    """
+    dist._validate_args = validate_args
+    for value in vars(dist).values():
+        members = value if isinstance(value, (list, tuple)) else [value]
+        for member in members:
+            if isinstance(member, torch.distributions.Distribution):
+                set_validate_args(member, validate_args)
+
+
 def process_device(device: Optional[Union[str, torch.device]]) -> str:
     """Resolve `device` to a canonical device string and set torch up to use it.
 
@@ -586,6 +608,7 @@ class BoxUniform(Independent):
                 validate_args=False,
             ),
             reinterpreted_batch_ndims,
+            validate_args=False,
         )
 
     def to(self, device: Union[str, torch.device]) -> None:
@@ -612,13 +635,17 @@ class BoxUniform(Independent):
         self.low = self.low.to(device=device)
         self.high = self.high.to(device=device)
 
+        # Rebuilding below would otherwise reset this to torch's class default.
+        validate_args = self._validate_args
+
         super().__init__(
             Uniform(
                 low=self.low,
                 high=self.high,
-                validate_args=False,
+                validate_args=validate_args,
             ),
             self.reinterpreted_batch_ndims,
+            validate_args=validate_args,
         )
 
 

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -16,6 +16,7 @@ from sbi.utils.torchutils import (
     assert_all_finite,
     atleast_2d,
     canonical_device,
+    set_validate_args,
 )
 from sbi.utils.user_input_checks_utils import (
     CustomPriorWrapper,
@@ -206,7 +207,7 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
 
     # Turn off validation of input arguments to allow `log_prob()` on samples outside
     # of the support.
-    prior.set_default_validate_args(False)
+    set_validate_args(prior, False)
 
     # Reject unwrapped scalar priors.
     # This will reject Uniform priors with dimension larger than 1.

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -16,7 +16,11 @@ from torch.distributions import (
     constraints,
 )
 
-from sbi.utils.torchutils import move_all_tensor_to_device, process_device
+from sbi.utils.torchutils import (
+    move_all_tensor_to_device,
+    process_device,
+    set_validate_args,
+)
 
 
 def get_distribution_parameters(
@@ -63,10 +67,13 @@ def move_distribution_to_device(
     else:
         try:
             params = get_distribution_parameters(dist, device)
-            return type(dist)(**params)
+            rebuilt = type(dist)(**params)
         except Exception:
             move_all_tensor_to_device(dist, device)
             return dist
+        # Not a constructor argument: a user subclass need not accept `validate_args`.
+        set_validate_args(rebuilt, dist._validate_args)
+        return rebuilt
 
 
 class CustomPriorWrapper(Distribution):
@@ -181,6 +188,10 @@ class PytorchReturnTypeWrapper(Distribution):
         event_shape=torch.Size(),
         validate_args=None,
     ):
+        self.prior = prior
+        if validate_args is not None:
+            set_validate_args(prior, validate_args)
+
         super().__init__(
             batch_shape=batch_shape,
             event_shape=event_shape,
@@ -189,7 +200,6 @@ class PytorchReturnTypeWrapper(Distribution):
             ),
         )
 
-        self.prior = prior
         self.device = None
         self.return_type = return_type
 
@@ -218,6 +228,11 @@ class PytorchReturnTypeWrapper(Distribution):
             self.prior.variance,
             dtype=self.return_type,  # type: ignore
         )
+
+    @property
+    def arg_constraints(self) -> Dict[str, constraints.Constraint]:
+        # Torch looks up a same-named attribute per constraint; this wrapper has none.
+        return {}
 
     @property
     def support(self):
@@ -271,14 +286,15 @@ class MultipleIndependent(Distribution):
             from sbi.utils.user_input_checks_utils import MultipleIndependent
 
             prior = MultipleIndependent([
-                Gamma(torch.zeros(1), torch.ones(1)),
-                Beta(torch.zeros(1), torch.ones(1)),
+                Gamma(torch.ones(1), torch.ones(1)),
+                Beta(2 * torch.ones(1), 2 * torch.ones(1)),
                 MultivariateNormal(torch.ones(2), torch.tensor([[1, .1], [.1, 1.]]))
             ])
         """
         self._check_distributions(dists)
         if validate_args is not None:
-            [d.set_default_validate_args(validate_args) for d in dists]
+            for d in dists:
+                set_validate_args(d, validate_args)
 
         self.dists = dists
         self.device = process_device(device or "cpu")
@@ -526,12 +542,14 @@ class OneDimPriorWrapper(Distribution):
 
     def __init__(self, prior: Distribution, validate_args=None) -> None:
         self.prior = prior
-        # The wrapped prior validates its own arguments; validating here would
-        # make torch look for them on the wrapper, which only delegates.
+        if validate_args is not None:
+            set_validate_args(prior, validate_args)
         super().__init__(
             batch_shape=prior.batch_shape,
             event_shape=prior.event_shape,
-            validate_args=False,
+            validate_args=(
+                prior._validate_args if validate_args is None else validate_args
+            ),
         )
         self.device = None
 
@@ -558,7 +576,8 @@ class OneDimPriorWrapper(Distribution):
 
     @property
     def arg_constraints(self) -> Dict[str, constraints.Constraint]:
-        return self.prior.arg_constraints
+        # Torch looks up a same-named attribute per constraint; this wrapper has none.
+        return {}
 
     @property
     def support(self):

--- a/sbi/utils/vector_field_utils.py
+++ b/sbi/utils/vector_field_utils.py
@@ -22,8 +22,6 @@ from torch.distributions import (
     constraints,
 )
 
-from sbi.utils.torchutils import BoxUniform
-
 
 class VectorFieldNet(nn.Module, ABC):
     """Abstract base class for vector field estimation networks.
@@ -302,7 +300,7 @@ def denoise(p: Distribution, m: Tensor, s: Tensor, x_t: Tensor) -> Distribution:
         return denoise_gaussian(p, m, s, x_t)
     elif isinstance(p, MultivariateNormal):
         return denoise_multivariate_gaussian(p, m, s, x_t)
-    elif isinstance(p, (Uniform, BoxUniform)):
+    elif isinstance(p, Uniform):
         return denoise_uniform(p, m, s, x_t)
     else:
         return denoise_general(p, m, s, x_t)
@@ -414,7 +412,7 @@ def denoise_mixture(
 
 
 def denoise_uniform(
-    p: Uniform | BoxUniform, m: Tensor, s: Tensor, x_t: Tensor
+    p: Uniform, m: Tensor, s: Tensor, x_t: Tensor
 ) -> 'UniformNormalPosterior':
     """Denoise a uniform distribution.
 
@@ -484,7 +482,7 @@ def marginalize(p: Distribution, m: Tensor, s: Tensor) -> Distribution:
         return marginalize_gaussian(p, m, s)
     elif isinstance(p, MultivariateNormal):
         return marginalize_multivariate_gaussian(p, m, s)
-    elif isinstance(p, (Uniform, BoxUniform)):
+    elif isinstance(p, Uniform):
         return marginalize_uniform(p, m, s)
     elif isinstance(p, MixtureSameFamily):
         return marginalize_mixture(p, m, s)
@@ -582,9 +580,7 @@ def marginalize_multivariate_gaussian(
     return MultivariateNormal(marginal_mean, covariance_matrix=marginal_cov)
 
 
-def marginalize_uniform(
-    p: Uniform | BoxUniform, m: Tensor, s: Tensor
-) -> 'UniformNormalConvolution':
+def marginalize_uniform(p: Uniform, m: Tensor, s: Tensor) -> 'UniformNormalConvolution':
     """Marginalize a uniform distribution.
 
     Args:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -8,7 +8,7 @@ import torch
 
 import sbi.inference
 from sbi import utils
-from sbi.inference import NPE, VectorFieldPosterior, infer
+from sbi.inference import FMPE, NPE, VectorFieldPosterior, infer
 from sbi.inference.trainers import nle, npe, nre
 from sbi.neural_nets.net_builders import (
     build_flow_matching_estimator,
@@ -256,3 +256,58 @@ def test_vector_field_posterior_sample_with_warns():
             reject_outside_prior=False,
             show_progress_bars=False,
         )
+
+
+@pytest.mark.parametrize(
+    "losses",
+    (
+        [10.0, 9.0, 8.0, 7.0, 6.0, 5.0],
+        [10.0, 9.0, 8.0, 7.0, 6.0, 6.0],
+    ),
+    ids=("best-is-the-last-epoch", "best-is-an-earlier-epoch"),
+)
+def test_exhausted_epoch_budget_returns_the_best_weights(losses):
+    """A run that hits `max_num_epochs` must end on the weights of its best epoch.
+
+    Both shapes matter. The loop condition short-circuits, so `_converged` never
+    scores the final epoch: a run still improving at the budget must not roll back
+    to an earlier, worse checkpoint, and a run that got worse must roll back.
+    """
+    prior = utils.BoxUniform(-torch.ones(2), torch.ones(2))
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+
+    inference = NPE(prior=prior, show_progress_bars=False)
+    inference.append_simulations(theta, x)
+
+    scripted = iter(losses)
+    inference._validate_epoch = lambda *_a, **_kw: next(scripted, losses[-1])
+    # `stop_after_epochs` is large so the run cannot converge early.
+    inference.train(max_num_epochs=5, stop_after_epochs=50, training_batch_size=50)
+
+    assert inference.epoch > 5, "the budget must have run out for this to test anything"
+    assert inference._best_val_loss == min(losses)
+    final = inference._neural_net.state_dict()
+    assert all(
+        torch.equal(final[k], v) for k, v in inference._best_model_state_dict.items()
+    )
+
+
+def test_vector_field_converged_resets_between_runs():
+    """A stale best-val-loss from run one must not leak into run two.
+
+    Otherwise run two can converge immediately and restore run one's weights.
+    """
+    prior = utils.BoxUniform(-torch.ones(2), torch.ones(2))
+    theta = prior.sample((100,))
+    x = theta + 0.1 * torch.randn_like(theta)
+
+    inference = FMPE(prior=prior, show_progress_bars=False)
+    inference.append_simulations(theta, x)
+    inference.train(max_num_epochs=1)
+
+    stale_best = inference._best_val_loss
+    inference._val_loss = stale_best + 10.0
+    inference._converged(epoch=0, stop_after_epochs=20)
+
+    assert inference._best_val_loss == pytest.approx(stale_best + 10.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,24 @@ def set_seed():
     seed_all_backends(seed)
 
 
+@pytest.fixture(autouse=True)
+def guard_torch_validation_default():
+    """Fail the test that mutates torch's global validation default.
+
+    `set_default_validate_args` is a torch staticmethod: called on any instance, it
+    changes validation for every distribution constructed afterwards, which makes
+    test failures order-dependent. sbi sets validation per instance only.
+    """
+    default = torch.distributions.Distribution._validate_args
+    yield
+    polluted = torch.distributions.Distribution._validate_args is not default
+    torch.distributions.Distribution._validate_args = default
+    assert not polluted, (
+        "This test changed torch's global validation default. Use "
+        "`sbi.utils.torchutils.set_validate_args` to configure single instances."
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def set_default_tensor_type():
     torch.set_default_dtype(torch.float32)

--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -921,3 +921,28 @@ def test_scan(
     assert torch.allclose(y_scan, y_loop, atol=1e-5)
 
     torch.compiler.reset()
+
+
+LRU_DEFAULTS = dict(
+    input_dim=4,
+    state_dim=8,
+    r_min=0.0,
+    r_max=1.0,
+    phase_max=torch.pi,
+    bidirectional=False,
+    mode="scan",
+)
+
+
+def test_lru_rejects_invalid_state_dim():
+    """The check read `input_dim`, so an invalid `state_dim` passed silently."""
+    with pytest.raises(ValueError, match="state_dim"):
+        LRU(**{**LRU_DEFAULTS, "state_dim": -5})
+
+
+def test_lru_forward_rejects_invalid_mode():
+    """`forward()`'s `match mode` must stay in sync with the constructor."""
+    layer = LRU(**LRU_DEFAULTS)
+
+    with pytest.raises(ValueError, match="mode"):
+        layer.forward(torch.randn(2, 6, LRU_DEFAULTS["input_dim"]), mode="invalid")

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -545,7 +545,11 @@ def test_multiround_mdn_training_on_device(method: Union[NPE_A, NPE_C]):
     num_rounds = 2
     num_simulations = 1000
     device = process_device("gpu")
-    prior = BoxUniform(-torch.ones(num_dim), torch.ones(num_dim), device=device)
+    # NPE-A's correction needs the Gaussian prior's precision to stay positive
+    # definite.
+    prior = MultivariateNormal(
+        torch.zeros(num_dim, device=device), torch.eye(num_dim, device=device)
+    )
     simulator = diagonal_linear_gaussian
 
     estimator = "mdn_snpe_a" if method == NPE_A else "mdn"

--- a/tests/marginal_estimator_test.py
+++ b/tests/marginal_estimator_test.py
@@ -62,3 +62,24 @@ def test_marginal_estimator(
         x_test = x_test.unsqueeze(1)
 
     check_c2st(x_test, samples.cpu(), f'MarginalEstimator-{model}')
+
+
+def test_marginal_trainer_exhausted_epoch_budget_returns_the_best_weights():
+    """A run that hits `max_num_epochs` must warn and end on its best weights.
+
+    The trainer has its own training loop, whose condition short-circuits like the
+    shared one in `NeuralInference`: `_converged` never scores the final epoch.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(200, 2)
+
+    trainer = MarginalTrainer(show_progress_bars=False)
+    trainer.append_samples(x)
+    with pytest.warns(UserWarning, match="max_num_epochs"):
+        trainer.train(max_num_epochs=2, stop_after_epochs=50)
+
+    assert trainer.epoch > 2, "the budget must run out for this to test anything"
+    final = trainer._neural_net.state_dict()
+    assert all(
+        torch.equal(final[k], v) for k, v in trainer._best_model_state_dict.items()
+    )

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -221,6 +221,45 @@ def test_mcmc_posterior_rejects_invalid_target_accept():
         posterior.sample((1,), method="hmc_pymc", target_accept=0.0)
 
 
+def _gaussian_potential_posterior():
+    prior = BoxUniform(low=-2 * ones(2), high=2 * ones(2))
+
+    def potential_fn(theta):
+        return -0.5 * (theta**2).sum(axis=-1)
+
+    with pytest.warns(UserWarning, match="unconditional potential"):
+        return build_from_potential(potential_fn, prior)
+
+
+@pytest.mark.mcmc
+def test_latest_sample_raises_before_any_sampling_run():
+    """`latest_sample` continues stored chains; without a run there are none."""
+    posterior = _gaussian_potential_posterior()
+
+    with pytest.raises(ValueError, match="no chain states"):
+        posterior.sample((1,), init_strategy="latest_sample", show_progress_bars=False)
+
+
+@pytest.mark.mcmc
+def test_latest_sample_raises_when_more_chains_than_stored():
+    """The last run stored one state per chain; a bigger run must not start."""
+    posterior = _gaussian_potential_posterior()
+    posterior.sample((10,), num_chains=2, show_progress_bars=False)
+
+    with pytest.raises(ValueError, match="chain state"):
+        posterior.sample(
+            (10,),
+            num_chains=5,
+            init_strategy="latest_sample",
+            show_progress_bars=False,
+        )
+
+    # The happy path: the same chain count continues the stored chains.
+    posterior.sample(
+        (10,), num_chains=2, init_strategy="latest_sample", show_progress_bars=False
+    )
+
+
 @pytest.mark.mcmc
 def test_direct_mcmc_unconditional():
     "Test MCMCPosterior from user defined potential (unconditional)"

--- a/tests/misspecification_test.py
+++ b/tests/misspecification_test.py
@@ -226,3 +226,11 @@ def test_marginal_log_prob_x_space(D: int, N: int):
     assert p_val_mis < 0.05, (
         f"Expected small p_val for misspecified data, obtained {p_val_mis}"
     )
+
+
+def test_mmd_embedding_mode_requires_trained_inference():
+    """An untrained trainer must raise a `ValueError`, not crash."""
+    x = torch.randn(10, 2)
+
+    with pytest.raises(ValueError, match="No neural net found"):
+        calc_misspecification_mmd(x_obs=x[:1], x=x, inference=NPE(), mode="embedding")

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -291,6 +291,31 @@ def test_process_device_rejects_unknown_device() -> None:
         torchutils.process_device("not-a-device")
 
 
+def test_box_uniform_never_inherits_the_global_validation_default() -> None:
+    """MCMC evaluates out-of-support thetas and needs `-inf` rather than a raise.
+
+    `BoxUniform` must therefore not pick up torch's global default, neither at
+    construction nor when `to()` rebuilds it.
+    """
+    default = distributions.Distribution._validate_args
+    try:
+        distributions.Distribution._validate_args = True
+        prior = torchutils.BoxUniform(-ones(2), ones(2))
+        outside = torch.tensor([5.0, 5.0])
+
+        assert prior.log_prob(outside).isinf()
+        prior.to("cpu")
+        assert prior.log_prob(outside).isinf()
+
+        # `to()` rebuilds both layers and must carry the per-instance setting.
+        torchutils.set_validate_args(prior, True)
+        prior.to("cpu")
+        assert prior._validate_args, "to() dropped the setting on the wrapper"
+        assert prior.base_dist._validate_args, "to() dropped the setting on the member"
+    finally:
+        distributions.Distribution._validate_args = default
+
+
 @pytest.mark.parametrize(
     "device_input, expected",
     (

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -108,6 +108,11 @@ torch.set_default_dtype(torch.float32)
             Exponential(torch.tensor([3.0])),
             dict(),
         ),
+        (
+            OneDimPriorWrapper,
+            Exponential(torch.tensor([3.0])),
+            dict(validate_args=True),
+        ),
     ),
 )
 def test_prior_wrappers(wrapper, prior, kwargs):
@@ -137,13 +142,57 @@ def test_prior_wrappers(wrapper, prior, kwargs):
     assert len(prior.log_prob(prior.sample((10,))).shape) == 1
 
 
+def test_multiple_independent_sets_validation_per_instance():
+    """`validate_args` must configure the members, not torch's global default."""
+    default = torch.distributions.Distribution._validate_args
+    prior = MultipleIndependent(
+        [Gamma(ones(1), ones(1)), BoxUniform(zeros(1), ones(1))],
+        validate_args=True,
+    )
+
+    assert torch.distributions.Distribution._validate_args is default
+    assert prior._validate_args
+    assert all(d._validate_args for d in prior.dists)
+    assert prior.dists[1].base_dist._validate_args
+
+
+@pytest.mark.parametrize(
+    "build",
+    (
+        lambda: MultipleIndependent(
+            [Gamma(ones(1), ones(1)), Beta(2 * ones(1), 2 * ones(1))],
+            validate_args=False,
+        ),
+        lambda: OneDimPriorWrapper(Exponential(3 * ones(1)), validate_args=False),
+    ),
+    ids=("MultipleIndependent", "OneDimPriorWrapper"),
+)
+def test_validate_args_false_survives_a_polluted_global(build):
+    """MCMC evaluates out-of-support and NaN values and needs `log_prob` not to raise.
+
+    These wrappers delegate `log_prob`, so the members must carry the setting too.
+    """
+    default = torch.distributions.Distribution._validate_args
+    try:
+        torch.distributions.Distribution._validate_args = True
+        prior = build()
+        bad = torch.full((1, prior.sample().numel()), float("nan"))
+
+        assert prior.log_prob(bad).isnan().all()
+        # Turning the global off would silence the raise too, so pin it untouched.
+        assert torch.distributions.Distribution._validate_args
+    finally:
+        torch.distributions.Distribution._validate_args = default
+
+
 def test_one_dim_wrapper_constructs_with_validation_on():
-    """With validation on (as here, or via torch's global default, which
-    `MultipleIndependent(validate_args=True)` flips), torch reads `arg_constraints`
-    during `__init__`, which used to dereference `self.prior` before it was set.
+    """The wrapper must construct and honour `validate_args=True`.
+
+    Torch reads `arg_constraints` during `__init__`, which dereferences `self.prior`.
     """
     prior = OneDimPriorWrapper(Exponential(torch.tensor([3.0])), validate_args=True)
 
+    assert prior._validate_args
     assert prior.log_prob(prior.sample((3,))).shape == (3,)
 
 

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -929,3 +929,17 @@ def test_vi_posterior_stores_resolved_device():
 
     posterior.to("cpu:0")
     assert posterior._device == "cpu"
+
+
+def test_learnable_gaussian_ignores_the_upper_triangle_of_scale_tril():
+    """`scale_tril` is optimized unconstrained, so it drifts off the identity.
+
+    `rsample` then used the full matrix while `log_prob` ignored the upper triangle,
+    which biased the ELBO by the difference.
+    """
+    q = LearnableGaussian(dim=3, full_covariance=True)
+    with torch.no_grad():
+        q.scale_tril.add_(0.5)
+
+    scale_tril = q._base_dist().scale_tril
+    assert torch.equal(scale_tril, scale_tril.tril())


### PR DESCRIPTION
Follow-up on #1962, more bug fixes. 

The 0.27 deprecation audit (#1960) found four bugs of one shape: a condition that can
never be true, which silently disables behaviour. A sweep over the package found the
remaining instances. Every finding was verified by execution before the fix.

### Custom prior `torch` argument validation is now set per instance, not for the whole process

**Before.** Torch distributions check their arguments and their samples. sbi must turn
this off for priors, because MCMC evaluates `prior.log_prob` outside the support and at
NaN, and needs `-inf` or NaN back instead of an exception. sbi turned it off with
`prior.set_default_validate_args(False)`. That method is a static method. A call through
an instance changes the default for **every** distribution built afterwards in the same
process. sbi did this in three places.

Two problems followed. Validation depended on what ran before, so test results changed
with the test order. And a prior that sbi did not touch could still lose its validation,
or keep it, by accident.

Three more bugs sat on top of this:

- `BoxUniform.to()` rebuilds its members. It read the process-wide default instead of the
  setting of the instance, so moving a prior to a device dropped that setting.
- `MultipleIndependent(validate_args=...)` set the global default from an instance
  constructor.
- `OneDimPriorWrapper(validate_args=True)` never worked. The wrapper delegates
  `log_prob`, so it holds no parameters of its own. Torch pairs each name in
  `arg_constraints` with an attribute of the same name, and the wrapper passed on the
  constraints of the wrapped distribution. Torch then looked for that distribution's
  parameters on the wrapper and raised `AttributeError`.

**Now.** A new helper `sbi.utils.torchutils.set_validate_args(dist, value)` sets the flag
on one instance. It also walks into the distributions inside it, because the wrapper
priors delegate `log_prob` and the members must carry the setting. Nothing in sbi changes
the global default. `BoxUniform.to()` carries the setting across the rebuild. The
delegating wrappers declare no parameters of their own. An autouse fixture in
`tests/conftest.py` fails any test that changes the global default.

Note: `import zuko` still sets the global default to `False` at module level, upstream.
sbi no longer adds its own changes.

### The "network has not yet fully converged" warning now works

**Before.** The training loop exits with `epoch == max_num_epochs + 1`. The warning
compared `max_num_epochs == epoch`, so it could never fire. Anyone who used up their epoch
budget got no output.

Two further faults would have made the warning unreliable even after that comparison was
corrected:

- The report called `_converged()` a second time to decide what to print. That call is
  not a question. It advances the counter it reads, and can reload the weights. A run
  that used up its epochs with the counter one step below the limit was reported as
  "successfully converged".
- The warning used `stacklevel=2`, which names `trainers/base.py`. Python shows a warning
  one time for each location. Every training run in a process shared that one location,
  so only the first run could warn.

**Now.** The warning fires when `epoch > max_num_epochs`. The report reads the epoch count
and does not call `_converged()` again. The stacklevel is computed, so the warning names
the user's `train()` call, and each call site warns.

A run that uses up its epoch budget also keeps the best weights it saw. It kept the
weights of its last epoch before, which are by definition not the best ones. The
converged path already did this from inside the loop; the two exit paths now agree.

The marginal trainer keeps its own copy of the training loop, with the same two exit
paths and no report at all. It gets the same treatment: the final epoch is scored, the
best weights are kept, and an exhausted budget warns.

Keeping the best weights surfaced a latent NPE-A failure. Its multi-round correction
subtracts the proposal's precision from the density estimator's, and only a Gaussian
prior's precision term keeps that difference positive definite. The device test used a
uniform prior and a tight epoch budget, and passed because the clipped rounds kept
undertrained, wide, last-epoch weights. With the best weights restored, it lands on the
documented "precision matrix is not positive definite" error — as it already does on
main for other seeds, on CPU, and whenever training converges. The test now uses a
Gaussian prior; the fragility itself is pre-existing and is tracked for 1.0.

Note: quick training runs with a small `max_num_epochs` now warn, including in tutorials
and tests. That is the warning doing its job.

### Other bug fixes

- **The vector-field trainers never reset their convergence tracking.** The reset sat
  behind `if not hasattr(self, '_best_val_loss')`, which is always false because the base
  class sets the attribute. A second `train()` call inherited the first run's best loss,
  could "converge" immediately, and silently restored the first run's weights. The
  tracking now resets at epoch 0. `_best_model_state_dict` is initialised in
  `NeuralInference.__init__`, which also removes a latent `AttributeError` for NaN
  validation losses.
- **`self.val_loss` was a write-only typo.** Every reader uses `self._val_loss`, so the
  per-run reset did nothing.
- **`calc_misspecification_mmd` crashed instead of raising its own error.** The guard
  tested `hasattr(inference, "_neural_net")`, which is always true. The attribute is
  `None` before training, so untrained trainers got an opaque `AttributeError`.
- **The LRU embedding rejected `state_dim=-5` by validating `input_dim`.** A copy-paste in
  the check. Two of its messages used an invalid f-string format spec
  (`{r_max: float = }`) and raised "Invalid format specifier" instead of the intended
  text. `forward()`'s `match mode` had no default case, so a bad `mode` gave
  `UnboundLocalError`.
- **`LearnableGaussian` used two different covariances.** `scale_tril` is optimized
  without a constraint, so its upper triangle drifts away from zero. `log_prob` ignores
  that triangle, but `rsample` used it, which biased the ELBO. The parameter is now read
  as lower-triangular. Its parameters are still unconstrained, so `_base_dist` builds with
  `validate_args=False`: a user who turns validation on gets NaN log-probs, not an
  exception in the middle of training.
- **No score estimator could load its own `state_dict`.**
  `ConditionalVectorFieldEstimator` registers `_mean_base` and `_std_base` as buffers
  and allocates them contiguously. The score estimators then overwrote them with the
  result of `torch.broadcast_to`, which is a stride-0 view over a single element.
  `nn.Module` replaces the buffer silently, and `load_state_dict` cannot copy into a
  view whose elements share memory. `_converged` restores the best weights with
  `load_state_dict`, so every NPSE run that converged raised `RuntimeError`. The fast
  tests missed it because they use small epoch budgets and rarely converge. The buffers
  are now materialised.
- **The `MultipleIndependent` docstring showed an invalid prior.** The example used
  `Gamma(zeros(1), ones(1))` and `Beta(zeros(1), ones(1))`. Both break
  `concentration > 0`. They only build because validation is off. The prior samples
  1e-38 and returns `-inf` everywhere, so inference gives nothing.

### Messages fixed

- Three SMCABC logger calls wrapped their arguments in an extra tuple, so the log showed
  the tuple repr with unsubstituted placeholders. One also mixed a `{epsilon:.6f}`
  placeholder into a %-style message.
- Six exceptions had a stray comma between concatenated fragments and rendered as tuple
  reprs (`plot.py` ×2, `trainers/base.py` ×3, `SC_embedding.py`).
- Three missing `f` prefixes (`plot.py`, `smcabc.py`, `lru.py`) printed literal
  `{placeholders}`.
- `_check_proposal` raised a message that contradicted its own condition. It fires when no
  proposal was passed after multi-round training, but claimed "A proposal was passed",
  blamed the prior, and its suggested fix re-raised the same error. It now says what
  happened and what to do.
- Nine runtime messages still used pre-rename names: "SNLE cannot handle…",
  "multi-round SNPE", `SNPE_A`, `SNPE-A`, and the factory's `SNPE_A(...)` constructor
  hint. Docstring prose that names the published algorithms is unchanged.

### Dead code removed

- Two `hasattr(self, 'HYPER_PARAMETERS')` guards in the VI optimizers. The base class
  always sets it before the subclass line runs, and the sibling subclasses already do a
  bare `+=`.
- `BoxUniform` in two `isinstance` arms of `vector_field_utils`. It subclasses
  `Independent` and always matches the first arm, so the entry was misleading. Their type
  hints named it too, and no longer do.
- `tensorboard_output` raised `ValueError(f"trainer {trainer}")`. It now says what was
  expected.
- Two guards in `NPE_C._log_prob_proposal_posterior`. The first tested for a
  `MixtureDensityEstimator` inside a branch that `_multiround_loss_is_per_row` only
  enters when the estimator is one. The second tested for a `log_prob` method that the
  estimator contract requires. Neither can fire, and `pyright` does not need either.

### `init_strategy='latest_sample'` said nothing useful when it could not run

It continues the chains of an earlier `sample()` call, and reads `_mcmc_init_params`
for their last state. That attribute was written only by a sampling run, so:

- On a posterior that had not sampled, it raised
  `AttributeError: 'MCMCPosterior' object has no attribute '_mcmc_init_params'`.
- With more chains than the last run used, the iterator ran dry and raised a bare
  `StopIteration`.

The attribute is now initialised to `None`, and both cases raise a `ValueError` that
says what happened and what to do instead. Both checks read the attribute with
`getattr`, because posteriors unpickled from older sbi versions lack it entirely.

### Deliberately not touched

- "SNPE-A", "SNRE" etc. in docstring prose that names the published algorithms.

### Tests

Behaviour pins: a run that uses up its epoch budget returns its best weights (in the
shared training loop and in the marginal trainer's own copy), the vector-field tracking
resets between runs, the two `latest_sample` errors fire before sampling starts, the
misspecification guard raises its `ValueError`, the LRU validation rejects a bad
`state_dim`, `OneDimPriorWrapper` constructs with `validate_args=True`, and
`MultipleIndependent(validate_args=True)` configures the instance without touching the
global.

Three of those pins passed both with and without their fix, because the old code reached
the same `log_prob` result by turning the global default off. They now assert the setting
itself, so they fail without the fix.

No new tests for the message changes. The epoch-count guard is structural:
`_report_convergence_at_end` no longer takes `stop_after_epochs`, so the removed
`_converged()` call cannot come back by accident.

### For the 0.27.0 release notes

- Training runs that use up `max_num_epochs` now warn. They were silent before. This
  covers all trainers, including the marginal trainer.
- Training runs that use up `max_num_epochs` now return the weights of their best
  validation epoch. They returned the weights of their last epoch before. Results of runs
  that were limited by `max_num_epochs` can change.
- `LearnableGaussian` checkpoints from v0.26.x: if `scale_tril` has a non-zero upper
  triangle, `rsample` now draws from `tril(L) @ tril(L).T` instead of `L @ L.T`.
  `log_prob` is unchanged, because it never read the upper triangle.
- sbi no longer changes torch's global argument-validation default. Code that relied on
  that side effect must now call `sbi.utils.torchutils.set_validate_args` on its own
  distributions.
- `init_strategy='latest_sample'` now raises a `ValueError` when it cannot run. It raised
  `AttributeError` or `StopIteration` before.
- Multi-round NPE-A with a uniform prior and a tight epoch budget can now raise the
  documented "precision matrix is not positive definite" error where it previously ran
  on undertrained last-epoch weights. The correction needs a Gaussian prior to be
  reliably positive definite; this fragility predates this release and is tracked for
  1.0.

Claude Code found these with an AST sweep and helped with the fixes.

