### PR TITLE
feat: derive x_o NaN-tolerance from the embedding net, guard batched paths

### DIFF
--- a/docs/advanced_tutorials/12_iid_data_and_permutation_invariant_embeddings.ipynb
+++ b/docs/advanced_tutorials/12_iid_data_and_permutation_invariant_embeddings.ipynb
@@ -337,6 +337,14 @@
     "\n",
     "In order to implement this in `sbi`, \"unobserved\" trials in the training dataset have to be masked by NaNs (and ignore the resulting SBI warning about NaNs in the training data).\n",
     "\n",
+    "`PermutationInvariantEmbedding` masks the NaN entries and declares this with the\n",
+    "class attribute `accepts_nan_input = True`. sbi derives its validation of `x_o`\n",
+    "from that marker, so a NaN-padded observation works with a plain\n",
+    "`build_posterior()` — no flag needed, for any sampler. If you write a custom\n",
+    "embedding net that consumes NaN by design, set the same attribute on your class.\n",
+    "The contract: the marked module must be the first to consume the raw `x`, and\n",
+    "only NaN is tolerated — `Inf` in `x_o` always raises.\n",
+    "\n",
     "### Construct training data set.\n"
    ]
   },

--- a/docs/how_to_guide/08_permutation_invariant_embeddings.ipynb
+++ b/docs/how_to_guide/08_permutation_invariant_embeddings.ipynb
@@ -61,7 +61,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have varying numbers of trials across multiple observations, pad the missing simulations with `NaN`."
+    "If you have varying numbers of trials across multiple observations, pad the missing simulations with `NaN`.\n",
+    "\n",
+    "`PermutationInvariantEmbedding` masks the NaN entries and declares this with the\n",
+    "class attribute `accepts_nan_input = True`. sbi derives its validation of `x_o`\n",
+    "from that marker, so a NaN-padded observation works with a plain\n",
+    "`build_posterior()` — no flag needed, for any sampler. If you write a custom\n",
+    "embedding net that consumes NaN by design, set the same attribute on your class.\n",
+    "The contract: the marked module must be the first to consume the raw `x`, and\n",
+    "only NaN is tolerated — `Inf` in `x_o` always raises.\n"
    ]
   },
   {

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -16,7 +16,12 @@ from sbi.inference.potentials.base_potential import (
 )
 from sbi.sbi_types import Array, Shape, TorchTransform
 from sbi.utils.sbiutils import gradient_ascent
-from sbi.utils.torchutils import assert_all_finite, ensure_theta_batched, process_device
+from sbi.utils.torchutils import (
+    assert_all_finite,
+    ensure_theta_batched,
+    net_accepts_nan_input,
+    process_device,
+)
 from sbi.utils.user_input_checks import process_x
 
 
@@ -35,7 +40,6 @@ class NeuralPosterior:
         theta_transform: Optional[TorchTransform] = None,
         device: Optional[Union[str, torch.device]] = None,
         x_shape: Optional[torch.Size] = None,
-        check_finite_x: bool = True,
     ):
         """
         Args:
@@ -46,9 +50,6 @@ class NeuralPosterior:
             device: Training device, e.g., "cpu", "cuda" or "cuda:0". If None,
                 `potential_fn.device` is used.
             x_shape: Deprecated, should not be passed.
-            check_finite_x: Whether to raise if the observed data `x_o` contains NaNs
-                or Infs. Set to False when the embedding net expects NaNs, e.g., when
-                `PermutationInvariantEmbedding` pads a varying number of trials.
         """
         if x_shape is not None:
             warn(
@@ -65,7 +66,6 @@ class NeuralPosterior:
             )
 
         self._device = process_device(potential_fn.device if device is None else device)
-        self._check_finite_x = check_finite_x
 
         self.potential_fn = potential_fn
 
@@ -83,9 +83,21 @@ class NeuralPosterior:
         # already to the potential function builder. If so, this `x_o` will be used
         # as default x.
         x_o = self.potential_fn.return_x_o()
-        if x_o is not None and self._check_finite_x:
-            assert_all_finite(x_o, "Observed data x_o")
+        if x_o is not None:
+            assert_all_finite(
+                x_o, "Observed data x_o", allow_nan=self._x_tolerates_nan()
+            )
         self._x = x_o
