### PR TITLE
docs: fix API ref links, add an estimators page, and correct docstrings

### DIFF
--- a/docs/advanced_tutorials.rst
+++ b/docs/advanced_tutorials.rst
@@ -11,7 +11,7 @@ Our advanced tutorials provide a detailed explanation of different methods. Thes
 tutorials are meant as further reading for power-users (or users who are particularly
 interested in a particular feature of ``sbi``), but they should not be required to
 successfully run ``sbi``. If you are looking for brief answers to specific questions,
-check our `how-to guide <https://sbi.readthedocs.io/en/latest/how_to_guide.html>`_.
+check our :doc:`how-to guide <how_to_guide>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/advanced_tutorials/03_density_estimators.ipynb
+++ b/docs/advanced_tutorials/03_density_estimators.ipynb
@@ -18,7 +18,7 @@
     "[`nflows`](https://github.com/bayesiains/nflows/) or [`zuko`](https://github.com/probabilists/zuko). \n",
     "\n",
     "For all options, check the API reference\n",
-    "[here](https://sbi.readthedocs.io/en/latest/sbi.html#neural-nets)."
+    "[here](https://sbi.readthedocs.io/en/latest/api_reference.html#neural-nets)."
    ]
   },
   {

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -10,6 +10,7 @@ API reference
 
    api_reference/prior_and_simulator
    api_reference/neural_nets
+   api_reference/estimators
    api_reference/embedding_nets
    api_reference/training
    api_reference/potentials
@@ -56,9 +57,12 @@ Estimators
    :nosignatures:
 
    sbi.neural_nets.estimators.ConditionalDensityEstimator
-   sbi.neural_nets.estimators.UnconditionalDensityEstimator
    sbi.neural_nets.estimators.ConditionalScoreEstimator
+   sbi.neural_nets.estimators.ConditionalVectorFieldEstimator
+   sbi.neural_nets.estimators.FlowMatchingEstimator
+   sbi.neural_nets.estimators.MixedDensityEstimator
    sbi.neural_nets.ratio_estimators.RatioEstimator
+   sbi.neural_nets.estimators.UnconditionalDensityEstimator
 
 
 Embedding nets

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -49,6 +49,18 @@ Neural nets
    sbi.neural_nets.posterior_score_nn
 
 
+Estimators
+----------
+
+.. autosummary::
+   :nosignatures:
+
+   sbi.neural_nets.estimators.ConditionalDensityEstimator
+   sbi.neural_nets.estimators.UnconditionalDensityEstimator
+   sbi.neural_nets.estimators.ConditionalScoreEstimator
+   sbi.neural_nets.ratio_estimators.RatioEstimator
+
+
 Embedding nets
 --------------
 

--- a/docs/api_reference/estimators.rst
+++ b/docs/api_reference/estimators.rst
@@ -1,0 +1,17 @@
+.. This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+.. under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+Estimators
+==========
+
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   sbi.neural_nets.estimators.ConditionalDensityEstimator
+   sbi.neural_nets.estimators.ConditionalScoreEstimator
+   sbi.neural_nets.estimators.ConditionalVectorFieldEstimator
+   sbi.neural_nets.estimators.FlowMatchingEstimator
+   sbi.neural_nets.estimators.MixedDensityEstimator
+   sbi.neural_nets.ratio_estimators.RatioEstimator
+   sbi.neural_nets.estimators.UnconditionalDensityEstimator

--- a/docs/api_reference/neural_nets.rst
+++ b/docs/api_reference/neural_nets.rst
@@ -14,3 +14,16 @@ Neural nets
    sbi.neural_nets.posterior_flow_nn
    sbi.neural_nets.posterior_nn
    sbi.neural_nets.posterior_score_nn
+
+
+Estimators
+----------
+
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   sbi.neural_nets.estimators.ConditionalDensityEstimator
+   sbi.neural_nets.estimators.UnconditionalDensityEstimator
+   sbi.neural_nets.estimators.ConditionalScoreEstimator
+   sbi.neural_nets.ratio_estimators.RatioEstimator

--- a/docs/api_reference/neural_nets.rst
+++ b/docs/api_reference/neural_nets.rst
@@ -14,16 +14,3 @@ Neural nets
    sbi.neural_nets.posterior_flow_nn
    sbi.neural_nets.posterior_nn
    sbi.neural_nets.posterior_score_nn
-
-
-Estimators
-----------
-
-.. autosummary::
-   :toctree: _autosummary
-   :nosignatures:
-
-   sbi.neural_nets.estimators.ConditionalDensityEstimator
-   sbi.neural_nets.estimators.UnconditionalDensityEstimator
-   sbi.neural_nets.estimators.ConditionalScoreEstimator
-   sbi.neural_nets.ratio_estimators.RatioEstimator

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,3 +9,4 @@ FAQ
    faq/question_01_leakage
    faq/question_02_nans
    faq/question_03_pickling_error
+   faq/question_08_unconstrained

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,4 +9,4 @@ FAQ
    faq/question_01_leakage
    faq/question_02_nans
    faq/question_03_pickling_error
-   faq/question_08_unconstrained
+   faq/question_04_unconstrained

--- a/docs/faq/question_04_unconstrained.md
+++ b/docs/faq/question_04_unconstrained.md
@@ -16,8 +16,13 @@ from simulations (more complex).
 To enable this for NPE:
 
 ```python
