### PR TITLE
refactor: port the Potentials bind() API from gsoc-2026 (#1937, #1943, #1945, #1946, #1948)

### DIFF
--- a/docs/how_to_guide/09_sampler_interface.ipynb
+++ b/docs/how_to_guide/09_sampler_interface.ipynb
@@ -237,6 +237,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "To evaluate the same potential at a different observation, use `bind()`:\n",
+    "\n",
+    "```python\n",
+    "potential_fn_new = potential_fn.bind(x_o_new)\n",
+    "```\n",
+    "\n",
+    "`bind()` returns a new potential and does not modify the original. A reference\n",
+    "to the old potential keeps the old observation, so always use the returned\n",
+    "object. The mutable `set_x()` is deprecated and will be removed in a future\n",
+    "release."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The equivalent function for NPE and NRE estimators is\n",
     "`posterior_estimator_based_potential` and `ratio_estimator_based_potential`,\n",
     "respectively. See [the abstraction levels guide](24_abstraction_levels.ipynb) for how this\n",

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -101,7 +101,7 @@ class NeuralPosterior:
                 This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
         """
-        self.potential_fn.set_x(self._x_else_default_x(x))
+        self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
         return self.potential_fn(
@@ -310,7 +310,7 @@ class NeuralPosterior:
             )
 
         if self._map is None or force_update:
-            self.potential_fn.set_x(self.default_x)
+            self.potential_fn = self.potential_fn.bind(self.default_x)
             self._map = self._calculate_map(
                 num_iter=num_iter,
                 num_to_optimize=num_to_optimize,

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -318,7 +318,7 @@ class EnsemblePosterior(NeuralPosterior):
                 This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
         """
-        self.potential_fn.set_x(self._x_else_default_x(x))
+        self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
 
@@ -399,7 +399,7 @@ class EnsemblePosterior(NeuralPosterior):
             return log_weights, maps
 
         else:
-            self.potential_fn.set_x(self._x_else_default_x(x))
+            self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
             if init_method == "posterior":
                 inits = self.sample((num_init_samples,), self._x_else_default_x(x))
@@ -489,6 +489,28 @@ class EnsemblePotential(BasePotential):
         self._x_o = x_o
         for comp_potential in self.potential_fns:
             comp_potential.set_x(x_o)
+
+    def bind(
+        self,
+        x_o: Tensor,
+        x_is_iid: bool = True,
+        **kwargs,
+    ) -> "EnsemblePotential":
+        """Return a new EnsemblePotential with x_o bound to all component potentials."""
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
+
+        bound_potentials = [
+            p.bind(x_o, x_is_iid=x_is_iid, **kwargs) for p in self.potential_fns
+        ]
+
+        return EnsemblePotential(
+            potential_fns=bound_potentials,
+            weights=self._weights,
+            prior=self.prior,
+            x_o=x_o,
+            device=self.device,
+        )
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential for posterior-based methods.

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -481,14 +482,21 @@ class EnsemblePotential(BasePotential):
         )
 
     def set_x(self, x_o: Optional[Tensor]):