+
+    def _x_tolerates_nan(self) -> bool:
+        """Return whether NaN entries in `x_o` are consumed by the estimator.
+
+        Derived at check time from the net that embeds `x`: NaN padding is valid
+        only if that net declares `accepts_nan_input`, e.g.,
+        `PermutationInvariantEmbedding` for a varying number of trials. Inf is
+        never valid.
+        """
+        return net_accepts_nan_input(self.potential_fn.x_embedding_net)
 
     def potential(
         self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False
@@ -189,8 +201,7 @@ class NeuralPosterior:
             `NeuralPosterior` that will use a default `x` when not explicitly passed.
         """
         x = process_x(x, x_event_shape=None)
-        if self._check_finite_x:
-            assert_all_finite(x, "Observed data x_o")
+        assert_all_finite(x, "Observed data x_o", allow_nan=self._x_tolerates_nan())
 
         self._x = x.to(self._device)
         self._map = None
@@ -201,8 +212,7 @@ class NeuralPosterior:
             # New x, reset posterior sampler.
             self._posterior_sampler = None
             x = process_x(x, x_event_shape=None)
-            if self._check_finite_x:
-                assert_all_finite(x, "Observed data x_o")
+            assert_all_finite(x, "Observed data x_o", allow_nan=self._x_tolerates_nan())
 
             return x
         elif self.default_x is None:
@@ -346,6 +356,4 @@ class NeuralPosterior:
         Args:
             state_dict: State to be restored.
         """
-        # Posteriors pickled before `check_finite_x` was introduced carry no such key.
-        state_dict.setdefault("_check_finite_x", True)
         self.__dict__ = state_dict

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -90,21 +90,13 @@ class NeuralPosterior:
         self._x = x_o
 
     def _x_tolerates_nan(self) -> bool:
-        """Return whether NaN entries in `x_o` are consumed by the estimator.
-
-        Derived at check time from the net that embeds `x`: NaN padding is valid
-        only if that net declares `accepts_nan_input`, e.g.,
-        `PermutationInvariantEmbedding` for a varying number of trials. Inf is
-        never valid.
-        """
+        """Return whether NaN in `x_o` is consumed by design, derived at check
+        time from the net that embeds `x` (e.g., a NaN-padding-aware
+        `PermutationInvariantEmbedding`)."""
         return net_accepts_nan_input(self.potential_fn.x_embedding_net)
 
     def _assert_finite_x(self, x: Tensor) -> None:
-        """Raise if `x` contains NaN (unless tolerated, see above) or Inf.
-
-        The batched entry points bypass `process_x` and `_x_else_default_x`, so
-        they call this guard directly.
-        """
+        """Raise if `x` contains Inf, or NaN unless the estimator tolerates it."""
         assert_all_finite(
             torch.as_tensor(x), "Observed data x_o", allow_nan=self._x_tolerates_nan()
         )

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -99,6 +99,16 @@ class NeuralPosterior:
         """
         return net_accepts_nan_input(self.potential_fn.x_embedding_net)
 
+    def _assert_finite_x(self, x: Tensor) -> None:
+        """Raise if `x` contains NaN (unless tolerated, see above) or Inf.
+
+        The batched entry points bypass `process_x` and `_x_else_default_x`, so
+        they call this guard directly.
+        """
+        assert_all_finite(
+            torch.as_tensor(x), "Observed data x_o", allow_nan=self._x_tolerates_nan()
+        )
+
     def potential(
         self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False
     ) -> Tensor:

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -49,7 +49,6 @@ class DirectPosterior(NeuralPosterior):
         device: Optional[Union[str, torch.device]] = None,
         x_shape: Optional[torch.Size] = None,
         enable_transform: bool = True,
-        check_finite_x: bool = True,
     ):
         """
         Args:
@@ -63,9 +62,6 @@ class DirectPosterior(NeuralPosterior):
             enable_transform: Whether to transform parameters to unconstrained space
                 during MAP optimization. When False, an identity transform will be
                 returned for `theta_transform`.
-            check_finite_x: Whether to raise if the observed data `x_o` contains NaNs
-                or Infs. Set to False when the embedding net expects NaNs, e.g., when
-                `PermutationInvariantEmbedding` pads a varying number of trials.
         """
         # Because `DirectPosterior` does not take the `potential_fn` as input, it
         # builds it itself. The `potential_fn` and `theta_transform` are used only for
@@ -85,7 +81,6 @@ class DirectPosterior(NeuralPosterior):
             theta_transform=theta_transform,
             device=device,
             x_shape=x_shape,
-            check_finite_x=check_finite_x,
         )
 
         self.device = device
@@ -133,7 +128,6 @@ class DirectPosterior(NeuralPosterior):
             theta_transform=theta_transform,
             device=device,
             x_shape=self.x_shape,
-            check_finite_x=self._check_finite_x,
         )
         # super().__init__ erases the self._x, so we need to set it again
         if x_o is not None:

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -245,6 +245,7 @@ class DirectPosterior(NeuralPosterior):
         Returns:
             Samples from the posteriors of shape (*sample_shape, B, *input_shape)
         """
+        self._assert_finite_x(x)
         num_samples = torch.Size(sample_shape).numel()
         condition_shape = self.posterior_estimator.condition_shape
         x = reshape_to_batch_event(x, event_shape=condition_shape)
@@ -418,6 +419,7 @@ class DirectPosterior(NeuralPosterior):
             in the support of the prior, -∞ (corresponding to 0 probability) outside.
         """
 
+        self._assert_finite_x(x)
         theta = ensure_theta_batched(torch.as_tensor(theta))
         event_shape = self.posterior_estimator.input_shape
         # If theta has 1 leading dim (batch, event), treat it as batch (matching x).

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -223,6 +223,9 @@ class EnsemblePosterior(NeuralPosterior):
         x: Tensor,
         **kwargs,
     ) -> Tensor:
+        # Guard here: sampling draws a random subset of components, so relying
+        # on component-level checks would validate nondeterministically.
+        self._assert_finite_x(x)
         num_samples = torch.Size(sample_shape).numel()
         posterior_indices = torch.multinomial(
             self._weights, num_samples, replacement=True
@@ -303,7 +306,9 @@ class EnsemblePosterior(NeuralPosterior):
             `EnsemblePosterior` that will use a default `x` when not explicitly
             passed.
         """
-        self._x = process_x(x, x_event_shape=None).to(self._device)
+        x = process_x(x, x_event_shape=None)
+        self._assert_finite_x(x)
+        self._x = x.to(self._device)
 
         for posterior in self.posteriors:
             posterior.set_default_x(x)

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -203,6 +203,10 @@ class EnsemblePosterior(NeuralPosterior):
         Returns:
             Samples drawn from the ensemble distribution.
         """
+        # Components are drawn randomly; guard here so validation of `x` does
+        # not depend on the draw.
+        if x is not None:
+            self._assert_finite_x(x)
         num_samples = torch.Size(sample_shape).numel()
         posterior_indizes = torch.multinomial(
             self._weights, num_samples, replacement=True
@@ -223,8 +227,7 @@ class EnsemblePosterior(NeuralPosterior):
         x: Tensor,
         **kwargs,
     ) -> Tensor:
-        # Guard here: sampling draws a random subset of components, so relying
-        # on component-level checks would validate nondeterministically.
+        # Guard here so validation of `x` does not depend on the component draw.
         self._assert_finite_x(x)
         num_samples = torch.Size(sample_shape).numel()
         posterior_indices = torch.multinomial(

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -133,6 +133,10 @@ class EnsemblePosterior(NeuralPosterior):
             device=self.device,
         )
 
+    def _x_tolerates_nan(self) -> bool:
+        """NaN `x_o` is valid only if every component tolerates it."""
+        return all(p._x_tolerates_nan() for p in self.posteriors)
+
     def ensure_same_device(self, posteriors: List) -> str:
         """Ensures that all posteriors in the ensemble are on the same device.
 

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -409,6 +409,7 @@ class MCMCPosterior(NeuralPosterior):
         Returns:
             Samples from the posteriors of shape (*sample_shape, B, *input_shape)
         """
+        self._assert_finite_x(x)
 
         # Replace arguments that were not passed with their default.
         method = self.method if method is None else method

--- a/sbi/inference/posteriors/posterior_parameters.py
+++ b/sbi/inference/posteriors/posterior_parameters.py
@@ -120,14 +120,10 @@ class DirectPosteriorParameters(PosteriorParameters):
         enable_transform: Whether to transform parameters to unconstrained space
             during MAP optimization. When False, an identity transform will be
             returned for `theta_transform`.
-        check_finite_x: Whether to raise if the observed data `x_o` contains NaNs or
-            Infs. Set to False when the embedding net expects NaNs, e.g., when
-            `PermutationInvariantEmbedding` pads a varying number of trials.
     """
 
     max_sampling_batch_size: int = 10_000
     enable_transform: bool = True
-    check_finite_x: bool = True
 
     def validate(self):
         """Validate DirectPosteriorParameters fields."""
@@ -350,14 +346,10 @@ class VectorFieldPosteriorParameters(PosteriorParameters):
         neural_ode_backend: The backend to use for the neural ODE. Currently,
             only "zuko" is supported.
         neural_ode_kwargs: Additional keyword arguments for the neural ODE.
-        check_finite_x: Whether to raise if the observed data `x_o` contains NaNs or
-            Infs. Set to False when the embedding net expects NaNs, e.g., when
-            `PermutationInvariantEmbedding` pads a varying number of trials.
     """
 
     max_sampling_batch_size: int = 10_000
     enable_transform: bool = True
-    check_finite_x: bool = True
 
     # fields passed from VectorfieldPosterior as keyword arguments
     # to VectorFieldBasedPotential __init__ method

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -549,6 +549,7 @@ class VectorFieldPosterior(NeuralPosterior):
         Returns:
             Samples from the posteriors of shape (*sample_shape, B, *input_shape)
         """
+        self._assert_finite_x(x)
         if self.vector_field_estimator.compose_enabled:
             raise NotImplementedError(
                 "compose_standardization does not yet support sample_batched "

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -59,7 +59,6 @@ class VectorFieldPosterior(NeuralPosterior):
         device: Optional[Union[str, torch.device]] = None,
         enable_transform: bool = True,
         sample_with: Literal["ode", "sde"] = "sde",
-        check_finite_x: bool = True,
         **kwargs,
     ):
         """
@@ -75,9 +74,6 @@ class VectorFieldPosterior(NeuralPosterior):
                 returned for `theta_transform`. True is not supported yet.
             sample_with: Whether to sample from the posterior using the ODE-based
                 sampler or the SDE-based sampler.
-            check_finite_x: Whether to raise if the observed data `x_o` contains NaNs
-                or Infs. Set to False when the embedding net expects NaNs, e.g., when
-                `PermutationInvariantEmbedding` pads a varying number of trials.
             **kwargs: Additional keyword arguments passed to
                 `VectorFieldBasedPotential`.
         """
@@ -94,7 +90,6 @@ class VectorFieldPosterior(NeuralPosterior):
             potential_fn=potential_fn,
             theta_transform=theta_transform,
             device=device,
-            check_finite_x=check_finite_x,
         )
         # Set the potential function type.
         self.potential_fn: VectorFieldBasedPotential = potential_fn
