### PR TITLE
removing .to for potential

### DIFF
--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -454,23 +454,6 @@ class EnsemblePotential(BasePotential):
         self.potential_fns = potential_fns
         super().__init__(prior, x_o, device)
 
-    def to(self, device: Union[str, torch.device]) -> None:
-        """
-        Moves the ensemble potentials, the prior, the weights and x_o to
-
-        the specified device.
-
-        Args:
-            device: The device to move the ensemble potential to.
-        """
-        self.device = device
-        for i in range(len(self.potential_fns)):
-            self.potential_fns[i].to(device)
-        self._weights = self._weights.to(device)
-        self.prior.to(device)  # type: ignore
-        if self._x_o is not None:
-            self._x_o = self._x_o.to(device)
-
     def allow_iid_x(self) -> bool:
         # in case there is different kinds of posteriors, this will produce an error
         # in `set_x()`

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -13,6 +13,10 @@ from sbi.samplers.importance.sir import sampling_importance_resampling
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils.sbiutils import mcmc_transform
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks_utils import (
+    move_distribution_to_device,
+    potential_on_device,
+)
 
 
 class ImportanceSamplingPosterior(NeuralPosterior):
@@ -88,13 +92,15 @@ class ImportanceSamplingPosterior(NeuralPosterior):
             device: Device on which to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
-        self.proposal.to(device)
+        self.proposal = move_distribution_to_device(self.proposal, device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):
             x_o = self._x.to(device)
 
         self.theta_transform = mcmc_transform(self.proposal, device=device)