-        """Check the shape of the observed data and, if valid, set it."""
-        if x_o is not None:
-            x_o = process_x(x_o).to(  # type: ignore
-                self.device
-            )
-        self._x_o = x_o
-        for comp_potential in self.potential_fns:
-            comp_potential.set_x(x_o)
+        """Check the shape of the observed data and, if valid, set it.
+
+        DEPRECATED: Use bind() instead. This method delegates to bind() internally.
+        It will be removed in a future release.
+        """
+
+        warnings.warn(
+            "set_x() is deprecated and will be removed in a future release. "
+            "Use bind() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        bound = self.bind(x_o)
+        self._x_o = bound._x_o
+        self.potential_fns = bound.potential_fns
 
     def bind(
         self,

--- a/sbi/inference/posteriors/ensemble_posterior.py
+++ b/sbi/inference/posteriors/ensemble_posterior.py
@@ -454,6 +454,8 @@ class EnsemblePotential(BasePotential):
         self._weights = weights
         self.potential_fns = potential_fns
         super().__init__(prior, x_o, device)
+        if self._x_o is not None:
+            self.potential_fns = [p.bind(self._x_o) for p in self.potential_fns]
 
     def to(self, device: Union[str, torch.device]) -> None:
         """
@@ -500,25 +502,38 @@ class EnsemblePotential(BasePotential):
 
     def bind(
         self,
-        x_o: Tensor,
-        x_is_iid: bool = True,
+        x_o: Optional[Tensor],
+        x_is_iid: Optional[bool] = None,
         **kwargs,
     ) -> "EnsemblePotential":
-        """Return a new EnsemblePotential with x_o bound to all component potentials."""
+        """Return a new EnsemblePotential with x_o bound to all component potentials.
+
+        Args:
+            x_o: Observed data to bind.
+            x_is_iid: Whether x_o is a batch of iid observations. With None,
+                every component keeps its own iid default.
+            kwargs: Forwarded to each component's bind().
+
+        Returns:
+            A new EnsemblePotential with bound components.
+        """
         if x_o is not None:
             x_o = process_x(x_o).to(self.device)
 
+        iid_kwargs = {} if x_is_iid is None else {"x_is_iid": x_is_iid}
         bound_potentials = [
-            p.bind(x_o, x_is_iid=x_is_iid, **kwargs) for p in self.potential_fns
+            p.bind(x_o, **iid_kwargs, **kwargs) for p in self.potential_fns
         ]
 
-        return EnsemblePotential(
+        bound = EnsemblePotential(
             potential_fns=bound_potentials,
             weights=self._weights,
             prior=self.prior,
-            x_o=x_o,
+            x_o=None,
             device=self.device,
         )
+        bound._x_o = x_o
+        return bound
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential for posterior-based methods.

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -129,7 +129,7 @@ class ImportanceSamplingPosterior(NeuralPosterior):
             `len($\theta$)`-shaped log-probability.
         """
         x = self._x_else_default_x(x)
-        self.potential_fn.set_x(x)
+        self.potential_fn = self.potential_fn.bind(x)
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
 
@@ -213,7 +213,7 @@ class ImportanceSamplingPosterior(NeuralPosterior):
 
         method = self.method if method is None else method
 
-        self.potential_fn.set_x(self._x_else_default_x(x))
+        self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
         if method == "sir":
             return self._sir_sample(

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -2,7 +2,6 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 import inspect
 import warnings
-from copy import deepcopy
 from functools import partial
 from math import ceil
 from typing import Any, Callable, Dict, Literal, Optional, Union
@@ -227,7 +226,7 @@ class MCMCPosterior(NeuralPosterior):
         warn("The log-probability is unnormalized!", stacklevel=2)
 
         x = self._x_else_default_x(x)
-        self.potential_fn.set_x(x, x_is_iid=True)
+        self.potential_fn = self.potential_fn.bind(x, x_is_iid=True)
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
         return self.potential_fn(
@@ -286,7 +285,7 @@ class MCMCPosterior(NeuralPosterior):
         """
 
         x = self._x_else_default_x(x)
-        self.potential_fn.set_x(x, x_is_iid=True)
+        self.potential_fn = self.potential_fn.bind(x, x_is_iid=True)
 
         # Replace arguments that were not passed with their default.
         method = self.method if method is None else method
@@ -451,7 +450,7 @@ class MCMCPosterior(NeuralPosterior):
         # in the order of the observations.
         x_ = x.repeat_interleave(num_chains, dim=0)
 
-        self.potential_fn.set_x(x_, x_is_iid=False)
+        self.potential_fn = self.potential_fn.bind(x_, x_is_iid=False)
         self.potential_ = self._prepare_potential(method)  # type: ignore
 
         # For each observation in the batch, we have num_chains independent chains.
@@ -689,25 +688,25 @@ class MCMCPosterior(NeuralPosterior):
         # One init per chain per observation, all drawn from the same iterator.
         self._check_latest_sample_supply(init_strategy, len(x) * num_chains_per_x)
 
-        potential_ = deepcopy(self.potential_fn)
+        potential_ = self.potential_fn
         initial_params = []
-        init_fn = self._build_mcmc_init_fn(
-            self.proposal,
-            potential_fn=potential_,
-            transform=self.theta_transform,
-            init_strategy=init_strategy,  # type: ignore
-            **kwargs,
-        )
         for xi in x:
-            # Build init function
-            potential_.set_x(xi)
+            # Build init function with bound potential for this specific xi
+            potential_bound = potential_.bind(xi)
+            init_fn = self._build_mcmc_init_fn(
+                self.proposal,
+                potential_fn=potential_bound,
+                transform=self.theta_transform,
+                init_strategy=init_strategy,  # type: ignore
+                **kwargs,
+            )
 
             # Parallelize inits for resampling or sir.
             if num_workers > 1 and (
                 init_strategy == "resample" or init_strategy == "sir"
             ):
 
-                def seeded_init_fn(seed):
+                def seeded_init_fn(seed, init_fn=init_fn):
                     torch.manual_seed(seed)
                     return init_fn()
 

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -121,7 +121,7 @@ class RejectionPosterior(NeuralPosterior):
         )
         warn("The log-probability is unnormalized!", stacklevel=2)
 
-        self.potential_fn.set_x(self._x_else_default_x(x))
+        self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
         return self.potential_fn(
@@ -175,7 +175,7 @@ class RejectionPosterior(NeuralPosterior):
             Samples from posterior.
         """
         num_samples = torch.Size(sample_shape).numel()
-        self.potential_fn.set_x(self._x_else_default_x(x))
+        self.potential_fn = self.potential_fn.bind(self._x_else_default_x(x))
 
         potential = partial(self.potential_fn, track_gradients=True)
 

--- a/sbi/inference/posteriors/vector_field_posterior.py
+++ b/sbi/inference/posteriors/vector_field_posterior.py
@@ -262,7 +262,7 @@ class VectorFieldPosterior(NeuralPosterior):
                 "guided sampling. Use a single observation, or disable "
                 "compose_standardization."
             )
-        self.potential_fn.set_x(
+        self.potential_fn = self.potential_fn.bind(
             x,
             x_is_iid=is_iid,
             iid_method=iid_method or self.potential_fn.iid_method,
@@ -496,7 +496,9 @@ class VectorFieldPosterior(NeuralPosterior):
                 "log_prob. Use a single observation, or disable "
                 "compose_standardization."
             )
-        self.potential_fn.set_x(x, x_is_iid=is_iid, **(ode_kwargs or {}))
+        self.potential_fn = self.potential_fn.bind(
+            x, x_is_iid=is_iid, **(ode_kwargs or {})
+        )
 
         theta = ensure_theta_batched(torch.as_tensor(theta))
         return self.potential_fn(
@@ -566,7 +568,7 @@ class VectorFieldPosterior(NeuralPosterior):
         condition_dim = len(self.vector_field_estimator.condition_shape)
         batch_shape = x.shape[:-condition_dim]
         batch_size = batch_shape.numel()
-        self.potential_fn.set_x(x)
+        self.potential_fn = self.potential_fn.bind(x)
 
         max_sampling_batch_size = (
             self.max_sampling_batch_size
@@ -713,7 +715,9 @@ class VectorFieldPosterior(NeuralPosterior):
 
         if self._map is None or force_update:
             # rebuild coarse flow fast for MAP optimization.
-            self.potential_fn.set_x(self.default_x, atol=1e-2, rtol=1e-3, exact=True)
+            self.potential_fn = self.potential_fn.bind(
+                self.default_x, atol=1e-2, rtol=1e-3, exact=True
+            )
             callable_potential_fn = CallableDifferentiablePotentialFunction(
                 self.potential_fn
             )

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -1276,7 +1276,7 @@ class VIPosterior(NeuralPosterior):
         x_expanded = x_batch.repeat(n_particles, 1)
 
         # Set x_o for batched evaluation (x_is_iid=False: each θ paired with its x)
-        self.potential_fn.set_x(x_expanded, x_is_iid=False)
+        self.potential_fn = self.potential_fn.bind(x_expanded, x_is_iid=False)
         log_potential_flat = self.potential_fn(theta_flat)
 
         # Reshape: (n_particles * batch_size,) -> (n_particles, batch_size)

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -927,6 +927,10 @@ class VIPosterior(NeuralPosterior):
                 break
         # Training finished:
         self._trained_on = x
+
+        # Bind potential_fn to the trained x so it can be used for sampling/evaluation
+        self.potential_fn = self.potential_fn.bind(x)
+
         if self._mode == "amortized":
             warnings.warn(
                 "Switching from amortized to single-x mode. "

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -31,7 +31,10 @@ class BasePotential(metaclass=ABCMeta):
         """
         self.device = process_device(device)
         self.prior = prior
-        self.set_x(x_o)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
+        self._x_o = x_o
+        self._x_is_iid = True
 
     @abstractmethod
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -57,11 +57,20 @@ class BasePotential(metaclass=ABCMeta):
             )
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = True):
-        """Check the shape of the observed data and, if valid, set it."""
-        if x_o is not None:
-            x_o = process_x(x_o).to(self.device)
-        self._x_o = x_o
-        self._x_is_iid = x_is_iid
+        """Check the shape of the observed data and, if valid, set it.
+
+        DEPRECATED: Use bind() instead. This method delegates to bind() internally.
+        """
+        import warnings
+
+        warnings.warn(
+            "set_x() is deprecated, use bind() instead",
+            FutureWarning,
+            stacklevel=2,
+        )
+        bound = self.bind(x_o, x_is_iid=x_is_iid)
+        self._x_o = bound._x_o
+        self._x_is_iid = bound._x_is_iid
 
     @property
     def x_o(self) -> Tensor:

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -70,11 +70,6 @@ class BasePotential(metaclass=ABCMeta):
                 "No observed data is available. Use `potential_fn.set_x(x_o)`."
             )
 
-    @x_o.setter
-    def x_o(self, x_o: Optional[Tensor]) -> None:
-        """Check the shape of the observed data and, if valid, set it."""
-        self.set_x(x_o)
-
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
 

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import copy
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Protocol, Union
 
@@ -82,8 +83,15 @@ class BasePotential(metaclass=ABCMeta):
                 "No observed data is available. Use `potential_fn.bind(x_o)`."
             )
 
-    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "BasePotential":
+    def bind(self, x_o: Optional[Tensor], x_is_iid: bool = True) -> "BasePotential":
         """Create new potential with x bound, without mutable state.
+
+        `bind()` does not modify the original potential. A reference to the
+        original keeps the old state; always use the returned potential.
+
+        The default returns a shallow copy, so the bound potential shares the
+        estimator, prior, and every other attribute with the original.
+        Subclasses override this only to rebuild state derived from `x_o`.
 
         Args:
             x_o: Observed data to bind.
@@ -91,10 +99,13 @@ class BasePotential(metaclass=ABCMeta):
 
         Returns:
             New potential instance with x bound.
-
-        Subclasses must implement this method.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement bind()")
+        bound = copy.copy(self)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
+        return bound
 
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
@@ -178,11 +189,15 @@ class CustomPotentialWrapper(BasePotential):
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)
 
-    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "CustomPotentialWrapper":
+    def bind(
+        self, x_o: Optional[Tensor], x_is_iid: bool = True
+    ) -> "CustomPotentialWrapper":
         """Create new potential with x bound, without mutable state."""
-        return CustomPotentialWrapper(
+        bound = CustomPotentialWrapper(
             potential_fn=self.potential_fn,
             prior=self.prior,
             x_o=x_o,
             device=self.device,
         )
+        bound._x_is_iid = x_is_iid
+        return bound

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -50,7 +50,7 @@ class BasePotential(metaclass=ABCMeta):
             return self._x_is_iid
         else:
             raise ValueError(
-                "No observed data is available. Use `potential_fn.set_x(x_o)`."
+                "No observed data is available. Use `potential_fn.bind(x_o)`."
             )
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = True):
@@ -67,8 +67,22 @@ class BasePotential(metaclass=ABCMeta):
             return self._x_o
         else:
             raise ValueError(
-                "No observed data is available. Use `potential_fn.set_x(x_o)`."
+                "No observed data is available. Use `potential_fn.bind(x_o)`."
             )
+
+    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "BasePotential":
+        """Create new potential with x bound, without mutable state.
+
+        Args:
+            x_o: Observed data to bind.
+            x_is_iid: Whether x represents iid observations.
+
+        Returns:
+            New potential instance with x bound.
+
+        Subclasses must implement this method.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement bind()")
 
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
@@ -151,3 +165,12 @@ class CustomPotentialWrapper(BasePotential):
         """
         with torch.set_grad_enabled(track_gradients):
             return self.potential_fn(theta, self.x_o)
+
+    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "CustomPotentialWrapper":
+        """Create new potential with x bound, without mutable state."""
+        return CustomPotentialWrapper(
+            potential_fn=self.potential_fn,
+            prior=self.prior,
+            x_o=x_o,
+            device=self.device,
+        )

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -19,6 +19,7 @@ from sbi.neural_nets.estimators.shape_handling import (
 )
 from sbi.sbi_types import TorchTransform
 from sbi.utils.sbiutils import mcmc_transform
+from sbi.utils.user_input_checks import process_x
 
 
 def likelihood_estimator_based_potential(
@@ -102,7 +103,9 @@ class LikelihoodBasedPotential(BasePotential):
             x_o=None,
             device=self.device,
         )
-        bound.set_x(x_o, x_is_iid=x_is_iid)
+        x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
         return bound
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -94,6 +94,17 @@ class LikelihoodBasedPotential(BasePotential):
         self.likelihood_estimator.to(device)
         return self
 
+    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "LikelihoodBasedPotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = LikelihoodBasedPotential(
+            likelihood_estimator=self.likelihood_estimator,
+            prior=self.prior,
+            x_o=None,
+            device=self.device,
+        )
+        bound.set_x(x_o, x_is_iid=x_is_iid)
+        return bound
+
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential $\log(p(x_o|\theta)p(\theta))$.
 

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -95,15 +95,26 @@ class LikelihoodBasedPotential(BasePotential):
         self.likelihood_estimator.to(device)
         return self
 
-    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "LikelihoodBasedPotential":
-        """Create new potential with x bound, without mutable state."""
+    def bind(
+        self, x_o: Optional[Tensor], x_is_iid: bool = True
+    ) -> "LikelihoodBasedPotential":
+        """Create new potential with x bound, without mutable state.
+
+        Args:
+            x_o: Observed data to bind.
+            x_is_iid: Whether x_o is a batch of iid observations.
+
+        Returns:
+            A new LikelihoodBasedPotential with x_o bound.
+        """
         bound = LikelihoodBasedPotential(
             likelihood_estimator=self.likelihood_estimator,
             prior=self.prior,
             x_o=None,
             device=self.device,
         )
-        x_o = process_x(x_o).to(self.device)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
         bound._x_o = x_o
         bound._x_is_iid = x_is_iid
         return bound

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -100,6 +100,17 @@ class PosteriorBasedPotential(BasePotential):
         self.posterior_estimator.to(device)
         return self
 
+    def bind(self, x_o: Tensor, x_is_iid: bool = False) -> "PosteriorBasedPotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = PosteriorBasedPotential(
+            posterior_estimator=self.posterior_estimator,
+            prior=self.prior,
+            x_o=None,
+            device=self.device,
+        )
+        bound.set_x(x_o, x_is_iid=x_is_iid)
+        return bound
+
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = False):
         """
         Check the shape of the observed data and, if valid, set it.

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -85,6 +85,7 @@ class PosteriorBasedPotential(BasePotential):
             The potential function.
         """
         super().__init__(prior, x_o, device)
+        self._x_is_iid = False
         self.posterior_estimator = posterior_estimator
         self.posterior_estimator.eval()
 
@@ -101,7 +102,9 @@ class PosteriorBasedPotential(BasePotential):
         self.posterior_estimator.to(device)
         return self
 
-    def bind(self, x_o: Tensor, x_is_iid: bool = False) -> "PosteriorBasedPotential":
+    def bind(
+        self, x_o: Optional[Tensor], x_is_iid: bool = False
+    ) -> "PosteriorBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = PosteriorBasedPotential(
             posterior_estimator=self.posterior_estimator,
@@ -109,7 +112,8 @@ class PosteriorBasedPotential(BasePotential):
             x_o=None,
             device=self.device,
         )
-        x_o = process_x(x_o).to(self.device)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
         bound._x_o = x_o
         bound._x_is_iid = x_is_iid
         return bound

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -115,13 +115,22 @@ class PosteriorBasedPotential(BasePotential):
         return bound
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = False):
+        """Check the shape of the observed data and, if valid, set it.
+
+        DEPRECATED: Use bind() instead. This method delegates to bind() internally.
+        It will be removed in a future release.
         """
-        Check the shape of the observed data and, if valid, set it.
-        """
-        if x_o is not None:
-            x_o = process_x(x_o).to(self.device)
-        self._x_o = x_o
-        self._x_is_iid = x_is_iid
+        import warnings
+
+        warnings.warn(
+            "set_x() is deprecated and will be removed in a future release. "
+            "Use bind() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        bound = self.bind(x_o, x_is_iid=x_is_iid)
+        self._x_o = bound._x_o
+        self._x_is_iid = bound._x_is_iid
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential for posterior-based methods.

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -21,6 +21,7 @@ from sbi.utils.sbiutils import (
     within_support,
 )
 from sbi.utils.torchutils import ensure_theta_batched, infer_module_device
+from sbi.utils.user_input_checks import process_x
 
 
 def posterior_estimator_based_potential(
@@ -108,14 +109,19 @@ class PosteriorBasedPotential(BasePotential):
             x_o=None,
             device=self.device,
         )
-        bound.set_x(x_o, x_is_iid=x_is_iid)
+        x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
         return bound
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = False):
         """
         Check the shape of the observed data and, if valid, set it.
         """
-        super().set_x(x_o, x_is_iid=x_is_iid)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
+        self._x_o = x_o
+        self._x_is_iid = x_is_iid
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential for posterior-based methods.

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -82,6 +82,17 @@ class RatioBasedPotential(BasePotential):
         self.ratio_estimator.to(device)
         return self
 
+    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "RatioBasedPotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = RatioBasedPotential(
+            ratio_estimator=self.ratio_estimator,
+            prior=self.prior,
+            x_o=None,
+            device=self.device,
+        )
+        bound.set_x(x_o, x_is_iid=x_is_iid)
+        return bound
+
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
         r"""Returns the potential for likelihood-ratio-based methods.
 

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -83,7 +83,9 @@ class RatioBasedPotential(BasePotential):
         self.ratio_estimator.to(device)
         return self
 
-    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "RatioBasedPotential":
+    def bind(
+        self, x_o: Optional[Tensor], x_is_iid: bool = True
+    ) -> "RatioBasedPotential":
         """Create new potential with x bound, without mutable state."""
         bound = RatioBasedPotential(
             ratio_estimator=self.ratio_estimator,
@@ -91,7 +93,8 @@ class RatioBasedPotential(BasePotential):
             x_o=None,
             device=self.device,
         )
-        x_o = process_x(x_o).to(self.device)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
         bound._x_o = x_o
         bound._x_is_iid = x_is_iid
         return bound

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -11,6 +11,7 @@ from sbi.inference.potentials.base_potential import BasePotential
 from sbi.sbi_types import TorchTransform
 from sbi.utils.sbiutils import match_theta_and_x_batch_shapes, mcmc_transform
 from sbi.utils.torchutils import atleast_2d
+from sbi.utils.user_input_checks import process_x
 
 
 def ratio_estimator_based_potential(
@@ -90,7 +91,9 @@ class RatioBasedPotential(BasePotential):
             x_o=None,
             device=self.device,
         )
-        bound.set_x(x_o, x_is_iid=x_is_iid)
+        x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
         return bound
 
     def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import warnings
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import torch
@@ -114,6 +115,8 @@ class VectorFieldBasedPotential(BasePotential):
 
         Rebuilds the continuous normalizing flow if the observed data is set.
 
+        DEPRECATED: Use bind() instead. This method delegates to bind() internally.
+        It will be removed in a future release.
         Args:
             x_o: The observed data.
             x_is_iid: Whether the observed data is IID (if batch_dim>1).
@@ -123,31 +126,32 @@ class VectorFieldBasedPotential(BasePotential):
                 `IIDScoreFunction`.
             ode_kwargs: Additional keyword arguments for the neural ODE.
         """
-        # IID and guidance require transforming the prior to standardized space.
-        if self.vector_field_estimator.compose_enabled:
-            if x_is_iid:
-                raise NotImplementedError(
-                    "compose_standardization does not yet support iid (x with "
-                    "batch>1). Use a single observation, or disable "
-                    "compose_standardization."
-                )
-            if guidance_method is not None:
-                raise NotImplementedError(
-                    "compose_standardization does not yet support guided sampling. "
-                    "Disable guidance, or disable compose_standardization."
-                )
-        if x_o is not None:
-            x_o = process_x(x_o).to(self.device)
-        self._x_o = x_o
-        self._x_is_iid = x_is_iid
-        self.iid_method = iid_method or self.iid_method
-        self.iid_params = iid_params
-        self.guidance_method = guidance_method
-        self.guidance_params = guidance_params
-        if not x_is_iid and (self._x_o is not None):
-            self.flow = self.rebuild_flow(**ode_kwargs)
-        elif self._x_o is not None:
-            self.flows = self.rebuild_flows_for_batch(**ode_kwargs)
+
+        warnings.warn(
+            "set_x() is deprecated and will be removed in a future release. "
+            "Use bind() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        bound = self.bind(
+            x_o,
+            x_is_iid=x_is_iid,
+            iid_method=iid_method,
+            iid_params=iid_params,
+            guidance_method=guidance_method,
+            guidance_params=guidance_params,
+            **ode_kwargs,
+        )
+        self._x_o = bound._x_o
+        self._x_is_iid = bound._x_is_iid
+        self.iid_method = bound.iid_method
+        self.iid_params = bound.iid_params
+        self.guidance_method = bound.guidance_method
+        self.guidance_params = bound.guidance_params
+        if not x_is_iid and (bound._x_o is not None):
+            self.flow = bound.flow
+        elif bound._x_o is not None:
+            self.flows = bound.flows
 
     def bind(
         self,

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -61,6 +61,7 @@ class VectorFieldBasedPotential(BasePotential):
         self.vector_field_estimator.eval()
         self.iid_method = iid_method
         self.iid_params = iid_params
+        self.neural_ode_backend = neural_ode_backend
 
         neural_ode_kwargs = neural_ode_kwargs or {}
         self.neural_ode = build_neural_ode(
@@ -141,6 +142,40 @@ class VectorFieldBasedPotential(BasePotential):
             self.flow = self.rebuild_flow(**ode_kwargs)
         elif self._x_o is not None:
             self.flows = self.rebuild_flows_for_batch(**ode_kwargs)
+
+    def bind(
+        self,
+        x_o: Tensor,
+        x_is_iid: bool = False,
+        iid_method: Optional[str] = None,
+        iid_params: Optional[Dict[str, Any]] = None,
+        guidance_method: Optional[str] = None,
+        guidance_params: Optional[Dict[str, Any]] = None,
+        **ode_kwargs,
+    ) -> "VectorFieldBasedPotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = VectorFieldBasedPotential(
+            vector_field_estimator=self.vector_field_estimator,
+            prior=self.prior,
+            x_o=None,
+            device=self.device,
+            iid_method=self.iid_method,
+            iid_params=self.iid_params,
+            neural_ode_backend=self.neural_ode_backend,
+        )
+        bound.neural_ode.params.update(self.neural_ode.params)
+        # Transfer learned neural ODE parameters (e.g., from training) to the bound
+        # potential. This preserves the trained flow model when conditioning on new x.
+        bound.set_x(
+            x_o,
+            x_is_iid=x_is_iid,
+            iid_method=iid_method,
+            iid_params=iid_params,
+            guidance_method=guidance_method,
+            guidance_params=guidance_params,
+            **ode_kwargs,
+        )
+        return bound
 
     def __call__(
         self,

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -22,6 +22,7 @@ from sbi.samplers.ode_solvers import build_neural_ode
 from sbi.sbi_types import TorchTransform
 from sbi.utils.sbiutils import mcmc_transform, within_support
 from sbi.utils.torchutils import ensure_theta_batched, process_device
+from sbi.utils.user_input_checks import process_x
 
 
 class VectorFieldBasedPotential(BasePotential):
@@ -61,6 +62,8 @@ class VectorFieldBasedPotential(BasePotential):
         self.vector_field_estimator.eval()
         self.iid_method = iid_method
         self.iid_params = iid_params
+        self.guidance_method: Optional[str] = None
+        self.guidance_params: Optional[Dict[str, Any]] = None
         self.neural_ode_backend = neural_ode_backend
 
         neural_ode_kwargs = neural_ode_kwargs or {}
@@ -133,7 +136,10 @@ class VectorFieldBasedPotential(BasePotential):
                     "compose_standardization does not yet support guided sampling. "
                     "Disable guidance, or disable compose_standardization."
                 )
-        super().set_x(x_o, x_is_iid)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
+        self._x_o = x_o
+        self._x_is_iid = x_is_iid
         self.iid_method = iid_method or self.iid_method
         self.iid_params = iid_params
         self.guidance_method = guidance_method
@@ -159,22 +165,24 @@ class VectorFieldBasedPotential(BasePotential):
             prior=self.prior,
             x_o=None,
             device=self.device,
-            iid_method=self.iid_method,
-            iid_params=self.iid_params,
+            iid_method=iid_method if iid_method is not None else self.iid_method,
+            iid_params=iid_params if iid_params is not None else self.iid_params,
             neural_ode_backend=self.neural_ode_backend,
         )
         bound.neural_ode.params.update(self.neural_ode.params)
-        # Transfer learned neural ODE parameters (e.g., from training) to the bound
-        # potential. This preserves the trained flow model when conditioning on new x.
-        bound.set_x(
-            x_o,
-            x_is_iid=x_is_iid,
-            iid_method=iid_method,
-            iid_params=iid_params,
-            guidance_method=guidance_method,
-            guidance_params=guidance_params,
-            **ode_kwargs,
+        x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
+        bound.guidance_method = (
+            guidance_method if guidance_method is not None else self.guidance_method
         )
+        bound.guidance_params = (
+            guidance_params if guidance_params is not None else self.guidance_params
+        )
+        if not x_is_iid and (bound._x_o is not None):
+            bound.flow = bound.rebuild_flow(**ode_kwargs)
+        elif bound._x_o is not None:
+            bound.flows = bound.rebuild_flows_for_batch(**ode_kwargs)
         return bound
 
     def __call__(

--- a/sbi/inference/potentials/vector_field_potential.py
+++ b/sbi/inference/potentials/vector_field_potential.py
@@ -81,6 +81,9 @@ class VectorFieldBasedPotential(BasePotential):
         )
 
         super().__init__(prior, x_o, device=device)
+        self._x_is_iid = False
+        if self._x_o is not None:
+            self.flow = self.rebuild_flow()
 
     def to(self, device: Union[str, torch.device]) -> None:
         """
@@ -155,7 +158,7 @@ class VectorFieldBasedPotential(BasePotential):
 
     def bind(
         self,
-        x_o: Tensor,
+        x_o: Optional[Tensor],
         x_is_iid: bool = False,
         iid_method: Optional[str] = None,
         iid_params: Optional[Dict[str, Any]] = None,
@@ -164,25 +167,35 @@ class VectorFieldBasedPotential(BasePotential):
         **ode_kwargs,
     ) -> "VectorFieldBasedPotential":
         """Create new potential with x bound, without mutable state."""
+        # IID and guidance require transforming the prior to standardized space.
+        if self.vector_field_estimator.compose_enabled:
+            if x_is_iid:
+                raise NotImplementedError(
+                    "compose_standardization does not yet support iid (x with "
+                    "batch>1). Use a single observation, or disable "
+                    "compose_standardization."
+                )
+            if guidance_method is not None:
+                raise NotImplementedError(
+                    "compose_standardization does not yet support guided sampling. "
+                    "Disable guidance, or disable compose_standardization."
+                )
         bound = VectorFieldBasedPotential(
             vector_field_estimator=self.vector_field_estimator,
             prior=self.prior,
             x_o=None,
             device=self.device,
             iid_method=iid_method if iid_method is not None else self.iid_method,
-            iid_params=iid_params if iid_params is not None else self.iid_params,
+            iid_params=iid_params,
             neural_ode_backend=self.neural_ode_backend,
         )
         bound.neural_ode.params.update(self.neural_ode.params)
-        x_o = process_x(x_o).to(self.device)
+        if x_o is not None:
+            x_o = process_x(x_o).to(self.device)
         bound._x_o = x_o
         bound._x_is_iid = x_is_iid
-        bound.guidance_method = (
-            guidance_method if guidance_method is not None else self.guidance_method
-        )
-        bound.guidance_params = (
-            guidance_params if guidance_params is not None else self.guidance_params
-        )
+        bound.guidance_method = guidance_method
+        bound.guidance_params = guidance_params
         if not x_is_iid and (bound._x_o is not None):
             bound.flow = bound.rebuild_flow(**ode_kwargs)
         elif bound._x_o is not None:

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -478,7 +478,7 @@ class ElboOptimizer(DivergenceOptimizer):
             samples = self.q.rsample(torch.Size((num_samples,)))
             log_q = self.q.log_prob(samples)
 
-        self.potential_fn.x_o = x_o
+        self.potential_fn.set_x(x_o)
         log_potential = self.potential_fn(samples)
         elbo = log_potential - log_q
         return elbo
@@ -635,7 +635,7 @@ class ForwardKLOptimizer(DivergenceOptimizer):
         if hasattr(self.q, "clear_cache"):
             self.q.clear_cache()
         logq = self.q.log_prob(samples)
-        self.potential_fn.x_o = x_o
+        self.potential_fn.set_x(x_o)
         logp = self.potential_fn(samples)
         with torch.no_grad():
             logweights = logp - logq

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -478,7 +478,7 @@ class ElboOptimizer(DivergenceOptimizer):
             samples = self.q.rsample(torch.Size((num_samples,)))
             log_q = self.q.log_prob(samples)
 
-        self.potential_fn.set_x(x_o)
+        self.potential_fn = self.potential_fn.bind(x_o)
         log_potential = self.potential_fn(samples)
         elbo = log_potential - log_q
         return elbo
@@ -635,7 +635,7 @@ class ForwardKLOptimizer(DivergenceOptimizer):
         if hasattr(self.q, "clear_cache"):
             self.q.clear_cache()
         logq = self.q.log_prob(samples)
-        self.potential_fn.set_x(x_o)
+        self.potential_fn = self.potential_fn.bind(x_o)
         logp = self.potential_fn(samples)
         with torch.no_grad():
             logweights = logp - logq

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -408,11 +408,13 @@ class ConditionedPotential(BasePotential):
     def x_is_iid(self) -> bool:
         """If x has batch dimension greater than 1, whether to intepret the batch as iid
         samples or batch of data points."""
-        if self._x_is_iid is not None:
+        if hasattr(self, "_x_is_iid") and self._x_is_iid is not None:
             return self._x_is_iid
+        elif hasattr(self, "potential_fn") and self.potential_fn is not None:
+            return self.potential_fn.x_is_iid
         else:
             raise ValueError(
-                "No observed data is available. Use `potential_fn.set_x(x_o)`."
+                "No observed data is available. Use `potential_fn.bind(x_o)`."
             )
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = True):
@@ -420,7 +422,17 @@ class ConditionedPotential(BasePotential):
         if x_o is not None:
             x_o = process_x(x_o).to(self.device)
         self._x_is_iid = x_is_iid