@@ -144,7 +139,6 @@ class VectorFieldPosterior(NeuralPosterior):
             potential_fn=potential_fn,
             theta_transform=theta_transform,
             device=device,
-            check_finite_x=self._check_finite_x,
         )
         # super().__init__ erases the self._x, so we need to set it again
         if x_o is not None:

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 from typing import Optional, Protocol, Union
 
 import torch
-from torch import Tensor
+from torch import Tensor, nn
 from torch.distributions import Distribution
 
 from sbi.utils.torchutils import process_device
@@ -41,6 +41,16 @@ class BasePotential(metaclass=ABCMeta):
         self, theta: Tensor, time: Optional[Tensor] = None, track_gradients: bool = True
     ) -> Tensor:
         raise NotImplementedError
+
+    @property
+    def x_embedding_net(self) -> Optional[nn.Module]:
+        """Return the network that embeds `x`, if the potential knows it.
+
+        `None` means no net is known to consume `x`, so posteriors derive
+        strict finiteness checks for `x_o`. Only potentials whose estimator
+        is conditioned on `x` override this.
+        """
+        return None
 
     @property
     def x_is_iid(self) -> bool:

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -44,12 +44,8 @@ class BasePotential(metaclass=ABCMeta):
 
     @property
     def x_embedding_net(self) -> Optional[nn.Module]:
