### PR TITLE
test: fix the strict XPASS on the FMPE shifted-data test

### DIFF
--- a/tests/linearGaussian_vector_field_test.py
+++ b/tests/linearGaussian_vector_field_test.py
@@ -828,7 +828,13 @@ def test_npse_affine_classifier_free(vector_field_type, prior_type, guidance_par
 @pytest.mark.parametrize(
     "z_score_theta, gaussian_baseline",
     [
-        pytest.param(None, False, marks=pytest.mark.xfail(reason="No z-scoring fails")),
+        # "none", not None: the config layer drops None fields, so None z-scores.
+        pytest.param(
+            "none",
+            False,
+            id="no_zscore",
+            marks=pytest.mark.xfail(reason="No z-scoring fails"),
+        ),
         pytest.param("independent", False, id="zscore"),
         pytest.param("independent", True, id="zscore_baseline"),
     ],


### PR DESCRIPTION

## Problem

CD is red on all four Python versions since #1921:

```
FAILED tests/linearGaussian_vector_field_test.py::test_fmpe_shifted_data_c2st[None-False]
  - [XPASS(strict)] No z-scoring fails
```

## Cause

The case does not test "no z-scoring" any more.

- The config layer drops `None` fields, because `None` is its "unset" sentinel.
- #1921 changed the `build_vector_field_estimator` defaults for `z_score_x` and
  `z_score_y` from `None` to `"independent"`. That change is correct. Without it, a
  default `VectorFieldEstimatorBuilder()` builds FMPE and NPSE with z-scoring off.
- Together, `posterior_flow_nn(z_score_theta=None)` forwards nothing, and the new
  default applies. `None` now means `"independent"`.

The case thus trains a fully z-scored FMPE, and it passes.

## Fix

The case uses `"none"`, which still disables z-scoring. The xfail stays valid: FMPE without z-scoring gives C2ST 0.61 on the shifted data, against 0.54 with z-scoring. The test id changes from `[None-False]` to `[no_zscore]`.

No source change. The behavior of `None` is a separate decision, below.

## For the per-model config work (GSoC PR 7.5 and PR 9)

No action in this PR. `None` needs a defined meaning before the conversion lands.

- Today `None` means `"independent"` on all factories. The density factories behave this way since 0.26. For the vector-field factories it starts with #1921, which is not released.
- With per-model configs and real defaults, the `Literal` check makes `None` raise. That gives three different behaviors in three releases.

My preference is that `None` keeps the meaning of `"none"` while the factories live, because `z_score_parser` always read the two values the same way. We can then drop `Optional` from those signatures at 1.0.

One test pins the decision either way: an explicitly disabled z-scoring must stay disabled after the build. That is the counterpart of the default-z-scoring test from July. The builder-versus-factory comparison in `vf_builder_integration_test.py` cannot see this class of change, because both paths moved together, and it goes away with the factory in PR 8.

_Analysis done with Claude Code._