+import torch
+
 from sbi.inference import NPE
 from sbi.neural_nets import posterior_nn
+from sbi.utils import BoxUniform
+
+prior = BoxUniform(low=torch.zeros(2), high=torch.ones(2))
 
 density_estimator_build_fun = posterior_nn(
     model="zuko_nsf",
@@ -40,8 +45,9 @@ This is why we pass the prior as `x_dist`.
 
 Important:
 
-- This transformation is currently supported by the zuko density estimators
-(`zuko_*`) and by `mdn`. The nflows-based estimators reject it.
+- This transformation is currently supported by the conditional zuko density
+estimators (for example `zuko_maf` and `zuko_nsf`) and by `mdn`. The nflows-based
+estimators reject it, and so do the unconditional (marginal) flows.
 - For **NLE/NRE**, setting up this transformation is more
 complex as it requires estimating bounds for the simulated data
 rather than using prior bounds.

--- a/docs/faq/question_04_unconstrained.md
+++ b/docs/faq/question_04_unconstrained.md
@@ -1,7 +1,9 @@
-# Using the logit transformation
-If you've ruled out simulator issues, you can try
-training your density or ratio estimator in an unbounded space
-using a logit transformation:
+# Can I train my density estimator in an unconstrained space?
+
+Yes. If posterior samples leak outside the prior bounds (see
+[posterior samples outside the prior support](question_01_leakage.md)) and you have
+ruled out simulator issues, you can train your density or ratio estimator in an
+unbounded space using a logit transformation:
 
 - **For NPE**: The transformation maps bounded parameters θ
 to unbounded space before training, then applies the inverse (sigmoid)
@@ -14,12 +16,15 @@ from simulations (more complex).
 To enable this for NPE:
 
 ```python
+from sbi.inference import NPE
+from sbi.neural_nets import posterior_nn
+
 density_estimator_build_fun = posterior_nn(
     model="zuko_nsf",
     hidden_features=60,
     num_transforms=3,
-    z_score_theta="transform_to_unconstrained"  # Transforms parameters to unconstrained space
-    x_dist=prior  # For NPE, this specifies bounds for parameters (internally called 'x')
+    z_score_theta="transform_to_unconstrained",  # Transform parameters to unconstrained space
+    x_dist=prior,  # For NPE, this specifies bounds for parameters (internally called 'x')
 )
 inference = NPE(prior, density_estimator=density_estimator_build_fun)
 ```
@@ -35,7 +40,8 @@ This is why we pass the prior as `x_dist`.
 
 Important:
 
-- This transformation is currently only supported for zuko density estimators.
+- This transformation is currently supported by the zuko density estimators
+(`zuko_*`) and by `mdn`. The nflows-based estimators reject it.
 - For **NLE/NRE**, setting up this transformation is more
 complex as it requires estimating bounds for the simulated data
 rather than using prior bounds.

--- a/docs/how_to_guide/03_density_estimators.ipynb
+++ b/docs/how_to_guide/03_density_estimators.ipynb
@@ -18,7 +18,7 @@
     "[`nflows`](https://github.com/bayesiains/nflows/) or [`zuko`](https://github.com/probabilists/zuko). \n",
     "\n",
     "For all options, check the API reference\n",
-    "[here](https://sbi.readthedocs.io/en/latest/sbi.html).\n"
+    "[here](https://sbi.readthedocs.io/en/latest/api_reference.html).\n"
    ]
   },
   {
@@ -137,7 +137,7 @@
     "- `loss(input, condition, **kwargs)`: Return the loss for training the density estimator.\n",
     "- `sample(sample_shape, condition, **kwargs)`: Return samples from the density estimator.\n",
     "\n",
-    "See more information on the [Reference API page](https://sbi.readthedocs.io/en/latest/sbi.html)."
+    "See more information on the [Reference API page](https://sbi.readthedocs.io/en/latest/api_reference.html)."
    ]
   }
  ],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -147,7 +147,7 @@ the inference on one particular observation to be more simulation-efficient
 (e.g., SNPE).
 
 Below, we list all implemented methods and their corresponding publications.