-        self.potential_fn.set_x(x_o, x_is_iid=x_is_iid)
+        self.potential_fn = self.potential_fn.bind(x_o, x_is_iid=x_is_iid)
+
+    def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "ConditionedPotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = ConditionedPotential(
+            potential_fn=self.potential_fn.bind(x_o, x_is_iid),
+            condition=self.condition,
+            dims_to_sample=self.dims_to_sample,
+        )
+        bound._x_is_iid = x_is_iid
+        return bound
 
     @property
     def x_o(self) -> Tensor:

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -430,11 +430,6 @@ class ConditionedPotential(BasePotential):
         else:
             raise ValueError("No observed data is available.")
 
-    @x_o.setter
-    def x_o(self, x_o: Optional[Tensor]) -> None:
-        """Check the shape of the observed data and, if valid, set it."""
-        self.set_x(x_o)
-
     def return_x_o(self) -> Optional[Tensor]:
         """Return the observed data at which the potential is evaluated.
 

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -15,7 +15,6 @@ from sbi.neural_nets.estimators.mixture_density_estimator import (
     MixtureDensityEstimator,
 )
 from sbi.utils.torchutils import ensure_theta_batched
-from sbi.utils.user_input_checks import process_x
 
 
 def compute_corrcoeff(probs: Tensor, limits: Tensor):
@@ -418,11 +417,20 @@ class ConditionedPotential(BasePotential):
             )
 
     def set_x(self, x_o: Optional[Tensor], x_is_iid: Optional[bool] = True):
-        """Check the shape of the observed data and, if valid, set it."""
-        if x_o is not None:
-            x_o = process_x(x_o).to(self.device)
-        self._x_is_iid = x_is_iid
-        self.potential_fn = self.potential_fn.bind(x_o, x_is_iid=x_is_iid)
+        """Check the shape of the observed data and, if valid, set it.
+
+        DEPRECATED: Use bind() instead. This method delegates to bind() internally.
+        """
+        import warnings
+
+        warnings.warn(
+            "set_x() is deprecated, use bind() instead",
+            FutureWarning,
+            stacklevel=2,
+        )
+        bound = self.bind(x_o, x_is_iid=x_is_iid)
+        self._x_is_iid = bound._x_is_iid
+        self.potential_fn = bound.potential_fn
 
     def bind(self, x_o: Tensor, x_is_iid: bool = True) -> "ConditionedPotential":
         """Create new potential with x bound, without mutable state."""

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -777,13 +777,14 @@ def _base_recursor(
         _active: Object identities on the active recursion path. Used internally
             to avoid infinite recursion in cyclic object graphs.
     """
