### PR TITLE
docs: limit API reference class pages to the sbi API

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,8 +1,11 @@
 {{ objname }}
 {{ underline }}
 
+{# `:inherited-members:` matches on the bare class name, so `torch.nn.Module` would
+   silently match nothing. #}
 .. autoclass:: {{ fullname }}
    :members:
    :undoc-members:
-   :inherited-members:
+   :inherited-members: Module
+   :exclude-members: training
    :show-inheritance:

--- a/docs/faq/question_04_unconstrained.md
+++ b/docs/faq/question_04_unconstrained.md
@@ -28,8 +28,8 @@ density_estimator_build_fun = posterior_nn(
     model="zuko_nsf",
     hidden_features=60,
     num_transforms=3,
-    z_score_theta="transform_to_unconstrained",  # Transform parameters to unconstrained space
-    x_dist=prior,  # For NPE, this specifies bounds for parameters (internally called 'x')
+    z_score_theta="transform_to_unconstrained",
+    x_dist=prior,
 )
 inference = NPE(prior, density_estimator=density_estimator_build_fun)
 ```

--- a/sbi/neural_nets/embedding_nets/causal_cnn.py
+++ b/sbi/neural_nets/embedding_nets/causal_cnn.py
@@ -267,6 +267,20 @@ class CausalCNNEmbedding(nn.Module):
         self.aggregation = aggregator
 
     def forward(self, x: Tensor) -> Tensor:
+        """Embed a batch of time series.
+
+        Args:
+            x: Inputs of shape `(batch_dim, *input_shape)`. A flat
+                `(batch_dim, prod(input_shape))` is also accepted, as is
+                `(batch_dim, *input_shape[1:])` for single-channel inputs.
+
+        Returns:
+            Embeddings of shape `(batch_dim, output_dim)` for the default
+            aggregator, otherwise the flattened output of the given `aggregator`.
+
+        Raises:
+            ValueError: If the trailing shape of `x` is none of the above.
+        """
         batch_size = x.size(0)
         _validate_cnn_input_shape(x, self.input_shape)
         x = x.reshape(batch_size, *self.input_shape)

--- a/sbi/neural_nets/embedding_nets/causal_cnn.py
+++ b/sbi/neural_nets/embedding_nets/causal_cnn.py
@@ -270,9 +270,9 @@ class CausalCNNEmbedding(nn.Module):
         """Embed a batch of time series.
 
         Args:
-            x: Inputs of shape `(batch_dim, *input_shape)`. A flat
-                `(batch_dim, prod(input_shape))` is also accepted, as is
-                `(batch_dim, *input_shape[1:])` for single-channel inputs.
+            x: Inputs of shape `(batch_dim, in_channels, *input_shape)`. A flat
+                `(batch_dim, in_channels * prod(input_shape))` is also accepted, as
+                is `(batch_dim, *input_shape)` when `in_channels` is 1.
 
         Returns:
             Embeddings of shape `(batch_dim, output_dim)` for the default

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -191,9 +191,9 @@ class CNNEmbedding(nn.Module):
         """Embed a batch of inputs.
 
         Args:
-            x: Inputs of shape `(batch_dim, *input_shape)`. A flat
-                `(batch_dim, prod(input_shape))` is also accepted, as is
-                `(batch_dim, *input_shape[1:])` for single-channel inputs.
+            x: Inputs of shape `(batch_dim, in_channels, *input_shape)`. A flat
+                `(batch_dim, in_channels * prod(input_shape))` is also accepted, as
+                is `(batch_dim, *input_shape)` when `in_channels` is 1.
 
         Returns:
             Embeddings of shape `(batch_dim, output_dim)`.

--- a/sbi/neural_nets/embedding_nets/cnn.py
+++ b/sbi/neural_nets/embedding_nets/cnn.py
@@ -188,6 +188,19 @@ class CNNEmbedding(nn.Module):
 
     # Defining the forward pass
     def forward(self, x: Tensor) -> Tensor:
+        """Embed a batch of inputs.
+
+        Args:
+            x: Inputs of shape `(batch_dim, *input_shape)`. A flat
+                `(batch_dim, prod(input_shape))` is also accepted, as is
+                `(batch_dim, *input_shape[1:])` for single-channel inputs.
+
+        Returns:
+            Embeddings of shape `(batch_dim, output_dim)`.
+
+        Raises:
+            ValueError: If the trailing shape of `x` is none of the above.
+        """
         batch_size = x.size(0)
         _validate_cnn_input_shape(x, self.input_shape)
 

--- a/sbi/neural_nets/embedding_nets/transformer.py
+++ b/sbi/neural_nets/embedding_nets/transformer.py
@@ -870,6 +870,23 @@ class TransformerEmbedding(nn.Module):
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ):
+        """Build an additive causal attention mask.
+
+        Args:
+            sequence_length: Length of the attention window.
+            batch_size: Number of sequences to expand the mask to.
+            dtype: Dtype of the returned mask.
+            device: Device of the returned mask.
+            min_dtype: Value that marks a masked position, usually the smallest
+                finite value of `dtype`.
+            attention_mask: Optional padding mask of shape
+                `(batch_dim, mask_length)`, where 0 marks a padding token.
+            kwargs: Ignored.
+
+        Returns:
+            Mask of shape `(batch_dim, 1, sequence_length, sequence_length)`, holding
+            `min_dtype` where attention is suppressed and 0 elsewhere.
+        """
         causal_mask = torch.full(
             (sequence_length, sequence_length),
             fill_value=min_dtype,

--- a/sbi/neural_nets/embedding_nets/transformer.py
+++ b/sbi/neural_nets/embedding_nets/transformer.py
@@ -885,7 +885,9 @@ class TransformerEmbedding(nn.Module):
 
         Returns:
             Mask of shape `(batch_dim, 1, sequence_length, sequence_length)`, holding
-            `min_dtype` where attention is suppressed and 0 elsewhere.
+            `min_dtype` where attention is suppressed and 0 elsewhere. For
+            `sequence_length` 1 every entry is `min_dtype`. That leaves attention
+            unchanged, because a softmax over a single position returns one.
         """
         causal_mask = torch.full(
             (sequence_length, sequence_length),

--- a/sbi/neural_nets/estimators/mixed_density_estimator.py
+++ b/sbi/neural_nets/estimators/mixed_density_estimator.py
@@ -54,6 +54,11 @@ class MixedDensityEstimator(ConditionalDensityEstimator):
         self.log_transform_input = log_transform_input
 
     def forward(self, input: Tensor):
+        """Not implemented for mixed density estimators.
+
+        Raises:
+            NotImplementedError: Always. Use `sample` instead.
+        """
         raise NotImplementedError(
             """The forward method is not implemented for mixed neural density
             estimation, use '.sample(...)' to generate samples though a forward

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -34,8 +34,8 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         p(x_t | x_0) = N(x_t; \text{mean}_t(t) \cdot x_0, \text{std}_t(t)^2),
 
     where mean_t(t) and std_t(t) are the conditional mean and standard deviation at a
-    given time t, respectively. The second argument of N is the variance, which
-    matches `std_fn`.
+    given time t, respectively. `std_fn` returns the standard deviation, so the second
+    argument of N is its square.
 
     References
     ----------

--- a/sbi/neural_nets/net_builders/classifier.py
+++ b/sbi/neural_nets/net_builders/classifier.py
@@ -17,6 +17,11 @@ from sbi.utils.sbiutils import (
 )
 from sbi.utils.user_input_checks import check_data_device
 
+transform_to_unconstrained_suggestion = (
+    "Ratio-based classifiers (NRE) do not implement it; "
+    "use one of 'none', 'independent', or 'structured' instead."
+)
+
 
 def build_z_scored_embedding_net(
     batch: Tensor,
@@ -84,8 +89,7 @@ def build_linear_classifier(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_linear_classifier",
-        "Ratio-based classifiers (NRE) do not implement it; "
-        "use one of 'none', 'independent', or 'structured' instead.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
     y_numel = get_numel(batch_y, embedding_net=embedding_net_y)
@@ -141,8 +145,7 @@ def build_mlp_classifier(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_mlp_classifier",
-        "Ratio-based classifiers (NRE) do not implement it; "
-        "use one of 'none', 'independent', or 'structured' instead.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
     y_numel = get_numel(batch_y, embedding_net=embedding_net_y)
@@ -206,8 +209,7 @@ def build_resnet_classifier(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_resnet_classifier",
-        "Ratio-based classifiers (NRE) do not implement it; "
-        "use one of 'none', 'independent', or 'structured' instead.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(batch_x, embedding_net=embedding_net_x)
     y_numel = get_numel(batch_y, embedding_net=embedding_net_y)

--- a/sbi/neural_nets/net_builders/flow.py
+++ b/sbi/neural_nets/net_builders/flow.py
@@ -33,6 +33,11 @@ from sbi.utils.user_input_checks import check_data_device
 
 nflow_specific_kwargs = ["num_bins", "num_components", "tail_bound"]
 
+transform_to_unconstrained_suggestion = (
+    "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
+    "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', 'structured'."
+)
+
 
 def build_made(
     batch_x: Tensor,
@@ -74,9 +79,7 @@ def build_made(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_made",
-        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
-        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
-        "'structured'.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(batch_x, embedding_net=None)
     y_numel = get_numel(batch_y, embedding_net=embedding_net)
@@ -160,9 +163,7 @@ def build_maf(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_maf",
-        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
-        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
-        "'structured'.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(
         batch_x,
@@ -275,9 +276,7 @@ def build_maf_rqs(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_maf_rqs",
-        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
-        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
-        "'structured'.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(
         batch_x,
@@ -385,9 +384,7 @@ def build_nsf(
     assert_transform_to_unconstrained_supported(
         z_score_x,
         "build_nsf",
-        "Use a model that supports it, e.g. `mdn` or a `zuko_*` model "
-        "(`zuko_maf`, `zuko_nsf`), or one of 'none', 'independent', "
-        "'structured'.",
+        transform_to_unconstrained_suggestion,
     )
     x_numel = get_numel(batch_x, embedding_net=None)
     y_numel = get_numel(batch_y, embedding_net=embedding_net)

--- a/sbi/neural_nets/ratio_estimators.py
+++ b/sbi/neural_nets/ratio_estimators.py
@@ -106,8 +106,8 @@ class RatioEstimator(ConditionalEstimator):
     def combine_theta_and_x(self, theta: Tensor, x: Tensor) -> Tensor:
         """After embedding them, concatenate embedded_theta and embedded_x
 
-        `theta` and `x` must agree on their shape prefix. This method does not
-        broadcast; expand `x` yourself if it lacks a sample dimension.
+        This method does not broadcast; expand `x` yourself if it lacks a sample
+        dimension.
 
         Args:
             theta: parameters of shape `(*batch_shape, *theta_shape)`, for example
@@ -132,8 +132,8 @@ class RatioEstimator(ConditionalEstimator):
         r"""Return the unnormalized log ratios of the thetas given an x, or multiple
         (batched) xs.
 
-        `theta` and `x` must agree on their shape prefix. This method does not
-        broadcast; expand `x` yourself if it lacks a sample dimension.
+        This method does not broadcast; expand `x` yourself if it lacks a sample
+        dimension.
 
         Args:
             theta: parameters of shape `(*batch_shape, *theta_shape)`, for example
@@ -142,7 +142,7 @@ class RatioEstimator(ConditionalEstimator):
                 `batch_shape` as `theta`.
 
         Returns:
-            Sample-wise unnormalized log ratios with shape `(*batch_shape)`.
+            Sample-wise unnormalized log ratios with shape `batch_shape`.
             Just like log_prob, the last dimension should be squeezed.
         """
 
@@ -154,4 +154,15 @@ class RatioEstimator(ConditionalEstimator):
         return self.unnormalized_log_ratio(*args, **kwargs)
 
     def loss(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
-        raise NotImplementedError()
+        """Not implemented for ratio estimators.
+
+        The NRE variants build their loss from `unnormalized_log_ratio` over
+        contrastive pairs, so each trainer defines its own `_loss`.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError(
+            "Ratio estimators do not implement `loss`; the NRE trainers compute it "
+            "from `unnormalized_log_ratio`."
+        )

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -203,10 +203,9 @@ def assert_transform_to_unconstrained_supported(
     The ``transform_to_unconstrained`` z-scoring option derives a bijection from the
     prior's support (rather than batch statistics). It is implemented for the
     conditional Zuko builders and for ``build_mdn``. For the other builders,
-    ``z_score_parser`` returns
-    ``(False, False)`` for this flag, which would otherwise make the option a silent
-    no-op (the model is built with no reparametrization at all). This guard turns that
-    silent no-op into a clear error.
+    ``z_score_parser`` returns ``(False, False)`` for this flag, which would otherwise
+    make the option a silent no-op (the model is built with no reparametrization at
+    all). This guard turns that silent no-op into a clear error.
 
     Args:
         z_score_x: The z-scoring option passed by the user.

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -466,12 +466,8 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
     elif build_fn == classifier_nn:
         models = ["linear", "mlp", "resnet"]
 
-    # `transform_to_unconstrained` is only implemented for the conditional Zuko
-    # builders; nflows/mdn/mnle and the ratio-based classifiers now raise a
-    # ValueError instead of silently no-op-ing. The factory maps the *modeled*
-    # variable's z-scoring to the builder's z_score_x: theta for posterior_nn and
-    # classifier_nn (`z_score_x=z_score_theta`), x for likelihood_nn.
-    # posterior_nn and classifier_nn both map z_score_x <- z_score_theta.
+    # The factory maps the *modeled* variable's z-scoring to the builder's `z_score_x`:
+    # theta for posterior_nn and classifier_nn, x for likelihood_nn.
     modeled_z = z_x if build_fn == likelihood_nn else z_theta
 
     for model in models:
@@ -490,8 +486,6 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
         if build_fn in [likelihood_nn, posterior_nn]:
             kwargs.update({"x_dist": dist, "num_transforms": 1})
 
-        # Unsupported combination: the modeled variable requests the unconstrained
-        # transform on a non-Zuko-conditional builder -> expect a clear ValueError.
         if (
             modeled_z == "transform_to_unconstrained"
             and not model.startswith("zuko")
@@ -556,7 +550,7 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
 def test_transform_to_unconstrained_raises_for_unsupported_builders(builder_name):
     """nflows and ratio-classifier builders raise a clear error for
     `transform_to_unconstrained` instead of silently building a model without the
-    reparametrization. MDN now supports it and is excluded."""
+    reparametrization. MDN supports it and is excluded."""
     from sbi.neural_nets.net_builders import flow as flow_builders
     from sbi.neural_nets.net_builders.classifier import (
         build_linear_classifier,


### PR DESCRIPTION
Follow-up to #1990.

## Problem

Each class page in the API reference shows all the members of `torch.nn.Module`. The `CNNEmbedding` page shows 54 members. Only one member belongs to sbi. The reader sees `bfloat16()`, `ipu()` and `register_full_backward_pre_hook()` before that member.

## Cause and correction

The autosummary class template gives `:inherited-members:` with no argument. Sphinx reads this as "stop at `object`". Sphinx then walks the full MRO. The option accepts the class to stop at. This PR gives `Module`.

The template also excludes `training`. `training` is an annotation on `nn.Module`. Sphinx removes only the members that a class defines, thus the first option cannot remove `training`.

## Result

The pages keep the members that come from the sbi base classes. `ConditionalScoreEstimator` keeps `ode_fn`, `to_z`, `from_z`, `log_abs_det`, `input_shape` and `condition_shape`. The `:show-inheritance:` option continues to show the base class. Intersphinx makes a link from the base class to the PyTorch documentation. The reader can still find the torch API.

16 pages change. All 16 pages are subclasses of `nn.Module`.

| Page | Before | After |
|---|---|---|
| ConditionalScoreEstimator | 79 | 26 |
| ConditionalVectorFieldEstimator | 74 | 21 |
| FlowMatchingEstimator | 74 | 21 |
| MixedDensityEstimator | 61 | 8 |
| ConditionalDensityEstimator | 61 | 7 |
| RatioEstimator | 59 | 6 |
| UnconditionalDensityEstimator | 59 | 5 |
| TransformerEmbedding | 55 | 2 |
| 8 more embedding nets, each | 54 | 1 |

The other 67 pages do not change. The distribution classes, for example `BoxUniform`, keep their inherited members. For those classes, `sample()` and `log_prob()` are the interface.

## Other corrections in this PR

The shorter pages show which sbi members have no docstring. Five members had no docstring: `CNNEmbedding.forward`, `CausalCNNEmbedding.forward`, `MixedDensityEstimator.forward`, `RatioEstimator.loss` and `TransformerEmbedding.causal_mask`. This PR adds a docstring to each member. `RatioEstimator.loss` also raised a `NotImplementedError` with no message. The error now tells the user that the NRE trainers calculate the loss.

The nflows builders gave the same suggestion string at four locations. The classifier builders gave a second string at three locations. This duplication made a message become stale: the nflows message named only the zuko models for two releases after #1888 added support to `build_mdn`. Each string is now in one location in its module.

This PR also removes three comments. The comment in `tests/sbiutils_test.py` said that `mdn` raises an error for `transform_to_unconstrained`. The `model != "mdn"` condition in the same test shows the opposite.

## AI usage

I used Claude Code with Opus 5 to detect, plan and implement these fixes, under my supervision.