-For usage in ``sbi``, see the `Inference API reference <https://sbi.readthedocs.io/en/latest/sbi.html>`_
+For usage in ``sbi``, see the `Inference API reference <https://sbi.readthedocs.io/en/latest/api_reference.html>`_
 and the `tutorial on implemented methods <https://sbi.readthedocs.io/en/latest/tutorials/16_implemented_methods.html>`_.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ To get started, install the ``sbi`` package with:
    python -m pip install sbi
 
 For Pyro- or PyMC-based MCMC samplers, install ``sbi[pyro]``, ``sbi[pymc]``, or
-``sbi[all]``. For more details, see our `Install Guide <https://sbi.readthedocs.io/en/latest/installation.html>`_.
+``sbi[all]``. For more details, see our :doc:`Install Guide <installation>`.
 
 Then, check out our material:
 
@@ -147,8 +147,8 @@ the inference on one particular observation to be more simulation-efficient
 (e.g., SNPE).
 
 Below, we list all implemented methods and their corresponding publications.
-For usage in ``sbi``, see the `Inference API reference <https://sbi.readthedocs.io/en/latest/api_reference.html>`_
-and the `tutorial on implemented methods <https://sbi.readthedocs.io/en/latest/tutorials/16_implemented_methods.html>`_.
+For usage in ``sbi``, see the :doc:`Inference API reference <api_reference>`
+and the :doc:`tutorial on implemented methods <tutorials/16_implemented_methods>`.
 
 
 Posterior estimation (``(S)NPE``)

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -4,18 +4,18 @@ Tutorials
 =========
 
 Before running the notebooks, follow our instructions to
-`install sbi <https://sbi.readthedocs.io/en/latest/installation.html>`_.
+:doc:`install sbi <installation>`.
 Alternatively, you can also open a `codespace on
 GitHub <https://codespaces.new/sbi-dev/sbi>`_ and work through the tutorials in
 the browser.
 
 Once you have familiarised yourself with the methods and identified how to apply
 ``sbi`` to your use case, you can check out our
-`how-to guide <https://sbi.readthedocs.io/en/latest/how_to_guide.html>`_
+:doc:`how-to guide <how_to_guide>`
 for brief answers to specific questions, our
-`advanced tutorials <https://sbi.readthedocs.io/en/latest/advanced_tutorials.html>`_
+:doc:`advanced tutorials <advanced_tutorials>`
 for longer explanations of particular features, and our