-    if _active is None:
-        _active = set()
+    _active_holder: Optional[set[int]] = _active
+    if _active_holder is None:
+        _active_holder = set()
 
     obj_id = id(obj)
-    if obj_id in _active:
+    if obj_id in _active_holder:
         return
-    _active.add(obj_id)
+    _active_holder.add(obj_id)
 
     if isinstance(obj, Module) and check(obj):
         action(obj)
@@ -798,7 +799,7 @@ def _base_recursor(
                     key=k,
                     check=check,
                     action=action,
-                    _active=_active,
+                    _active=_active_holder,
                 )
     elif isinstance(obj, type):
         # Skip class/type objects to avoid modifying immutable C extension types
@@ -815,7 +816,7 @@ def _base_recursor(
                     key=k,
                     check=check,
                     action=action,
-                    _active=_active,
+                    _active=_active_holder,
                 )
     elif isinstance(obj, (List, Tuple, Generator)):
         new_obj = []
@@ -823,12 +824,12 @@ def _base_recursor(
             if check(o):
                 new_obj.append(action(o))
             else:
-                _base_recursor(o, check=check, action=action, _active=_active)
+                _base_recursor(o, check=check, action=action, _active=_active_holder)
                 new_obj.append(o)
         if parent is not None and key is not None:
             setattr(parent, key, type(obj)(new_obj))  # type: ignore
 
-    _active.remove(obj_id)
+    _active_holder.remove(obj_id)
 
 
 def move_all_tensor_to_device(obj: object, device: Union[str, torch.device]) -> None:

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -192,6 +192,8 @@ class PytorchReturnTypeWrapper(Distribution):
         if validate_args is not None:
             set_validate_args(prior, validate_args)
 
+        self.device = None
+        self.return_type = return_type
         super().__init__(
             batch_shape=batch_shape,
             event_shape=event_shape,
@@ -199,9 +201,6 @@ class PytorchReturnTypeWrapper(Distribution):
                 prior._validate_args if validate_args is None else validate_args
             ),
         )