+
+        self.potential_fn = potential_on_device(self.potential_fn, device)
+
         super().__init__(
             self.potential_fn,
             theta_transform=self.theta_transform,

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -30,6 +30,10 @@ from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
 from sbi.utils.torchutils import ensure_theta_batched, tensor2numpy
+from sbi.utils.user_input_checks_utils import (
+    move_distribution_to_device,
+    potential_on_device,
+)
 
 
 class MCMCPosterior(NeuralPosterior):
@@ -168,13 +172,14 @@ class MCMCPosterior(NeuralPosterior):
             device: Device to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
-        self.proposal.to(device)
+        self.proposal = move_distribution_to_device(self.proposal, device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):
             x_o = self._x.to(device)
 
         self.theta_transform = mcmc_transform(self.proposal, device=device)
+
+        self.potential_fn = potential_on_device(self.potential_fn, device)
 
         super().__init__(
             self.potential_fn,

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -14,6 +14,10 @@ from sbi.samplers.rejection.rejection import rejection_sample
 from sbi.sbi_types import Shape, TorchTransform
 from sbi.utils import mcmc_transform
 from sbi.utils.torchutils import ensure_theta_batched
+from sbi.utils.user_input_checks_utils import (
+    move_distribution_to_device,
+    potential_on_device,
+)
 
 
 class RejectionPosterior(NeuralPosterior):
@@ -82,13 +86,15 @@ class RejectionPosterior(NeuralPosterior):
             device: The device to move the posterior to.
         """
         self.device = device
-        self.potential_fn.to(device)  # type: ignore
-        self.proposal.to(device)
+        self.proposal = move_distribution_to_device(self.proposal, device)
         x_o = None
         if hasattr(self, "_x") and (self._x is not None):
             x_o = self._x.to(device)
 
         self.theta_transform = mcmc_transform(self.proposal, device=device)
+
+        self.potential_fn = potential_on_device(self.potential_fn, device)
+
         super().__init__(
             self.potential_fn,
             theta_transform=self.theta_transform,

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -43,7 +43,10 @@ from sbi.sbi_types import (
 )
 from sbi.utils.sbiutils import mcmc_transform
 from sbi.utils.torchutils import atleast_2d_float32_tensor, ensure_theta_batched
-from sbi.utils.user_input_checks_utils import move_distribution_to_device
+from sbi.utils.user_input_checks_utils import (
+    move_distribution_to_device,
+    potential_on_device,
+)
 
 # Supported Zuko flow types for VI (lowercase names)
 _ZUKO_FLOW_TYPES = {"maf", "nsf", "naf", "unaf", "nice", "sospf", "gf"}
@@ -155,8 +158,6 @@ class VIPosterior(NeuralPosterior):
         self._device = device
         self.theta_transform = theta_transform
         self.x_shape = x_shape
-        self.potential_fn.device = device
-        self.potential_fn.to(device)
 
         # Get prior and previous builds
         if prior is not None:
@@ -223,11 +224,10 @@ class VIPosterior(NeuralPosterior):
         """
         self._device = device
 
-        # Move potential (which moves prior, x_o, and estimator).
-        self.potential_fn.to(device)  # type: ignore
         self._prior = move_distribution_to_device(self._prior, device)
 
-        # Rebuild link_transform on new device (same logic as __init__).
+        self.potential_fn = potential_on_device(self.potential_fn, device)
+
         if self.theta_transform is None:
             self.link_transform = mcmc_transform(self._prior, device=device).inv
         else:

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -1113,7 +1113,7 @@ class VIPosterior(NeuralPosterior):
             )
 
         # Ensure potential_fn is on the correct device for amortized training
-        self.potential_fn.to(self._device)
+        self.potential_fn = potential_on_device(self.potential_fn, self._device)
 
         # Setup optimizer
         optimizer = Adam(self._amortized_q.parameters(), lr=learning_rate)

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Protocol, Union
 
@@ -59,8 +60,6 @@ class BasePotential(metaclass=ABCMeta):
 
         DEPRECATED: Use bind() instead. This method delegates to bind() internally.
         """
-        import warnings
-
         warnings.warn(
             "set_x() is deprecated, use bind() instead",
             FutureWarning,
@@ -115,8 +114,6 @@ class BasePotential(metaclass=ABCMeta):
         Returns:
             Self for method chaining.
         """
-        import warnings
-
         warnings.warn(
             "Calling .to() on a potential is deprecated and will be removed. "
             "Move estimator, prior, and x to the device first, then build the "

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -9,7 +9,6 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 from sbi.utils.user_input_checks import process_x
-from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 
 class BasePotential(metaclass=ABCMeta):
@@ -104,22 +103,27 @@ class BasePotential(metaclass=ABCMeta):
         return self._x_o
 
     def to(self, device: Union[str, torch.device]) -> "BasePotential":
-        """Move prior and x_o to the given device.
+        """Deprecated: Do not call .to() on potentials.
 
-        It also sets the device attribute to the given device.
+        Potentials are immutable after creation. To move to a different device:
+        - Option 1: Move estimator, prior, and x first, then build potential
+        - Option 2: Use posterior.to(device) which handles this internally
 
         Args:
-            device: Device to move the prior and x_o to.
+            device: Device (unused, kept for API compatibility).
 
         Returns:
             Self for method chaining.
         """
+        import warnings
 
-        self.device = device
-        if self.prior is not None:
-            self.prior = move_distribution_to_device(self.prior, device)
-        if self._x_o is not None:
-            self._x_o = self._x_o.to(device)
+        warnings.warn(
+            "Calling .to() on a potential is deprecated and will be removed. "
+            "Move estimator, prior, and x to the device first, then build the "
+            "potential, or use posterior.to(device) which handles this internally.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self
 
 
@@ -155,18 +159,6 @@ class CustomPotentialWrapper(BasePotential):
         super().__init__(prior, x_o, device)
 
         self.potential_fn = potential_fn
-
-    def to(self, device: Union[str, torch.device]) -> "CustomPotentialWrapper":
-        """Move prior and x_o to the given device.
-
-        Args:
-            device: Device to move the prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        return self
 
     def __call__(self, theta, track_gradients: bool = True):
         """Calls the custom potential function on given theta.

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -2,7 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import warnings
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -81,19 +81,6 @@ class LikelihoodBasedPotential(BasePotential):
         super().__init__(prior, x_o, device)
         self.likelihood_estimator = likelihood_estimator
         self.likelihood_estimator.eval()
-
-    def to(self, device: Union[str, torch.device]) -> "LikelihoodBasedPotential":
-        """Move likelihood estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the likelihood_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.likelihood_estimator.to(device)
-        return self
 
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "LikelihoodBasedPotential":
         """Create new potential with x bound, without mutable state."""

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -88,19 +88,6 @@ class PosteriorBasedPotential(BasePotential):
         self.posterior_estimator = posterior_estimator
         self.posterior_estimator.eval()
 
-    def to(self, device: Union[str, torch.device]) -> "PosteriorBasedPotential":
-        """Move posterior estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the posterior_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.posterior_estimator.to(device)
-        return self
-
     def bind(self, x_o: Tensor, x_is_iid: bool = False) -> "PosteriorBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = PosteriorBasedPotential(

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -70,19 +70,6 @@ class RatioBasedPotential(BasePotential):
         self.ratio_estimator = ratio_estimator
         self.ratio_estimator.eval()
 
-    def to(self, device: Union[str, torch.device]) -> "RatioBasedPotential":
-        """Move ratio estimator, prior and x_o to the given device.
-
-        Args:
-            device: Device to move the ratio_estimator, prior and x_o to.
-
-        Returns:
-            Self for method chaining.
-        """
-        super().to(device)
-        self.ratio_estimator.to(device)
-        return self
-
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "RatioBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = RatioBasedPotential(

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -82,23 +82,6 @@ class VectorFieldBasedPotential(BasePotential):
 
         super().__init__(prior, x_o, device=device)
 
-    def to(self, device: Union[str, torch.device]) -> None:
-        """
-        Moves score_estimator, prior and x_o to the given device.
-
-        It also sets the device attribute to the given device.
-
-        Args:
-            device: Device to move the score_estimator, prior and x_o to.
-        """
-
-        self.device = device
-        self.vector_field_estimator.to(device)
-        if self.prior:
-            self.prior.to(device)  # type: ignore
-        if self._x_o is not None:
-            self._x_o = self._x_o.to(device)
-
     def set_x(
         self,
         x_o: Optional[Tensor],

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -72,13 +72,16 @@ def move_distribution_to_device(
 def potential_on_device(potential, device: Union[str, torch.device]):
     """Create a new potential on the specified device.
 
-    This utility creates a new potential with the neural estimator moved to a new
-    device. It does NOT mutate the original potential.
+    This utility creates a new potential configured for the target device.
+
+    Note: moving the underlying estimator/prior may mutate those objects in-place
+    if they are shared with other potentials/posteriors. After calling this function,
+    the original estimator and prior should not be used with a different device.
 
     The function:
     1. Finds the estimator attribute (likelihood_estimator, ratio_estimator,
        posterior_estimator, or vector_field_estimator)
-    2. Moves it to the device
+    2. Moves it to the device (mutates in-place)
     3. Creates a NEW potential with the moved estimator
 
     Args:
@@ -88,6 +91,9 @@ def potential_on_device(potential, device: Union[str, torch.device]):
     Returns:
         A new potential instance with the estimator on the target device.
     """
+    from sbi.inference.potentials.base_potential import (
+        CustomPotentialWrapper,
+    )
     from sbi.inference.potentials.likelihood_based_potential import (
         LikelihoodBasedPotential,
     )
@@ -101,6 +107,26 @@ def potential_on_device(potential, device: Union[str, torch.device]):
         VectorFieldBasedPotential,
     )
 
+    # Handle CustomPotentialWrapper separately - it has no estimator
+    if isinstance(potential, CustomPotentialWrapper):
+        prior = (
+            move_distribution_to_device(potential.prior, device)
+            if hasattr(potential, "prior") and potential.prior
+            else None
+        )
+        x_o = potential._x_o.to(device) if potential._x_o is not None else None
+        x_is_iid = getattr(potential, "_x_is_iid", True)
+
+        new_potential = CustomPotentialWrapper(
+            potential_fn=potential.potential_fn,
+            prior=prior,
+            x_o=x_o,
+            device=device,
+        )
+        if x_o is not None:
+            new_potential.bind(x_o, x_is_iid=x_is_iid)
+        return new_potential
+
     for attr_name in (
         "likelihood_estimator",
         "ratio_estimator",
@@ -113,14 +139,11 @@ def potential_on_device(potential, device: Union[str, torch.device]):
                 moved_estimator = estimator.to(device)
                 break
     else:
-        warnings.warn(
+        raise ValueError(
             "Could not find an estimator in the potential to move. "
             "The potential may not work correctly on the new device. "
-            "Consider moving the estimator before building the potential.",
-            UserWarning,
-            stacklevel=2,
+            "Consider moving the estimator before building the potential."
         )
-        return potential
 
     prior = (
         move_distribution_to_device(potential.prior, device)
@@ -128,15 +151,20 @@ def potential_on_device(potential, device: Union[str, torch.device]):
         else None
     )
     x_o = potential._x_o
+    x_is_iid = getattr(potential, "_x_is_iid", True)
 
     if isinstance(potential, LikelihoodBasedPotential):
-        return LikelihoodBasedPotential(moved_estimator, prior, x_o, device=device)
+        new_potential = LikelihoodBasedPotential(
+            moved_estimator, prior, x_o, device=device
+        )
     elif isinstance(potential, PosteriorBasedPotential):
-        return PosteriorBasedPotential(moved_estimator, prior, x_o, device=device)
+        new_potential = PosteriorBasedPotential(
+            moved_estimator, prior, x_o, device=device
+        )
     elif isinstance(potential, RatioBasedPotential):
-        return RatioBasedPotential(moved_estimator, prior, x_o, device=device)
+        new_potential = RatioBasedPotential(moved_estimator, prior, x_o, device=device)
     elif isinstance(potential, VectorFieldBasedPotential):
-        return VectorFieldBasedPotential(
+        new_potential = VectorFieldBasedPotential(
             moved_estimator,
             prior,
             x_o,
@@ -147,6 +175,11 @@ def potential_on_device(potential, device: Union[str, torch.device]):
         )
     else:
         return potential
+
+    if x_o is not None:
+        new_potential.bind(x_o, x_is_iid=x_is_iid)
+
+    return new_potential
 
 
 class CustomPriorWrapper(Distribution):

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -69,6 +69,86 @@ def move_distribution_to_device(
             return dist
 
 
+def potential_on_device(potential, device: Union[str, torch.device]):
+    """Create a new potential on the specified device.
+
+    This utility creates a new potential with the neural estimator moved to a new
+    device. It does NOT mutate the original potential.
+
+    The function:
+    1. Finds the estimator attribute (likelihood_estimator, ratio_estimator,
+       posterior_estimator, or vector_field_estimator)
+    2. Moves it to the device
+    3. Creates a NEW potential with the moved estimator
+
+    Args:
+        potential: The potential to create a new copy of on the target device.
+        device: The target device.
+
+    Returns:
+        A new potential instance with the estimator on the target device.
+    """
+    from sbi.inference.potentials.likelihood_based_potential import (
+        LikelihoodBasedPotential,
+    )
+    from sbi.inference.potentials.posterior_based_potential import (
+        PosteriorBasedPotential,
+    )
+    from sbi.inference.potentials.ratio_based_potential import (
+        RatioBasedPotential,
+    )
+    from sbi.inference.potentials.vector_field_potential import (
+        VectorFieldBasedPotential,
+    )
+
+    for attr_name in (
+        "likelihood_estimator",
+        "ratio_estimator",
+        "posterior_estimator",
+        "vector_field_estimator",
+    ):
+        if hasattr(potential, attr_name):
+            estimator = getattr(potential, attr_name)
+            if hasattr(estimator, "to"):
+                moved_estimator = estimator.to(device)
+                break
+    else:
+        warnings.warn(
+            "Could not find an estimator in the potential to move. "
+            "The potential may not work correctly on the new device. "
+            "Consider moving the estimator before building the potential.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return potential
+
+    prior = (
+        move_distribution_to_device(potential.prior, device)
+        if hasattr(potential, "prior") and potential.prior
+        else None
+    )
+    x_o = potential._x_o
+
+    if isinstance(potential, LikelihoodBasedPotential):
+        return LikelihoodBasedPotential(moved_estimator, prior, x_o, device=device)
+    elif isinstance(potential, PosteriorBasedPotential):
+        return PosteriorBasedPotential(moved_estimator, prior, x_o, device=device)
+    elif isinstance(potential, RatioBasedPotential):
+        return RatioBasedPotential(moved_estimator, prior, x_o, device=device)
+    elif isinstance(potential, VectorFieldBasedPotential):
+        return VectorFieldBasedPotential(
+            moved_estimator,
+            prior,
+            x_o,
+            device=device,
+            iid_method=potential.iid_method,
+            iid_params=potential.iid_params,
+            neural_ode_backend=potential.neural_ode_backend,
+        )
+    else:
+        return potential
+
+
 class CustomPriorWrapper(Distribution):
     def __init__(
         self,

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -92,6 +92,7 @@ def potential_on_device(potential, device: Union[str, torch.device]):
         A new potential instance with the estimator on the target device.
     """
     from sbi.inference.potentials.base_potential import (
+        BasePotential,
         CustomPotentialWrapper,
     )
     from sbi.inference.potentials.likelihood_based_potential import (
@@ -127,6 +128,16 @@ def potential_on_device(potential, device: Union[str, torch.device]):
             new_potential.bind(x_o, x_is_iid=x_is_iid)
         return new_potential
 
+    # Check if it's a known estimator-based potential type
+    estimator_based_types = (
+        LikelihoodBasedPotential,
+        PosteriorBasedPotential,
+        RatioBasedPotential,
+        VectorFieldBasedPotential,
+    )
+    is_estimator_based = isinstance(potential, estimator_based_types)
+
+    # Look for estimator in potential
     for attr_name in (
         "likelihood_estimator",
         "ratio_estimator",
@@ -139,11 +150,36 @@ def potential_on_device(potential, device: Union[str, torch.device]):
                 moved_estimator = estimator.to(device)
                 break
     else:
-        raise ValueError(
-            "Could not find an estimator in the potential to move. "
-            "The potential may not work correctly on the new device. "
-            "Consider moving the estimator before building the potential."
-        )
+        # No estimator found
+        if is_estimator_based:
+            raise ValueError(
+                "Could not find an estimator in the potential to move. "
+                "The potential may not work correctly on the new device. "
+                "Consider moving the estimator before building the potential."
+            )
+        # For other BasePotential subclasses (e.g., custom potentials like
+        # FakePotential), just move prior and x_o
+        if isinstance(potential, BasePotential):
+            prior = (
+                move_distribution_to_device(potential.prior, device)
+                if hasattr(potential, "prior") and potential.prior
+                else None
+            )
+            x_o = potential._x_o.to(device) if potential._x_o is not None else None
+            x_is_iid = getattr(potential, "_x_is_iid", True)
+
+            # Create new instance of the same type
+            new_potential = type(potential)(
+                prior=prior,
+                x_o=x_o,
+                device=device,
+            )
+            if x_o is not None:
+                new_potential.bind(x_o, x_is_iid=x_is_iid)
+            return new_potential
+
+        # Not a known potential type, return as-is
+        return potential
 
     prior = (
         move_distribution_to_device(potential.prior, device)


### PR DESCRIPTION
This is the second attempt to removing `to()` from the potential. First was [here](https://github.com/sbi-dev/sbi/pull/1949)

Potentials are now immutable after creation, similar to how `.bind()` works.

## Two Usage Patterns

### Option 1: Move components first, then build potential

```python
# Move estimator, prior, and x to device first
estimator = estimator.to(device)
prior = prior.to(device)
x_o = x_o.to(device)

# Build potential from already-moved components
potential, transform = some_potential_builder(estimator, prior)
bound_potential = potential.bind(x_o)
```

### Option 2: Use posterior.to()

```python
# Build posterior first
posterior = inference.build_posterior()

# Posterior.to() handles moving estimator, prior, and x internally
posterior.to(device)
```

This is the recommended approach as it handles all components automatically.

## What Changed

- `.to()` on potentials now shows a `FutureWarning` and does nothing
- Posterior classes (DirectPosterior, MCMCPosterior, etc.) now rebuild their potential internally when `.to()` is called