-`API reference <https://sbi.readthedocs.io/en/latest/api_reference.html>`_
+:doc:`API reference <api_reference>`
 for documentation of all features.
 
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -15,7 +15,7 @@ Once you have familiarised yourself with the methods and identified how to apply
 for brief answers to specific questions, our
 `advanced tutorials <https://sbi.readthedocs.io/en/latest/advanced_tutorials.html>`_
 for longer explanations of particular features, and our
-`API reference <https://sbi.readthedocs.io/en/latest/sbi.html>`_
+`API reference <https://sbi.readthedocs.io/en/latest/api_reference.html>`_
 for documentation of all features.
 
 

--- a/docs/tutorials/00_getting_started.ipynb
+++ b/docs/tutorials/00_getting_started.ipynb
@@ -415,7 +415,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "This tutorial provided a brief overview of the capabilities of the `sbi` toolbox. Next, we recommend that you check out the tutorial on the [full Bayesian workflow with `sbi`](https://sbi.readthedocs.io/en/latest/tutorials/01_Bayesian_workflow.html). Alternatively, you can check our [how-to guide](https://sbi.readthedocs.io/en/latest/how_to_guide.html) for brief tutorials on specific features, or you can read our [API reference](https://sbi.readthedocs.io/en/latest/sbi.html), which provides a complete list of all features in the `sbi` toolbox."
+    "This tutorial provided a brief overview of the capabilities of the `sbi` toolbox. Next, we recommend that you check out the tutorial on the [full Bayesian workflow with `sbi`](https://sbi.readthedocs.io/en/latest/tutorials/01_Bayesian_workflow.html). Alternatively, you can check our [how-to guide](https://sbi.readthedocs.io/en/latest/how_to_guide.html) for brief tutorials on specific features, or you can read our [API reference](https://sbi.readthedocs.io/en/latest/api_reference.html), which provides a complete list of all features in the `sbi` toolbox."
    ]
   }
  ],

--- a/docs/tutorials/01_Bayesian_workflow.ipynb
+++ b/docs/tutorials/01_Bayesian_workflow.ipynb
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now want to set up a neural network for this example. For this example, we will use Neural Posterior Estimation (NPE) with a neural spline flow (`nsf`) as density estimator. See [here](https://sbi.readthedocs.io/en/latest/sbi.html#neural-nets) for the collection of neural networks and [here](https://sbi.readthedocs.io/en/latest/how_to_guide/03_choose_neural_net.html) for a guide on which methods to choose."
+    "We now want to set up a neural network for this example. For this example, we will use Neural Posterior Estimation (NPE) with a neural spline flow (`nsf`) as density estimator. See [here](https://sbi.readthedocs.io/en/latest/api_reference.html#neural-nets) for the collection of neural networks and [here](https://sbi.readthedocs.io/en/latest/how_to_guide/03_choose_neural_net.html) for a guide on which methods to choose."
    ]
   },
   {
@@ -826,7 +826,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "Next, we recommend that you check our [how-to guide](https://sbi.readthedocs.io/en/latest/how_to_guide.html) for brief tutorials on specific features, our [advanced tutorials](https://sbi.readthedocs.io/en/latest/advanced_tutorials.html) for detailed explanations, or our [API reference](https://sbi.readthedocs.io/en/latest/sbi.html), which provides a complete list of all features in the `sbi` toolbox."
+    "Next, we recommend that you check our [how-to guide](https://sbi.readthedocs.io/en/latest/how_to_guide.html) for brief tutorials on specific features, our [advanced tutorials](https://sbi.readthedocs.io/en/latest/advanced_tutorials.html) for detailed explanations, or our [API reference](https://sbi.readthedocs.io/en/latest/api_reference.html), which provides a complete list of all features in the `sbi` toolbox."
    ]
   }
  ],

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -533,7 +533,7 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
 
         .. math::
             p(\theta_t | \theta_0) =