-
-        self.device = None
-        self.return_type = return_type
 
     def log_prob(self, value) -> Tensor:
         return torch.as_tensor(

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -413,6 +413,7 @@ def test_vi_on_gpu(num_dim: int, q: str, vi_method: str):
 
         def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
             """Create new potential with x bound, without mutable state."""
+
             bound = FakePotential(prior=self.prior, device=self.device)
             x_o = process_x(x_o).to(self.device)
             bound._x_o = x_o
@@ -475,6 +476,7 @@ def test_amortized_vi_on_gpu(num_dim: int, flow_type: str):
 
         def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
             """Create new potential with x bound, without mutable state."""
+
             bound = FakePotential(prior=self.prior, device=self.device)
             x_o = process_x(x_o).to(self.device)
             bound._x_o = x_o
@@ -795,8 +797,8 @@ def test_to_method_on_npe_posteriors(trained_npe_for_device_test, posterior_para
     assert sample_device.device.type == device.split(":")[0], (
         f"sample was not correctly moved to {device}."
     )
-    posterior.potential_fn.set_x(x_o)
-    potential_values = posterior.potential_fn(sample_device)
+    bound_potential = posterior.potential_fn.bind(x_o)
+    potential_values = bound_potential(sample_device)
     assert potential_values.device.type == device.split(":")[0], (
         f"potential was not correctly evaluated on {device}."
     )

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -411,6 +411,12 @@ def test_vi_on_gpu(num_dim: int, q: str, vi_method: str):
         def allow_iid_x(self) -> bool:
             return True
 
+        def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
+            """Create new potential with x bound, without mutable state."""
+            bound = FakePotential(prior=self.prior, device=self.device)
+            bound.set_x(x_o, x_is_iid=x_is_iid)
+            return bound
+
     potential_fn = FakePotential(
         prior=MultivariateNormal(
             zeros(num_dim, device=device), eye(num_dim, device=device)
@@ -464,6 +470,12 @@ def test_amortized_vi_on_gpu(num_dim: int, flow_type: str):
 
         def allow_iid_x(self) -> bool:
             return True
+
+        def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
+            """Create new potential with x bound, without mutable state."""
+            bound = FakePotential(prior=self.prior, device=self.device)
+            bound.set_x(x_o, x_is_iid=x_is_iid)
+            return bound
 
     potential_fn = FakePotential(prior=prior, device=device)
 

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -52,7 +52,7 @@ from sbi.simulators.linear_gaussian import diagonal_linear_gaussian, linear_gaus
 from sbi.utils import BoxUniform
 from sbi.utils.sbiutils import seed_all_backends
 from sbi.utils.torchutils import gpu_available, process_device
-from sbi.utils.user_input_checks import validate_theta_and_x
+from sbi.utils.user_input_checks import process_x, validate_theta_and_x
 from tests.test_utils import mps_fallback_disabled
 
 pytestmark = pytest.mark.skipif(
@@ -414,7 +414,9 @@ def test_vi_on_gpu(num_dim: int, q: str, vi_method: str):
         def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
             """Create new potential with x bound, without mutable state."""
             bound = FakePotential(prior=self.prior, device=self.device)
-            bound.set_x(x_o, x_is_iid=x_is_iid)
+            x_o = process_x(x_o).to(self.device)
+            bound._x_o = x_o
+            bound._x_is_iid = x_is_iid
             return bound
 
     potential_fn = FakePotential(
@@ -474,7 +476,9 @@ def test_amortized_vi_on_gpu(num_dim: int, flow_type: str):
         def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
             """Create new potential with x bound, without mutable state."""
             bound = FakePotential(prior=self.prior, device=self.device)
-            bound.set_x(x_o, x_is_iid=x_is_iid)
+            x_o = process_x(x_o).to(self.device)
+            bound._x_o = x_o
+            bound._x_is_iid = x_is_iid
             return bound
 
     potential_fn = FakePotential(prior=prior, device=device)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -685,7 +685,7 @@ def test_sample_conditional(mcmc_params_accurate: MCMCPosteriorParameters):
         condition=samples[0],
         dims_to_sample=[dim_to_sample_1, dim_to_sample_2],
     )
-    conditioned_potential_fn.set_x(x_o, x_is_iid=False)
+    conditioned_potential_fn = conditioned_potential_fn.bind(x_o, x_is_iid=False)
     mcmc_posterior = MCMCPosterior(
         potential_fn=conditioned_potential_fn,
         theta_transform=restricted_tf,

--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -583,7 +583,7 @@ def test_sample_conditional():
         condition=samples[0],
         dims_to_sample=[dim_to_sample_1, dim_to_sample_2],
     )
-    conditioned_potential_fn.set_x(x_o, x_is_iid=False)
+    conditioned_potential_fn = conditioned_potential_fn.bind(x_o, x_is_iid=False)
     mcmc_posterior = MCMCPosterior(
         potential_fn=conditioned_potential_fn,
         theta_transform=restricted_tf,

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -516,7 +516,7 @@ def test_posterior_based_potential_iid_log_prob(iid_batch_size: int):
     potential_fn, _ = posterior_estimator_based_potential(
         posterior_estimator, prior, x_o=None
     )
-    potential_fn.set_x(x_o, x_is_iid=True)
+    potential_fn = potential_fn.bind(x_o, x_is_iid=True)
 
     posterior_samples = true_posterior.sample((num_posterior_samples,))
     true_prob = true_posterior.log_prob(posterior_samples)

--- a/tests/potential_test.py
+++ b/tests/potential_test.py
@@ -16,8 +16,15 @@ from sbi.inference import (
     RejectionPosterior,
     VIPosterior,
 )
+from sbi.inference.posteriors.ensemble_posterior import EnsemblePotential
 from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters
-from sbi.inference.potentials.base_potential import CustomPotentialWrapper
+from sbi.inference.potentials.base_potential import (
+    BasePotential,
+    CustomPotentialWrapper,
+)
+from sbi.inference.potentials.posterior_based_potential import PosteriorBasedPotential
+from sbi.inference.potentials.vector_field_potential import VectorFieldBasedPotential
+from sbi.neural_nets import posterior_nn, posterior_score_nn
 from sbi.utils import BoxUniform
 from sbi.utils.conditional_density_utils import ConditionedPotential
 
@@ -94,3 +101,111 @@ def test_conditioned_potential(condition: Tensor):
     )
 
     ConditionedPotential(potential_fn, condition=condition, dims_to_sample=[0])
+
+
+def _build_potential(potential_type: str, x_o: Tensor | None = None) -> BasePotential:
+    """Build a small untrained potential of the given type."""
+    prior = BoxUniform(zeros(2), ones(2))
+    theta = prior.sample((20,))
+    x = torch.randn(20, 2)
+
+    if potential_type == "posterior":
+        return PosteriorBasedPotential(posterior_nn("mdn")(theta, x), prior, x_o=x_o)
+    return VectorFieldBasedPotential(posterior_score_nn()(theta, x), prior, x_o=x_o)
+
+
+@pytest.mark.parametrize("potential_type", ("posterior", "vector_field"))
+def test_bind_preserves_estimator(potential_type: str):
+    """Test that bind() returns a potential holding the same estimator object.
+
+    The planned x_o NaN-tolerance derivation (ADR 0001) reads the embedding net
+    that consumes x through the potential's estimator. A bind() that re-threads
+    state by hand and drops or copies the estimator would silently change the
+    derived tolerance on the bound potential.
+    """
+    potential = _build_potential(potential_type)
+    bound = potential.bind(zeros(1, 2))
+
+    if potential_type == "posterior":
+        assert bound.posterior_estimator is potential.posterior_estimator
+    else:
+        assert bound.vector_field_estimator is potential.vector_field_estimator
+
+    assert bound is not potential
+    assert bound.x_o is not None
+
+
+@pytest.mark.parametrize("potential_type", ("posterior", "vector_field"))
+def test_potential_with_x_o_at_construction(potential_type: str):
+    """Test that x_o passed to the constructor behaves like a later bind()."""
+    potential = _build_potential(potential_type, x_o=zeros(1, 2))
+
+    assert potential.x_is_iid is False
+    assert torch.isfinite(potential(zeros(1, 2))).all()
+
+
+def test_base_bind_default_for_custom_potentials():
+    """Test that a subclass overriding only __call__ survives bind()."""
+
+    class QuadraticPotential(BasePotential):
+        def __call__(self, theta: Tensor, track_gradients: bool = True) -> Tensor:
+            return -(theta**2).sum(-1)
+
+    potential = QuadraticPotential(prior=BoxUniform(zeros(2), ones(2)))
+    bound = potential.bind(zeros(1, 2))
+
+    assert bound is not potential
+    assert bound.prior is potential.prior
+    assert torch.equal(bound.x_o, zeros(1, 2))
+    assert torch.equal(bound(ones(3, 2)), -2 * ones(3))
+
+
+def test_bind_clears_guidance_by_default():
+    """Test that bind() without guidance args clears guidance, like set_x did."""
+    potential = _build_potential("vector_field")
+
+    guided = potential.bind(
+        zeros(1, 2), guidance_method="classifier_free", guidance_params={"scale": 2.0}
+    )
+    assert guided.guidance_method == "classifier_free"
+
+    rebound = guided.bind(zeros(1, 2))
+    assert rebound.guidance_method is None
+    assert rebound.guidance_params is None
+
+
+def test_ensemble_bind_and_construction_respect_components():
+    """Test that the ensemble binds its components and keeps their iid defaults."""
+    components = [_build_potential("posterior") for _ in range(2)]
+    prior = components[0].prior
+    ensemble = EnsemblePotential(
+        potential_fns=components,
+        weights=torch.tensor([0.5, 0.5]),
+        prior=prior,
+        x_o=None,
+    )
+
+    bound = ensemble.bind(zeros(1, 2))
+    assert all(p.x_is_iid is False for p in bound.potential_fns)
+
+    bound_iid = ensemble.bind(zeros(1, 2), x_is_iid=True)
+    assert all(p.x_is_iid is True for p in bound_iid.potential_fns)
+
+    constructed = EnsemblePotential(
+        potential_fns=components,
+        weights=torch.tensor([0.5, 0.5]),
+        prior=prior,
+        x_o=zeros(1, 2),
+    )
+    assert all(p.return_x_o() is not None for p in constructed.potential_fns)
+    assert torch.isfinite(constructed(zeros(1, 2))).all()
+
+
+def test_set_x_none_clears_observation():
+    """Test that set_x(None) clears the observation, as it did before bind()."""
+    bound = _build_potential("vector_field").bind(zeros(1, 2))
+    assert bound.return_x_o() is not None
+
+    with pytest.warns(FutureWarning):
+        bound.set_x(None)
+    assert bound.return_x_o() is None

--- a/tests/rejection_sampling_test.py
+++ b/tests/rejection_sampling_test.py
@@ -87,7 +87,7 @@ def test_reject_outside_prior_support_behavior():
         def __call__(self, theta, x_o=None):
             return torch.zeros(theta.shape[0])
 
-        def set_x(self, x):
+        def bind(self, x_o, x_is_iid=True):
             pass
 
         def to(self, device):

--- a/tests/rejection_sampling_test.py
+++ b/tests/rejection_sampling_test.py
@@ -88,7 +88,7 @@ def test_reject_outside_prior_support_behavior():
             return torch.zeros(theta.shape[0])
 
         def bind(self, x_o, x_is_iid=True):
-            pass
+            return self
 
         def to(self, device):
             self.device = device

--- a/tests/score_samplers_test.py
+++ b/tests/score_samplers_test.py
@@ -67,10 +67,10 @@ def test_score_fn_iid_on_different_priors(sde_type, iid_method, num_dim):
 
     priors = build_random_priors(num_dim)
     x_o_iid = torch.ones((5, 1))
-    score_fn.set_x(x_o_iid, x_is_iid=True, iid_method=iid_method)
+    score_fn = score_fn.bind(x_o_iid, x_is_iid=True, iid_method=iid_method)
     inputs = torch.ones((1, 1, num_dim))
+    time = torch.ones(1)
     for prior in priors:
-        time = torch.ones(1)
         score_fn.prior = prior
         output = score_fn.gradient(inputs, time=time)
 
@@ -116,7 +116,9 @@ def test_score_fn_guidance_general(sde_type, guidance_method, num_dim):
     score_fn = _build_gaussian_score_estimator(sde_type, (num_dim,), mean0, std0)
     x_o = torch.ones((1, 1))
     guidance_name, guidance_params = guidance_method
-    score_fn.set_x(x_o, guidance_method=guidance_name, guidance_params=guidance_params)
+    score_fn = score_fn.bind(
+        x_o, guidance_method=guidance_name, guidance_params=guidance_params
+    )
     inputs = torch.ones((1, 1, num_dim))
     time = torch.ones(1)
 
@@ -149,7 +151,7 @@ def test_score_fn_combined_guidance_and_iid(sde_type, iid_method, guidance_metho
 
     x_o_iid = torch.ones((5, 1))
     guidance_name, guidance_params = guidance_method
-    score_fn.set_x(
+    score_fn = score_fn.bind(
         x_o_iid,
         x_is_iid=True,
         iid_method=iid_method,

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -58,6 +58,12 @@ class FakePotential(BasePotential):
     def allow_iid_x(self) -> bool:
         return True
 
+    def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
+        """Create new potential with x bound, without mutable state."""
+        bound = FakePotential(prior=self.prior, device=self.device)
+        bound.set_x(x_o, x_is_iid=x_is_iid)
+        return bound
+
 
 def make_tractable_potential(target_distribution, prior):
     """Create a potential function from a known target distribution."""
@@ -70,6 +76,14 @@ def make_tractable_potential(target_distribution, prior):
 
         def allow_iid_x(self) -> bool:
             return True
+
+        def bind(
+            self, x_o: torch.Tensor, x_is_iid: bool = True
+        ) -> "TractablePotential":
+            """Create new potential with x bound, without mutable state."""
+            bound = TractablePotential(prior=self.prior, device=self.device)
+            bound.set_x(x_o, x_is_iid=x_is_iid)
+            return bound
 
     return TractablePotential(prior=prior)
 

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -61,6 +61,7 @@ class FakePotential(BasePotential):
 
     def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
         """Create new potential with x bound, without mutable state."""
+
         bound = FakePotential(prior=self.prior, device=self.device)
         x_o = process_x(x_o).to(self.device)
         bound._x_o = x_o
@@ -84,6 +85,7 @@ def make_tractable_potential(target_distribution, prior):
             self, x_o: torch.Tensor, x_is_iid: bool = True
         ) -> "TractablePotential":
             """Create new potential with x bound, without mutable state."""
+
             bound = TractablePotential(prior=self.prior, device=self.device)
             x_o = process_x(x_o).to(self.device)
             bound._x_o = x_o

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -35,6 +35,7 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils import MultipleIndependent
 from sbi.utils.metrics import c2st, check_c2st
+from sbi.utils.user_input_checks import process_x
 
 # Supported variational families for VI
 FLOWS = ["maf", "nsf", "naf", "unaf", "nice", "sospf", "gaussian", "gaussian_diag"]
@@ -61,7 +62,9 @@ class FakePotential(BasePotential):
     def bind(self, x_o: torch.Tensor, x_is_iid: bool = True) -> "FakePotential":
         """Create new potential with x bound, without mutable state."""
         bound = FakePotential(prior=self.prior, device=self.device)
-        bound.set_x(x_o, x_is_iid=x_is_iid)
+        x_o = process_x(x_o).to(self.device)
+        bound._x_o = x_o
+        bound._x_is_iid = x_is_iid
         return bound
 
 
@@ -82,7 +85,9 @@ def make_tractable_potential(target_distribution, prior):
         ) -> "TractablePotential":
             """Create new potential with x bound, without mutable state."""
             bound = TractablePotential(prior=self.prior, device=self.device)
-            bound.set_x(x_o, x_is_iid=x_is_iid)
+            x_o = process_x(x_o).to(self.device)
+            bound._x_o = x_o
+            bound._x_is_iid = x_is_iid
             return bound
 
     return TractablePotential(prior=prior)


### PR DESCRIPTION
This PR ports @Jocho-Smith's Potentials API work from `gsoc-2026` onto `main` (#1937, #1943, #1945, #1946, #1948). The cherry-picks keep his authorship. Future work can build
on `main` before the GSoC final evaluation.

What the port brings:

- `bind(x_o)` returns a new potential with the observation bound. It replaces the
  mutable `set_x()` at every internal call site.
- `set_x()` is deprecated. It warns with `FutureWarning` and delegates to `bind()`.
  The warning ships with the next release.
- `x_o` has no public setter anymore.

On top of his commits, one commit with the net changes needed on `main`:

- The `compose_standardization` guard moved from `set_x()` into `bind()`, which is
  the chokepoint now.
- The subclass constructors set their own iid default and build the flow when `x_o`
  is given. `__init__` no longer dispatches through `set_x()`, so this happens
  explicitly.
- `BasePotential.bind()` has a copy-based default. A custom potential that only
  overrides `__call__` keeps working with all samplers.
- `bind()` overwrites `guidance_method`, `guidance_params`, and `iid_params`.
  `None` clears, like `set_x` on `main`. Without this, guidance is sticky and
  `log_prob()` fails after a guided `sample()`. @Jocho-Smith — this changes your
  inherit-if-`None` semantics, please check that you agree.
- `EnsemblePotential` binds its components at construction, and its `bind()`
  forwards `x_is_iid` only when the caller sets it. Each component keeps its own
  default.
- `set_x(None)` and `bind(None)` clear the observation again.
- New tests in `tests/potential_test.py`: a contract test that `bind()` keeps the
  same estimator object (the planned NaN-tolerance derivation reads the embedding
  net through it), plus regression tests for the changes above.

Open question, @Jocho-Smith: `EnsemblePotential.bind()` and `ConditionedPotential.bind()` create new component potentials, but the enclosing
posteriors keep their old references. Under `set_x` both views shared one object. I think we need a decision on this sharing contract — no need to solve it in this PR.

Validation: full fast suite, targeted slow MNLE tests (custom potential through
MCMC), ruff, pyright, and pre-commit all pass.

The port was done with substantial AI assistance (Claude Code), supervised by me.

