### PR TITLE
chore: point the feature form at the feature request label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement or a new feature for sbi
-labels: ["enhancement"]
+labels: ["feature request"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
Follow-up to the label cleanup.

We now separate two things that the single `enhancement` label mixed:

- `feature request` - asked for by a user, not yet planned by us.
- `enhancement` - an improvement that we plan or want ourselves.

The feature form is filled in by users, so it applies `feature request`. Nobody
has to decide this during triage, which is why the old `feature` / `enhancement`
split did not survive.

`bug_report.yml` needs no change, because the `bug` label keeps its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)