-            N(\theta_t; \text{mean}_t(t) \cdot \theta_0, \text{std}_t(t)).
+            N(\theta_t; \text{mean}_t(t) \cdot \theta_0, \text{std}_t(t)^2).
 
         Args:
             times: SDE time variable in [0,1].

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -527,13 +527,13 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
 
     def mean_t_fn(self, times: Tensor) -> Tensor:
         r"""Linear coefficient mean_t of the perturbation kernel expectation
-        :math:`\mu_t(t) = E[\theta_t | \theta_0] = \text{mean_t}(t) \cdot \theta_0`
+        :math:`\mu_t(t) = E[\theta_t | \theta_0] = \text{mean}_t(t) \cdot \theta_0`
         specifying the "mean factor" at a given time, which is always multiplied by
         :math:`\theta_0` to get the mean of the noise distribution, i.e.,
 
         .. math::
             p(\theta_t | \theta_0) =
-            N(\theta_t; \text{mean_t}(t) \cdot \theta_0, \text{std_t}(t)).
+            N(\theta_t; \text{mean}_t(t) \cdot \theta_0, \text{std}_t(t)).
 
         Args:
             times: SDE time variable in [0,1].
@@ -548,8 +548,8 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
             time,
 
         .. math::
-            p(\theta_t | \theta_0) = N(\theta_t; \text{mean_t}(t) \cdot
-            \theta_0, \text{std_t}(t)^2).
+            p(\theta_t | \theta_0) = N(\theta_t; \text{mean}_t(t) \cdot
+            \theta_0, \text{std}_t(t)^2).
 
         Args:
             times: SDE time variable in [0,1].

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -207,9 +207,10 @@ class ConditionalDensityEstimator(ConditionalEstimator):
 
     Note:
         We assume that the input to the density estimator is a tensor of shape
-        (sample_dim, batch_dim, *input_shape), where input_shape is the dimensionality
-        of the input. The condition is a tensor of shape (batch_size, *condition_shape),
-        where condition_shape is the shape of the condition tensor.
+        `(sample_dim, batch_dim, *input_shape)`, where `input_shape` is the
+        dimensionality of the input. The condition is a tensor of shape
+        `(batch_size, *condition_shape)`, where `condition_shape` is the shape of
+        the condition tensor.
 
     """
 
@@ -277,7 +278,7 @@ class ConditionalDensityEstimator(ConditionalEstimator):
             condition: Conditions of shape `(batch_dim, *event_shape_condition)`.
 
         Returns:
-            Samples of shape (*sample_shape, batch_dim, *event_shape_input).
+            Samples of shape `(*sample_shape, batch_dim, *event_shape_input)`.
         """
 
         pass
@@ -315,9 +316,10 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
 
     Note:
         We assume that the input to the density estimator is a tensor of shape
-        (sample_dim, batch_dim, *input_shape), where input_shape is the dimensionality
-        of the input. The condition is a tensor of shape (batch_dim, *condition_shape),
-        where condition_shape is the shape of the condition tensor.
+        `(sample_dim, batch_dim, *input_shape)`, where `input_shape` is the
+        dimensionality of the input. The condition is a tensor of shape
+        `(batch_dim, *condition_shape)`, where `condition_shape` is the shape of
+        the condition tensor.
     """
 
     # When implementing custom estimators,
@@ -528,8 +530,10 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
         :math:`\mu_t(t) = E[\theta_t | \theta_0] = \text{mean_t}(t) \cdot \theta_0`
         specifying the "mean factor" at a given time, which is always multiplied by
         :math:`\theta_0` to get the mean of the noise distribution, i.e.,
-        :math:`p(\theta_t | \theta_0) = N(\theta_t;
-                \text{mean_t}(t)*\theta_0, \text{std_t}(t)).`
+
+        .. math::
+            p(\theta_t | \theta_0) =
+            N(\theta_t; \text{mean_t}(t) \cdot \theta_0, \text{std_t}(t)).
 
         Args:
             times: SDE time variable in [0,1].
@@ -701,8 +705,8 @@ class UnconditionalDensityEstimator(UnconditionalEstimator):
 
     Note:
         We assume that the input to the density estimator is a tensor of shape