-        """Return the network that embeds `x`, if the potential knows it.
-
-        `None` means no net is known to consume `x`, so posteriors derive
-        strict finiteness checks for `x_o`. Only potentials whose estimator
-        is conditioned on `x` override this.
-        """
+        """Return the net that embeds `x`; `None` (default) means no net is
+        known to consume `x`, so posteriors validate `x_o` strictly."""
         return None
 
     @property

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Optional, Tuple, Union
 
 import torch
-from torch import Tensor
+from torch import Tensor, nn
 from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
@@ -86,6 +86,11 @@ class PosteriorBasedPotential(BasePotential):
         super().__init__(prior, x_o, device)
         self.posterior_estimator = posterior_estimator
         self.posterior_estimator.eval()
+
+    @property
+    def x_embedding_net(self) -> Optional[nn.Module]:
+        """Return the net embedding `x`: the estimator's condition is `x`."""
+        return self.posterior_estimator.embedding_net
 
     def to(self, device: Union[str, torch.device]) -> "PosteriorBasedPotential":
         """Move posterior estimator, prior and x_o to the given device.

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -4,7 +4,7 @@
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import torch
-from torch import Tensor
+from torch import Tensor, nn
 from torch.distributions import Distribution
 from zuko.distributions import NormalizingFlow
 
@@ -76,6 +76,11 @@ class VectorFieldBasedPotential(BasePotential):
         )
 
         super().__init__(prior, x_o, device=device)
+
+    @property
+    def x_embedding_net(self) -> nn.Module:
+        """Return the net embedding `x`: the estimator's condition is `x`."""
+        return self.vector_field_estimator.embedding_net
 
     def to(self, device: Union[str, torch.device]) -> None:
         """

--- a/sbi/neural_nets/embedding_nets/permutation_invariant.py
+++ b/sbi/neural_nets/embedding_nets/permutation_invariant.py
@@ -15,10 +15,8 @@ class PermutationInvariantEmbedding(nn.Module):
     Takes as input a tensor with (batch, permutation_dim, input_dim)
     and outputs (batch, output_dim).
 
-    A varying number of trials is padded with NaN, which the forward pass
-    masks. The class attribute ``accepts_nan_input = True`` declares this;
-    sbi uses it to derive NaN-tolerant validation of the observation `x_o`
-    (Inf is always rejected).
+    The class attribute ``accepts_nan_input = True`` marks NaN input as padding
+    by design; sbi derives NaN-tolerant `x_o` validation from it.
 
     References:
     Chan et al. (2018): "A likelihood-free inference framework for population genetic

--- a/sbi/neural_nets/embedding_nets/permutation_invariant.py
+++ b/sbi/neural_nets/embedding_nets/permutation_invariant.py
@@ -15,12 +15,19 @@ class PermutationInvariantEmbedding(nn.Module):
     Takes as input a tensor with (batch, permutation_dim, input_dim)
     and outputs (batch, output_dim).
 
+    A varying number of trials is padded with NaN, which the forward pass
+    masks. The class attribute ``accepts_nan_input = True`` declares this;
+    sbi uses it to derive NaN-tolerant validation of the observation `x_o`
+    (Inf is always rejected).
+
     References:
     Chan et al. (2018): "A likelihood-free inference framework for population genetic
     data using exchangeable neural networks"
     Radev et al. (2020): "BayesFlow: Learning complex stochastic models with invertible
     neural networks"
     """