-        (sample_dim, batch_dim, *input_shape), where input_shape is the dimensionality
-        of the input.
+        `(sample_dim, batch_dim, *input_shape)`, where `input_shape` is the
+        dimensionality of the input.
 
     """
 
@@ -739,7 +743,7 @@ class UnconditionalDensityEstimator(UnconditionalEstimator):
             sample_shape: Shape of the samples to return.
 
         Returns:
-            Samples of shape (*sample_shape, batch_dim, *event_shape_input).
+            Samples of shape `(*sample_shape, batch_dim, *event_shape_input)`.
         """
 
         return self._neural_net.sample(sample_shape)

--- a/sbi/neural_nets/estimators/flowmatching_estimator.py
+++ b/sbi/neural_nets/estimators/flowmatching_estimator.py
@@ -378,13 +378,13 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
 
         .. math::
             \nabla_{\theta_t} \log p(\theta_t | x_o) =
-            (- (1 - t) v(\theta_t, t; x_o) - \theta_0 ) / t
+            (- (1 - t) v(\theta_t, t; x_o) - \theta_t ) / t
 
         Taking into account the noise scale :math:`\sigma_{min}`, the score function is
 
         .. math::
             \nabla_{\theta_t} \log p(\theta_t | x_o) =
-            (- (1 - t) v(\theta_t, t; x_o) - \theta_0 ) / (t + \sigma_{min}).
+            (- (1 - t) v(\theta_t, t; x_o) - \theta_t ) / (t + \sigma_{min}).
 
         Args:
             input: variable whose distribution is estimated.

--- a/sbi/neural_nets/estimators/flowmatching_estimator.py
+++ b/sbi/neural_nets/estimators/flowmatching_estimator.py
@@ -17,7 +17,7 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
     Rectified flow matching estimator class that estimates the conditional vector field,
     :math:`v(\theta_t, t; x_o) = \mathbb{E}[\theta_1 - \theta_0 | \theta_t, x_o = x_o]`
 
-    This estimator implements the flow matching approach where the vector field is
+    This estimator implements the flow matching approach [2]_ where the vector field is
     learned by matching the flow between the base and target distributions. The vector
     field represents the instantaneous change in the distribution at time t.
 
@@ -381,8 +381,10 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
             (- (1 - t) v(\theta_t, t; x_o) - \theta_0 ) / t
 
         Taking into account the noise scale :math:`\sigma_{min}`, the score function is
-        :math:`\nabla_{\theta_t} \log p(\theta_t | x_o) =
-            (- (1 - t) v(\theta_t, t; x_o) - \theta_0 ) / (t + \sigma_{min})`.
+
+        .. math::
+            \nabla_{\theta_t} \log p(\theta_t | x_o) =
+            (- (1 - t) v(\theta_t, t; x_o) - \theta_0 ) / (t + \sigma_{min}).
 
         Args:
             input: variable whose distribution is estimated.

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -31,10 +31,11 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
     a Wiener process. This will lead to marginal distribution of the form:
 
     .. math::
-        p(x_t | x_0) = N(x_t; \text{mean}_t(t) \cdot x_0, \text{std}_t(t)),
+        p(x_t | x_0) = N(x_t; \text{mean}_t(t) \cdot x_0, \text{std}_t(t)^2),
 
     where mean_t(t) and std_t(t) are the conditional mean and standard deviation at a
-    given time t, respectively.
+    given time t, respectively. The second argument of N is the variance, which
+    matches `std_fn`.
 
     References
     ----------

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -31,7 +31,7 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
     a Wiener process. This will lead to marginal distribution of the form:
 
     .. math::
-        p(x_t | x_0) = N(x_t; \text{mean_t}(t) \cdot x_0, \text{std_t}(t)),
+        p(x_t | x_0) = N(x_t; \text{mean}_t(t) \cdot x_0, \text{std}_t(t)),
 
     where mean_t(t) and std_t(t) are the conditional mean and standard deviation at a
     given time t, respectively.

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -19,11 +19,20 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
     to generate samples from the target distribution by solving the SDE starting from
     the base (Gaussian) distribution.
 
+    See [2]_ for the denoising diffusion formulation and [3]_ for the
+    noise-conditional score network formulation.
+
     We assume the following SDE:
-                        dx = A(t)xdt + B(t)dW,
+
+    .. math::
+        dx = A(t) x \, dt + B(t) \, dW,
+
     where A(t) and B(t) are the drift and diffusion functions, respectively, and dW is
     a Wiener process. This will lead to marginal distribution of the form:
-                        p(xt|x0) = N(xt; mean_t(t)*x0, std_t(t)),
+
+    .. math::
+        p(x_t | x_0) = N(x_t; \text{mean_t}(t) \cdot x_0, \text{std_t}(t)),
+
     where mean_t(t) and std_t(t) are the conditional mean and standard deviation at a
     given time t, respectively.
 

--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -74,8 +74,9 @@ def build_made(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_made",
-        "Use a `zuko_*` model (e.g. `zuko_maf`, `zuko_nsf`), which supports it, "
-        "or one of 'none', 'independent', 'structured'.",
+        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
+        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
+        "'structured'.",
     )
     x_numel = get_numel(batch_x, embedding_net=None)
     y_numel = get_numel(batch_y, embedding_net=embedding_net)
@@ -159,8 +160,9 @@ def build_maf(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_maf",
-        "Use a `zuko_*` model (e.g. `zuko_maf`, `zuko_nsf`), which supports it, "
-        "or one of 'none', 'independent', 'structured'.",
+        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
+        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
+        "'structured'.",
     )
     x_numel = get_numel(
         batch_x,
@@ -273,8 +275,9 @@ def build_maf_rqs(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_maf_rqs",
-        "Use a `zuko_*` model (e.g. `zuko_maf`, `zuko_nsf`), which supports it, "
-        "or one of 'none', 'independent', 'structured'.",
+        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
+        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
+        "'structured'.",
     )
     x_numel = get_numel(
         batch_x,
@@ -382,8 +385,9 @@ def build_nsf(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_nsf",
-        "Use a `zuko_*` model (e.g. `zuko_maf`, `zuko_nsf`), which supports it, "
-        "or one of 'none', 'independent', 'structured'.",
+        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
+        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
+        "'structured'.",
     )
     x_numel = get_numel(batch_x, embedding_net=None)
     y_numel = get_numel(batch_y, embedding_net=embedding_net)

--- a/sbi/neural_nets/ratio_estimators.py
+++ b/sbi/neural_nets/ratio_estimators.py
@@ -106,12 +106,17 @@ class RatioEstimator(ConditionalEstimator):
     def combine_theta_and_x(self, theta: Tensor, x: Tensor) -> Tensor:
         """After embedding them, concatenate embedded_theta and embedded_x
 
+        `theta` and `x` must agree on their shape prefix. This method does not
+        broadcast; expand `x` yourself if it lacks a sample dimension.
+
         Args:
-            theta: parameters of shape `(sample_dim, batch_dim, *theta_shape)`.
-            x: data of shape `(batch_dim, *x_shape)`.
+            theta: parameters of shape `(*batch_shape, *theta_shape)`, for example
+                `(sample_dim, batch_dim, *theta_shape)`.
+            x: data of shape `(*batch_shape, *x_shape)`, with the same
+                `batch_shape` as `theta`.
 
         Returns:
-            combined: shape (sample_dim, batch_dim, combined_event_dim)
+            combined: shape `(*batch_shape, combined_event_dim)`
         """
         dim = -1
         self._check_theta_shape_suffix(theta)
@@ -127,12 +132,17 @@ class RatioEstimator(ConditionalEstimator):
         r"""Return the unnormalized log ratios of the thetas given an x, or multiple
         (batched) xs.
 
+        `theta` and `x` must agree on their shape prefix. This method does not
+        broadcast; expand `x` yourself if it lacks a sample dimension.
+
         Args:
-            theta: parameters of shape `(sample_dim, batch_dim, *theta_shape)`.
-            x: data of shape `(batch_dim, *x_shape)`.
+            theta: parameters of shape `(*batch_shape, *theta_shape)`, for example
+                `(sample_dim, batch_dim, *theta_shape)`.
+            x: data of shape `(*batch_shape, *x_shape)`, with the same
+                `batch_shape` as `theta`.
 
         Returns:
-            Sample-wise unnormalized log ratios with shape (sample_dim, batch_dim).
+            Sample-wise unnormalized log ratios with shape `(*batch_shape)`.
             Just like log_prob, the last dimension should be squeezed.
         """
 

--- a/sbi/neural_nets/ratio_estimators.py
+++ b/sbi/neural_nets/ratio_estimators.py
@@ -57,7 +57,7 @@ class RatioEstimator(ConditionalEstimator):
         r"""This method checks whether x has the correct shape.
 
         Args:
-            x: Tensor of shape (*batch_shape, *x_shape).
+            x: Tensor of shape `(*batch_shape, *x_shape)`.
 
         Raises:
             ValueError: If the x has a dimensionality that does not match
@@ -71,7 +71,7 @@ class RatioEstimator(ConditionalEstimator):
         r"""This method checks whether theta has the correct shape.
 
         Args:
-            theta: Tensor of shape (*batch_shape, *theta_shape).
+            theta: Tensor of shape `(*batch_shape, *theta_shape)`.
 
         Raises:
             ValueError: If the theta has a dimensionality that does not match
@@ -87,8 +87,8 @@ class RatioEstimator(ConditionalEstimator):
         r"""This method checks whether theta and x agree on the prefix of their shape.
 
         Args:
-            theta: Tensor of shape (*batch_shape, *theta_shape).
-            x: Tensor of shape (*batch_shape, *x_shape).
+            theta: Tensor of shape `(*batch_shape, *theta_shape)`.
+            x: Tensor of shape `(*batch_shape, *x_shape)`.
 
         Raises:
             ValueError: If the `batch_shape`s do not agree.
@@ -107,8 +107,8 @@ class RatioEstimator(ConditionalEstimator):
         """After embedding them, concatenate embedded_theta and embedded_x
 
         Args:
-            theta: parameters of shape (sample_dim, batch_dim, *theta_shape).
-            x: data of shape (batch_dim, *x_shape).
+            theta: parameters of shape `(sample_dim, batch_dim, *theta_shape)`.
+            x: data of shape `(batch_dim, *x_shape)`.
 
         Returns:
             combined: shape (sample_dim, batch_dim, combined_event_dim)
@@ -128,8 +128,8 @@ class RatioEstimator(ConditionalEstimator):
         (batched) xs.
 
         Args:
-            theta: parameters of shape (sample_dim, batch_dim, *theta_shape).
-            x: data of shape (batch_dim, *x_shape).
+            theta: parameters of shape `(sample_dim, batch_dim, *theta_shape)`.
+            x: data of shape `(batch_dim, *x_shape)`.
 
         Returns:
             Sample-wise unnormalized log ratios with shape (sample_dim, batch_dim).

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -201,8 +201,9 @@ def assert_transform_to_unconstrained_supported(
     set, so the caller is responsible for only invoking it from such builders.
 
     The ``transform_to_unconstrained`` z-scoring option derives a bijection from the
-    prior's support (rather than batch statistics) and is only implemented for the
-    conditional Zuko builders. For the other builders, ``z_score_parser`` returns
+    prior's support (rather than batch statistics). It is implemented for the
+    conditional Zuko builders and for ``build_mdn``. For the other builders,
+    ``z_score_parser`` returns
     ``(False, False)`` for this flag, which would otherwise make the option a silent
     no-op (the model is built with no reparametrization at all). This guard turns that
     silent no-op into a clear error.


### PR DESCRIPTION
Closes #1982

- Fix two broken links to the API reference in `docs/index.rst` and `docs/tutorials.rst` (the old `sbi.html` target returns 404).
- Add the orphaned `faq/question_08_unconstrained` page to the FAQ toctree.
- Add the `DensityEstimator`, `RatioEstimator` and `ScoreEstimator` classes to the API reference under a new `Estimators` section.