+
+    accepts_nan_input = True
 
     def __init__(
         self,

--- a/sbi/neural_nets/estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixed_density_estimator.py
@@ -53,6 +53,11 @@ class MixedDensityEstimator(ConditionalDensityEstimator):
         self.condition_embedding = embedding_net
         self.log_transform_input = log_transform_input
 
+    @property
+    def embedding_net(self) -> nn.Module:
+        r"""Return the embedding network for the condition."""
+        return self.condition_embedding
+
     def forward(self, input: Tensor):
         raise NotImplementedError(
             """The forward method is not implemented for mixed neural density

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.distributions.transforms as torch_tf
-from torch import Tensor
+from torch import Tensor, nn
 from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
@@ -403,6 +403,11 @@ class ConditionedPotential(BasePotential):
         theta_condition[:, self.dims_to_sample] = theta_
 
         return self.potential_fn(theta_condition, track_gradients=track_gradients)
+
+    @property
+    def x_embedding_net(self) -> Optional[nn.Module]:
+        """Delegate to the wrapped potential, like `set_x` and `return_x_o`."""
+        return self.potential_fn.x_embedding_net
 
     @property
     def x_is_iid(self) -> bool:

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -739,14 +739,8 @@ def batched_first_of_batch(t: Tensor) -> Tensor:
 def assert_all_finite(
     quantity: Tensor, description: str = "tensor", allow_nan: bool = False
 ) -> None:
-    """Raise if tensor quantity contains any NaN or Inf element.
-
-    Args:
-        quantity: Tensor to check.
-        description: Name of the quantity used in the error message.
-        allow_nan: If True, NaN elements are accepted (e.g., NaN-padded trials
-            for a NaN-tolerant embedding); Inf still raises.
-    """
+    """Raise if tensor quantity contains NaN or Inf; `allow_nan` accepts NaN
+    (e.g., NaN-padded trials), Inf still raises."""
 
     msg = f"NaN/Inf present in {description}."
     invalid = (
@@ -761,16 +755,8 @@ def assert_all_finite(
 def net_accepts_nan_input(net: Optional[Module]) -> bool:
     """Return whether any module in `net` declares `accepts_nan_input`.
 
-    NaN-tolerant embeddings such as `PermutationInvariantEmbedding` declare
-    `accepts_nan_input = True` as a class attribute. Builders wrap user
-    embeddings (e.g., inside a standardizing `nn.Sequential`), so the lookup
-    recurses the module tree.
-
-    Args:
-        net: Module to inspect, or None if no net consumes `x`.
-
-    Returns:
-        True if any submodule (including `net` itself) sets `accepts_nan_input`.
+    Recurses the module tree because builders wrap user embeddings, e.g.,
+    inside a standardizing `nn.Sequential`. `None` means no net consumes `x`.
     """
     if net is None:
         return False

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -736,12 +736,45 @@ def batched_first_of_batch(t: Tensor) -> Tensor:
     return t[:1]
 
 
-def assert_all_finite(quantity: Tensor, description: str = "tensor") -> None:
-    """Raise if tensor quantity contains any NaN or Inf element."""
+def assert_all_finite(
+    quantity: Tensor, description: str = "tensor", allow_nan: bool = False
+) -> None:
+    """Raise if tensor quantity contains any NaN or Inf element.
+
+    Args:
+        quantity: Tensor to check.
+        description: Name of the quantity used in the error message.
+        allow_nan: If True, NaN elements are accepted (e.g., NaN-padded trials
+            for a NaN-tolerant embedding); Inf still raises.
+    """
 
     msg = f"NaN/Inf present in {description}."
-    if not torch.isfinite(quantity).all():
+    invalid = (
+        bool(torch.isinf(quantity).any())
+        if allow_nan
+        else not bool(torch.isfinite(quantity).all())
+    )
+    if invalid:
         raise ValueError(msg)
+
+
+def net_accepts_nan_input(net: Optional[Module]) -> bool:
+    """Return whether any module in `net` declares `accepts_nan_input`.
+
+    NaN-tolerant embeddings such as `PermutationInvariantEmbedding` declare
+    `accepts_nan_input = True` as a class attribute. Builders wrap user
+    embeddings (e.g., inside a standardizing `nn.Sequential`), so the lookup
+    recurses the module tree.
+
+    Args:
+        net: Module to inspect, or None if no net consumes `x`.
+
+    Returns:
+        True if any submodule (including `net` itself) sets `accepts_nan_input`.
+    """
+    if net is None:
+        return False
+    return any(getattr(m, "accepts_nan_input", False) for m in net.modules())
 
 
 def assert_not_nan_or_plus_inf(quantity: Tensor, description: str = "tensor") -> None:

--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -497,7 +497,6 @@ def test_npe_with_with_iid_embedding_varying_num_trials(trial_factor=50):
     _ = inference.append_simulations(theta, x, exclude_invalid_x=False).train(
         training_batch_size=100
     )
-    # No flag needed: the NaN-tolerance is derived from the embedding net.
     posterior = inference.build_posterior()
 
     num_samples = 1000

--- a/tests/embedding_net_test.py
+++ b/tests/embedding_net_test.py
@@ -15,7 +15,6 @@ from torch.distributions import MultivariateNormal
 from sbi import utils
 from sbi.inference import NLE, NPE, NRE, simulate_for_sbi
 from sbi.inference.posteriors.posterior_parameters import (
-    DirectPosteriorParameters,
     MCMCPosteriorParameters,
 )
 from sbi.neural_nets import classifier_nn, likelihood_nn, posterior_nn
@@ -498,9 +497,8 @@ def test_npe_with_with_iid_embedding_varying_num_trials(trial_factor=50):
     _ = inference.append_simulations(theta, x, exclude_invalid_x=False).train(
         training_batch_size=100
     )
-    posterior = inference.build_posterior(
-        posterior_parameters=DirectPosteriorParameters(check_finite_x=False)
-    )
+    # No flag needed: the NaN-tolerance is derived from the embedding net.
+    posterior = inference.build_posterior()
 
     num_samples = 1000
     # test different number of trials

--- a/tests/posterior_parameters_test.py
+++ b/tests/posterior_parameters_test.py
@@ -108,8 +108,6 @@ def get_inference():
                 "x_o",
                 "enable_transform",
                 "max_sampling_batch_size",
-                # consumed by VectorFieldPosterior, not forwarded to the potential.
-                "check_finite_x",
             },
         ),
     ],

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -24,10 +24,11 @@ from sbi.inference import NPE_A, NPE_C, simulate_for_sbi
 from sbi.inference.posteriors import EnsemblePosterior
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
+from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.potentials.posterior_based_potential import (
     posterior_estimator_based_potential,
 )
-from sbi.neural_nets import posterior_nn
+from sbi.neural_nets import posterior_nn, posterior_score_nn
 from sbi.neural_nets.embedding_nets import (
     FCEmbedding,
     PermutationInvariantEmbedding,
@@ -337,16 +338,6 @@ def test_nonfinite_x_on_preconditioned_potential(trained_npe):
         MCMCPosterior(potential_fn, theta_transform=theta_transform, proposal=prior)
 
 
-def test_strict_validation_needs_no_pickled_state(trained_npe):
-    """A restored posterior still rejects NaN: validation derives at check time."""
-    _, inference, _ = trained_npe
-    restored = pickle.loads(pickle.dumps(inference.build_posterior()))
-
-    restored.set_default_x(torch.zeros(1, 2))
-    with pytest.raises(ValueError, match="NaN/Inf"):
-        restored.set_default_x(torch.tensor([0.0, float("nan")]))
-
-
 @pytest.fixture(scope="module")
 def trained_nan_tolerant_npe():
     """A minimally trained NPE with a `PermutationInvariantEmbedding`.
@@ -498,6 +489,49 @@ def test_derived_nan_tolerance_survives_pickling(trained_nan_tolerant_npe):
 
     assert restored.default_x is not None
     assert restored.default_x.isnan().any()
+
+
+def test_batched_apis_reject_nonfinite_x(trained_npe):
+    """The batched entry points must validate `x` like the non-batched paths.
+
+    They bypass `process_x` and `_x_else_default_x`, so before the shared guard
+    they silently computed on NaN.
+    """
+    prior, inference, _ = trained_npe
+    x_batch = torch.stack([zeros(2), torch.tensor([0.0, float("nan")])])
+    direct = inference.build_posterior()
+
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        direct.sample_batched((1,), x_batch)
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        direct.log_prob_batched(prior.sample((2,)), x_batch)
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        inference.build_posterior(sample_with="mcmc").sample_batched((1,), x_batch)
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        EnsemblePosterior([direct, direct]).sample_batched((1,), x_batch)
+
+
+def test_vector_field_sample_batched_rejects_nonfinite_x(trained_npe):
+    """The vector-field batched path needs the same guard."""
+    prior, _, _ = trained_npe
+    estimator = posterior_score_nn(z_score_x="none")(
+        prior.sample((20,)), torch.randn(20, 2)
+    )
+    posterior = VectorFieldPosterior(estimator, prior)
+
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        posterior.sample_batched((1,), torch.tensor([[0.0, float("nan")]]))
+
+
+def test_sample_batched_accepts_nan_with_tolerant_embedding(trained_nan_tolerant_npe):
+    """A derived-tolerant posterior samples from NaN-padded batched `x`."""
+    _, inference, x_nan = trained_nan_tolerant_npe
+    posterior = inference.build_posterior()
+    x_batch = torch.cat([x_nan, x_nan])
+
+    samples = posterior.sample_batched((3,), x_batch, show_progress_bars=False)
+
+    assert samples.shape[:2] == (3, 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import pickle
 from typing import Callable, Tuple
 
 import numpy as np
@@ -373,13 +372,9 @@ def trained_nan_tolerant_npe():
     return prior, inference, x_nan
 
 
-@pytest.mark.parametrize("sample_with", ("direct", "mcmc", "rejection"))
+@pytest.mark.parametrize("sample_with", ("direct", "mcmc"))
 def test_nan_tolerance_derived_from_embedding(sample_with, trained_nan_tolerant_npe):
-    """A NaN-tolerant embedding must derive the tolerance for every sampler.
-
-    Before derivation, only `DirectPosterior` and `VectorFieldPosterior` could
-    opt out of the finiteness check; switching the sampler lost the tolerance.
-    """
+    """A NaN-tolerant embedding must derive the tolerance for every sampler."""
     _, inference, x_nan = trained_nan_tolerant_npe
     posterior = inference.build_posterior(sample_with=sample_with)
 
@@ -427,6 +422,9 @@ def test_ensemble_derives_nan_tolerance_from_components(trained_nan_tolerant_npe
     mixed = EnsemblePosterior([tolerant, strict])
     with pytest.raises(ValueError, match="NaN/Inf"):
         mixed.potential(theta, x=x_nan)
+    # sample() draws components randomly; rejection must not depend on the draw.
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        mixed.sample((1,), x=x_nan, show_progress_bars=False)
 
 
 def test_conditioned_potential_preserves_nan_tolerance(trained_nan_tolerant_npe):
@@ -480,23 +478,8 @@ def test_mnpe_derives_nan_tolerance_from_marked_embedding():
     assert posterior.default_x.isnan().any()
 
 
-def test_derived_nan_tolerance_survives_pickling(trained_nan_tolerant_npe):
-    """The tolerance derives at check time, so it needs no pickled state."""
-    _, inference, x_nan = trained_nan_tolerant_npe
-    restored = pickle.loads(pickle.dumps(inference.build_posterior()))
-
-    restored.set_default_x(x_nan)
-
-    assert restored.default_x is not None
-    assert restored.default_x.isnan().any()
-
-
 def test_batched_apis_reject_nonfinite_x(trained_npe):
-    """The batched entry points must validate `x` like the non-batched paths.
-
-    They bypass `process_x` and `_x_else_default_x`, so before the shared guard
-    they silently computed on NaN.
-    """
+    """The batched entry points bypass `process_x` and must guard themselves."""
     prior, inference, _ = trained_npe
     x_batch = torch.stack([zeros(2), torch.tensor([0.0, float("nan")])])
     direct = inference.build_posterior()

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -19,14 +19,18 @@ from torch.distributions import (
     Uniform,
 )
 
+from sbi.analysis import conditional_potential
 from sbi.inference import NPE_A, NPE_C, simulate_for_sbi
+from sbi.inference.posteriors import EnsemblePosterior
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
-from sbi.inference.posteriors.posterior_parameters import (
-    DirectPosteriorParameters,
-)
 from sbi.inference.potentials.posterior_based_potential import (
     posterior_estimator_based_potential,
+)
+from sbi.neural_nets import posterior_nn
+from sbi.neural_nets.embedding_nets import (
+    FCEmbedding,
+    PermutationInvariantEmbedding,
 )
 from sbi.neural_nets.estimators.mixture_density_estimator import (
     MultivariateGaussianMDN,
@@ -296,7 +300,7 @@ def test_process_x(x, x_shape):
 
 @pytest.fixture(scope="module")
 def trained_npe():
-    """A minimally trained NPE, shared by the `check_finite_x` tests."""
+    """A minimally trained NPE, shared by the non-finite `x_o` tests."""
     prior = BoxUniform(zeros(2), ones(2))
     inference = NPE_C(prior=prior, show_progress_bars=False)
     theta = prior.sample((100,))
@@ -306,30 +310,23 @@ def trained_npe():
     return prior, inference, estimator
 
 
-@pytest.mark.parametrize("check_finite_x", (True, False))
-def test_posterior_check_finite_x(check_finite_x: bool, trained_npe):
-    """`x_o` with NaNs must raise unless the user opts out via `check_finite_x`.
+def test_posterior_rejects_nonfinite_x(trained_npe):
+    """`x_o` with NaNs must raise when the embedding net is not NaN-tolerant.
 
     Covers both guarded paths: `set_default_x` and, via `log_prob(x=...)`,
     `_x_else_default_x`.
     """
     prior, inference, _ = trained_npe
-    posterior = inference.build_posterior(
-        posterior_parameters=DirectPosteriorParameters(check_finite_x=check_finite_x)
-    )
+    posterior = inference.build_posterior()
     x_with_nan = torch.tensor([0.0, float("nan")])
 
-    if check_finite_x:
-        with pytest.raises(ValueError, match="NaN/Inf"):
-            posterior.set_default_x(x_with_nan)
-        with pytest.raises(ValueError, match="NaN/Inf"):
-            posterior.log_prob(prior.sample((2,)), x=x_with_nan)
-    else:
+    with pytest.raises(ValueError, match="NaN/Inf"):
         posterior.set_default_x(x_with_nan)
-        assert posterior.default_x.isnan().any()
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        posterior.log_prob(prior.sample((2,)), x=x_with_nan)
 
 
-def test_check_finite_x_on_preconditioned_potential(trained_npe):
+def test_nonfinite_x_on_preconditioned_potential(trained_npe):
     """`x_o` passed to the potential builder (#573) must be checked too."""
     prior, _, estimator = trained_npe
     potential_fn, theta_transform = posterior_estimator_based_potential(
@@ -340,17 +337,167 @@ def test_check_finite_x_on_preconditioned_potential(trained_npe):
         MCMCPosterior(potential_fn, theta_transform=theta_transform, proposal=prior)
 
 
-def test_posterior_unpickles_without_check_finite_x(trained_npe):
-    """Posteriors pickled before `check_finite_x` existed must still load."""
+def test_strict_validation_needs_no_pickled_state(trained_npe):
+    """A restored posterior still rejects NaN: validation derives at check time."""
     _, inference, _ = trained_npe
-    state = inference.build_posterior().__getstate__().copy()
-    del state["_check_finite_x"]
+    restored = pickle.loads(pickle.dumps(inference.build_posterior()))
 
-    restored = DirectPosterior.__new__(DirectPosterior)
-    restored.__setstate__(pickle.loads(pickle.dumps(state)))
-
-    assert restored._check_finite_x
     restored.set_default_x(torch.zeros(1, 2))
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        restored.set_default_x(torch.tensor([0.0, float("nan")]))
+
+
+@pytest.fixture(scope="module")
+def trained_nan_tolerant_npe():
+    """A minimally trained NPE with a `PermutationInvariantEmbedding`.
+
+    The embedding declares `accepts_nan_input`, so posteriors built from this
+    trainer must derive NaN-tolerant `x_o` validation without any flag.
+    """
+    num_dim, max_trials, num_sims = 2, 3, 100
+    prior = BoxUniform(zeros(num_dim), ones(num_dim))
+    theta = prior.sample((num_sims,))
+    num_trials = torch.randint(1, max_trials + 1, size=(num_sims,))
+    x = torch.full((num_sims, max_trials, num_dim), float("nan"))
+    for i in range(num_sims):
+        x[i, : num_trials[i]] = theta[i] + 0.1 * torch.randn(num_trials[i], num_dim)
+
+    embedding_net = PermutationInvariantEmbedding(
+        trial_net=FCEmbedding(input_dim=num_dim, output_dim=4),
+        trial_net_output_dim=4,
+        output_dim=4,
+    )
+    density_estimator = posterior_nn(
+        model="mdn", embedding_net=embedding_net, z_score_x="none"
+    )
+    inference = NPE_C(
+        prior=prior, density_estimator=density_estimator, show_progress_bars=False
+    )
+    inference.append_simulations(theta, x, exclude_invalid_x=False).train(
+        max_num_epochs=1, training_batch_size=50
+    )
+
+    x_nan = torch.full((1, max_trials, num_dim), float("nan"))
+    x_nan[0, :1] = 0.5
+    return prior, inference, x_nan
+
+
+@pytest.mark.parametrize("sample_with", ("direct", "mcmc", "rejection"))
+def test_nan_tolerance_derived_from_embedding(sample_with, trained_nan_tolerant_npe):
+    """A NaN-tolerant embedding must derive the tolerance for every sampler.
+
+    Before derivation, only `DirectPosterior` and `VectorFieldPosterior` could
+    opt out of the finiteness check; switching the sampler lost the tolerance.
+    """
+    _, inference, x_nan = trained_nan_tolerant_npe
+    posterior = inference.build_posterior(sample_with=sample_with)
+
+    posterior.set_default_x(x_nan)
+
+    assert posterior.default_x is not None
+    assert posterior.default_x.isnan().any()
+
+
+def test_inf_x_rejected_despite_nan_tolerance(trained_nan_tolerant_npe):
+    """Inf in `x_o` is never padding and must raise even where NaN is accepted."""
+    _, inference, x_nan = trained_nan_tolerant_npe
+    posterior = inference.build_posterior()
+    x_inf = x_nan.clone()
+    x_inf[0, 0, 0] = float("inf")
+
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        posterior.set_default_x(x_inf)
+
+
+def test_ensemble_derives_nan_tolerance_from_components(trained_nan_tolerant_npe):
+    """An ensemble tolerates NaN iff every component does (strict-if-any-strict)."""
+    prior, inference, x_nan = trained_nan_tolerant_npe
+    tolerant = inference.build_posterior()
+    theta = prior.sample((2,))
+
+    ensemble = EnsemblePosterior([tolerant, inference.build_posterior()])
+    ensemble.potential(theta, x=x_nan)
+
+    class FlattenEmbedding(nn.Module):
+        """Same input shapes as the trial embedding, but without the marker."""
+
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(6, 6)
+
+        def forward(self, x: Tensor) -> Tensor:
+            return self.linear(x.flatten(start_dim=1))
+
+    strict_estimator = posterior_nn(
+        model="mdn", embedding_net=FlattenEmbedding(), z_score_x="none"
+    )(prior.sample((20,)), torch.randn(20, 3, 2))
+    strict = DirectPosterior(posterior_estimator=strict_estimator, prior=prior)
+
+    mixed = EnsemblePosterior([tolerant, strict])
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        mixed.potential(theta, x=x_nan)
+
+
+def test_conditioned_potential_preserves_nan_tolerance(trained_nan_tolerant_npe):
+    """`conditional_potential()` over a NaN-tolerant potential must stay tolerant.
+
+    Constructing the posterior runs the `x_o` guard on the NaN-padded
+    observation carried by the conditioned potential.
+    """
+    prior, inference, x_nan = trained_nan_tolerant_npe
+    estimator = inference.build_posterior().posterior_estimator
+    potential_fn, theta_transform = posterior_estimator_based_potential(
+        estimator, prior, x_o=x_nan
+    )
+    conditioned_potential_fn, restricted_tf, restricted_prior = conditional_potential(
+        potential_fn,
+        theta_transform,
+        prior,
+        condition=zeros(1, 2),
+        dims_to_sample=[0],
+    )
+
+    MCMCPosterior(
+        conditioned_potential_fn,
+        theta_transform=restricted_tf,
+        proposal=restricted_prior,
+    )
+
+
+def test_mnpe_derives_nan_tolerance_from_marked_embedding():
+    """The mixed density estimator must expose its condition embedding.
+
+    Any third-party module carrying `accepts_nan_input` counts as NaN-tolerant,
+    and MNPE participates via the standard `embedding_net` property.
+    """
+
+    class NaNTolerantEmbedding(nn.Identity):
+        accepts_nan_input = True
+
+    theta = torch.cat((torch.rand(100, 2), torch.bernoulli(0.5 * ones(100, 1))), dim=1)
+    x = torch.randn(100, 2)
+    estimator = posterior_nn(model="mnpe", embedding_net=NaNTolerantEmbedding())(
+        theta, x
+    )
+    posterior = DirectPosterior(
+        posterior_estimator=estimator, prior=BoxUniform(zeros(3), ones(3))
+    )
+
+    posterior.set_default_x(torch.tensor([[0.0, float("nan")]]))
+
+    assert posterior.default_x is not None
+    assert posterior.default_x.isnan().any()
+
+
+def test_derived_nan_tolerance_survives_pickling(trained_nan_tolerant_npe):
+    """The tolerance derives at check time, so it needs no pickled state."""
+    _, inference, x_nan = trained_nan_tolerant_npe
+    restored = pickle.loads(pickle.dumps(inference.build_posterior()))
+
+    restored.set_default_x(x_nan)
+
+    assert restored.default_x is not None
+    assert restored.default_x.isnan().any()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Whether NaN in `x_o` is valid is a property of the embedding net, not of the posterior class. #1828 added a `check_finite_x` flag on two posterior classes (my bad).
The same estimator loses its NaN-tolerance when the posterior class changes. e.g., currently, sample_with="mcmc"`, NPE-A, ensembles, and conditional analysis all reject NaN-padded observations.

This PR removes the flag and derives the behavior from the estimator:

- `PermutationInvariantEmbedding` declares `accepts_nan_input = True`.
- `BasePotential.x_embedding_net` returns the net that consumes `x`
  (`None` means strict). Only the posterior-based and vector-field potentials
  override it. `ConditionedPotential` delegates to its wrapped potential.
- `NeuralPosterior` derives the tolerance at check time. There is no stored
  state, no pickle handling, and nothing to forward through `.to()`.
- Ensembles tolerate NaN only if every component does.
- Inf in `x_o` always raises, also with a NaN-tolerant embedding.
- `MixedDensityEstimator` exposes its condition embedding, so MNPE
  participates in the derivation.

The NaN-padding workflow now works with a plain `build_posterior()`. The varying-trials embedding test passes with its explicit flag removed.

The second commit closes an older miss we had: `sample_batched` and `log_prob_batched` bypass `process_x`, so they computed on non-finite `x` without any error (this predates #1701). They now validate through one shared guard that respects the derived tolerance.

## Does this close any issues?

Follow-up to #1828, which fixed #1717 for `DirectPosterior` and `VectorFieldPosterior` only. This closes the remaining gaps: mcmc/rejection/vi/importance sampling, NPE-A, ensembles, conditional potentials, and the batched entry points.

## Anything else we should know?

For the release notes:

- `check_finite_x` (added in #1828 after 0.27.0) is removed again. It never shipped in a release.
- Batched calls that silently accepted non-finite `x` now raise.

The marker contract (NaN only; the marked module must be the first to consume the raw `x`) is documented in the embedding docstring and in both trial-padding notebooks. Custom embeddings opt in with the same one-line attribute.

## Checklist

- [x] I have read the contributing guide.
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [x] New tests run in seconds; the pre-existing varying-trials test stays
      `slow`.

AI assistance: implemented with Claude Code (design discussion, implementation,
tests); reviewed by two independent agent reviews (Claude and Codex) before my
own review.
