### PR TITLE
feat: round-level convergence diagnostics for sequential NPE

### DIFF
--- a/docs/api_reference/diagnostics.rst
+++ b/docs/api_reference/diagnostics.rst
@@ -13,6 +13,8 @@ Diagnostics
    sbi.diagnostics.check_sbc
    sbi.diagnostics.check_tarp
    sbi.diagnostics.get_nltp
+   sbi.diagnostics.kl_divergence_mc
    sbi.diagnostics.LC2ST
    sbi.diagnostics.run_sbc
    sbi.diagnostics.run_tarp
+   sbi.diagnostics.SequentialConvergenceTracker

--- a/docs/how_to_guide/02_multiround_inference.ipynb
+++ b/docs/how_to_guide/02_multiround_inference.ipynb
@@ -47,13 +47,13 @@
    "source": [
     "## Tracking convergence across rounds\n",
     "\n",
-    "A common question when running sequential inference is: how many rounds are enough? `sbi` provides [`SequentialConvergenceTracker`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.SequentialConvergenceTracker) to help answer this by reporting three quantities at each round:\n",
+    "A common question when running sequential inference is: how many rounds are enough? `sbi` provides [`SequentialConvergenceTracker`](https://sbi.readthedocs.io/en/latest/api_reference/_autosummary/sbi.diagnostics.SequentialConvergenceTracker.html) to help answer this by reporting three quantities at each round:\n",
     "\n",
     "- **compression** $\\mathrm{KL}(q_r \\| \\pi)$: how far the current estimate has travelled from the prior.\n",
     "- **increment** $\\mathrm{KL}(q_r \\| q_{r-1})$: how much the last round moved the estimate.\n",
     "- **ratio** increment / compression: the fraction of the distance from the prior contributed by the last round.\n",
     "\n",
-    "When the increment and ratio become small and the compression is stable, further rounds are unlikely to improve the estimate meaningfully. The tracker is a diagnostic, not an automatic stopping rule: it measures the self-consistency of the sequence, not the distance to the true posterior. To check correctness, use [`run_sbc`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.run_sbc) or [`run_tarp`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.run_tarp).\n",
+    "When the increment and ratio become small and the compression is stable, further rounds are unlikely to improve the estimate meaningfully. The tracker is a diagnostic, not an automatic stopping rule: it measures the self-consistency of the sequence, not the distance to the true posterior. To check correctness, use [`run_sbc`](https://sbi.readthedocs.io/en/latest/api_reference/_autosummary/sbi.diagnostics.run_sbc.html) or [`run_tarp`](https://sbi.readthedocs.io/en/latest/api_reference/_autosummary/sbi.diagnostics.run_tarp.html).\n",
     "\n",
     "The tracker works with any sequential method (NPE-C, NPE-A, TSNPE, etc.) and fits into the loop with two extra lines:\n"
    ]

--- a/docs/how_to_guide/02_multiround_inference.ipynb
+++ b/docs/how_to_guide/02_multiround_inference.ipynb
@@ -38,7 +38,57 @@
     "    ).train()\n",
     "    posterior = inference.build_posterior(density_estimator)\n",
     "    proposal = posterior.set_default_x(x_o)\n",
-    "```"
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tracking convergence across rounds\n",
+    "\n",
+    "A common question when running sequential inference is: how many rounds are enough? `sbi` provides [`SequentialConvergenceTracker`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.SequentialConvergenceTracker) to help answer this by reporting three quantities at each round:\n",
+    "\n",
+    "- **compression** $\\mathrm{KL}(q_r \\| \\pi)$: how far the current estimate has travelled from the prior.\n",
+    "- **increment** $\\mathrm{KL}(q_r \\| q_{r-1})$: how much the last round moved the estimate.\n",
+    "- **ratio** increment / compression: the fraction of the distance from the prior contributed by the last round.\n",
+    "\n",
+    "When the increment and ratio become small and the compression is stable, further rounds are unlikely to improve the estimate meaningfully. The tracker is a diagnostic, not an automatic stopping rule: it measures the self-consistency of the sequence, not the distance to the true posterior. To check correctness, use [`run_sbc`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.run_sbc) or [`run_tarp`](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.run_tarp).\n",
+    "\n",
+    "The tracker works with any sequential method (NPE-C, NPE-A, TSNPE, etc.) and fits into the loop with two extra lines:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "from sbi.diagnostics import SequentialConvergenceTracker\n",
+    "\n",
+    "inference = NPE(prior)\n",
+    "tracker = SequentialConvergenceTracker(prior, x_o, num_samples=2000)\n",
+    "proposal = prior\n",
+    "\n",
+    "for _ in range(num_rounds):\n",
+    "    theta = proposal.sample((100,))\n",
+    "    x = simulate(theta)\n",
+    "    inference.append_simulations(theta, x, proposal=proposal).train()\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "\n",
+    "    tracker.update(posterior)   # returns a dict with per-round diagnostics\n",
+    "    print(tracker.ratios[-1])    # fraction of total compression from this round\n",
+    "\n",
+    "    proposal = posterior\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After the loop, `tracker.history` holds the full record (round, compression, increment, ratio, and standard errors). The convenience properties `.compressions`, `.increments` and `.ratios` return the values as lists for plotting.\n",
+    "\n",
+    "The tracker also flags rounds where the estimate is indistinguishable from the prior (`uninformative=True`, ratio reported as `NaN`), which can happen with weakly informative observations or in very early rounds before training has moved the estimate.\n"
    ]
   },
   {
@@ -47,7 +97,7 @@
    "source": [
     "## Example\n",
     "\n",
-    "You can find an example and more explanation in the tutorial [here](https://sbi.readthedocs.io/en/latest/advanced_tutorials/02_multiround_inference.html).\n"
+    "You can find a full example and more explanation in the tutorial [here](https://sbi.readthedocs.io/en/latest/advanced_tutorials/02_multiround_inference.html).\n"
    ]
   }
  ],

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,7 @@ sbi provides both a simple one-line interface (`sbi.inference.infer`) and a
 flexible class-based interface (`NPE`, `NLE`, `NRE`, `FMPE`). The typical
 workflow is: define a prior and simulator, generate simulations, train a neural
 density estimator, build a posterior, and validate with diagnostics (SBC,
-expected coverage, TARP, L-C2ST).
+expected coverage, TARP, L-C2ST, sequential convergence).
 
 ## Tutorials
 
@@ -42,6 +42,7 @@ expected coverage, TARP, L-C2ST).
 - [TARP](https://sbi.readthedocs.io/en/latest/how_to_guide/17_tarp.html): Calibration without density evaluation
 - [L-C2ST](https://sbi.readthedocs.io/en/latest/how_to_guide/13_diagnostics_lc2st.html): Per-observation local coverage test
 - [Model Misspecification](https://sbi.readthedocs.io/en/latest/how_to_guide/18_model_misspecification.html): Detecting if x_o is outside simulator range
+- [Sequential Convergence](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.SequentialConvergenceTracker): Track how a posterior estimate evolves across rounds of sequential inference
 
 ## Advanced Topics
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,7 +42,7 @@ expected coverage, TARP, L-C2ST, sequential convergence).
 - [TARP](https://sbi.readthedocs.io/en/latest/how_to_guide/17_tarp.html): Calibration without density evaluation
 - [L-C2ST](https://sbi.readthedocs.io/en/latest/how_to_guide/13_diagnostics_lc2st.html): Per-observation local coverage test
 - [Model Misspecification](https://sbi.readthedocs.io/en/latest/how_to_guide/18_model_misspecification.html): Detecting if x_o is outside simulator range
-- [Sequential Convergence](https://sbi.readthedocs.io/en/latest/api_reference.html#sbi.diagnostics.SequentialConvergenceTracker): Track how a posterior estimate evolves across rounds of sequential inference
+- [Sequential Convergence](https://sbi.readthedocs.io/en/latest/api_reference/_autosummary/sbi.diagnostics.SequentialConvergenceTracker.html): Track how a posterior estimate evolves across rounds of sequential inference
 
 ## Advanced Topics
 

--- a/sbi/diagnostics/__init__.py
+++ b/sbi/diagnostics/__init__.py
@@ -7,6 +7,10 @@ from sbi.diagnostics.misspecification import (
     calc_misspecification_mmd,
 )
 from sbi.diagnostics.sbc import check_sbc, get_nltp, run_sbc
+from sbi.diagnostics.sequential_convergence import (
+    SequentialConvergenceTracker,
+    kl_divergence_mc,
+)
 from sbi.diagnostics.tarp import check_tarp, run_tarp
 
 __all__ = [
@@ -21,4 +25,6 @@ __all__ = [
     "LC2STState",
     "calc_misspecification_logprob",
     "calc_misspecification_mmd",
+    "kl_divergence_mc",
+    "SequentialConvergenceTracker",
 ]

--- a/sbi/diagnostics/sequential_convergence.py
+++ b/sbi/diagnostics/sequential_convergence.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import math
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -47,7 +48,7 @@ def _log_prob_normalized(
                 if isinstance(dist, Distribution)
                 else dist.log_prob(theta, x=x_o)
             )
-        except UserWarning as unnormalized:
+        except Warning as unnormalized:
             raise NotImplementedError(
                 f"`{name}` is a `{type(dist).__name__}`, whose `log_prob()` is "
                 "only defined up to a normalizing constant. The constants do not "
@@ -112,15 +113,13 @@ def kl_divergence_mc(
     if num_nonfinite > 0:
         raise ValueError(
             f"{num_nonfinite}/{len(log_ratio)} samples from `p` have non-finite "
-            "log-ratios, i.e. they fall outside the support of `q`. The KL "
-            "divergence is infinite. This typically happens when `q` is "
-            "truncated or has bounded support that `p` exceeds."
+            "log-ratios, so they most likely fall outside the support of `q` "
+            "and the KL divergence is infinite. This typically happens when `q` "
+            "is truncated or has bounded support that `p` exceeds."
         )
 
     estimate = log_ratio.mean()
-    standard_error = log_ratio.std() / torch.sqrt(
-        torch.tensor(float(log_ratio.numel()))
-    )
+    standard_error = log_ratio.std() / math.sqrt(log_ratio.numel())
     return estimate, standard_error
 
 

--- a/sbi/diagnostics/sequential_convergence.py
+++ b/sbi/diagnostics/sequential_convergence.py
@@ -1,0 +1,271 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import warnings
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.distributions import Distribution
+
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
+
+# Posteriors that can only evaluate the density up to a normalizing constant
+# announce it with this warning when `log_prob()` is called. Keying on the
+# warning rather than on a list of classes keeps the check next to the behaviour
+# it describes, and it propagates through wrappers such as `EnsemblePosterior`,
+# whose normalization depends on the components it holds.
+UNNORMALIZED_LOG_PROB_WARNING = ".*log-probability is unnormalized.*"
+
+
+def _log_prob_normalized(
+    dist: Union[NeuralPosterior, Distribution],
+    theta: Tensor,
+    x_o: Optional[Tensor],
+    name: str,
+) -> Tensor:
+    """Evaluate a log-density, refusing objects defined only up to a constant.
+
+    Args:
+        dist: Distribution or posterior to evaluate.
+        theta: Parameters at which to evaluate.
+        x_o: Observation to condition posteriors on. Ignored for torch
+            distributions; if None, a posterior's `default_x` is used.
+        name: Argument name used in the error message.
+
+    Returns:
+        Log-probabilities, flattened to shape `(len(theta),)`.
+
+    Raises:
+        NotImplementedError: If `dist` reports an unnormalized log-density.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=UNNORMALIZED_LOG_PROB_WARNING)
+        try:
+            log_prob = (
+                dist.log_prob(theta)
+                if isinstance(dist, Distribution)
+                else dist.log_prob(theta, x=x_o)
+            )
+        except UserWarning as unnormalized:
+            raise NotImplementedError(
+                f"`{name}` is a `{type(dist).__name__}`, whose `log_prob()` is "
+                "only defined up to a normalizing constant. The constants do not "
+                "cancel in a KL divergence, so it cannot be estimated here. Use a "
+                "sample-based divergence such as `sbi.utils.metrics.c2st` instead."
+            ) from unnormalized
+    return log_prob.reshape(-1)
+
+
+def kl_divergence_mc(
+    p: Union[NeuralPosterior, Distribution],
+    q: Union[NeuralPosterior, Distribution],
+    x_o: Optional[Tensor] = None,
+    num_samples: int = 1000,
+    p_samples: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Monte Carlo estimate of $D_{KL}(p \| q)$ using samples drawn from `p`.
+
+    Computes $\frac{1}{N} \sum_i \log p(\theta_i) - \log q(\theta_i)$ with
+    $\theta_i \sim p$. Both `p` and `q` must expose a *normalized* `log_prob()`,
+    and `p` must expose `sample()`; posteriors that are only defined up to a
+    normalizing constant raise a `NotImplementedError`.
+
+    The estimator is unbiased but its variance grows with the divergence, so the
+    returned standard error should be checked before interpreting small
+    differences.
+
+    Args:
+        p: Distribution to sample from and evaluate in the numerator.
+        q: Distribution to evaluate in the denominator.
+        x_o: Observation to condition posteriors on. If None, a posterior's
+            `default_x` is used. Ignored for torch distributions.
+        num_samples: Number of Monte Carlo samples. Ignored if `p_samples` is
+            given.
+        p_samples: Pre-drawn samples from `p`. Reusing one sample set across
+            several calls gives a paired (lower-variance) comparison and avoids
+            repeated sampling. Note that the normalization of `p` can only be
+            checked once it is evaluated, so when this is None the samples are
+            drawn before that check; pass `p_samples` to avoid paying for
+            sampling that is then discarded.
+
+    Returns:
+        Tuple of the KL estimate and its standard error, both scalar tensors.
+
+    Raises:
+        NotImplementedError: If `p` or `q` has no normalized `log_prob()`.
+        ValueError: If any sample falls outside the support of `q`, which makes
+            the divergence infinite.
+    """
+    if p_samples is None:
+        p_samples = (
+            p.sample((num_samples,))
+            if isinstance(p, Distribution)
+            else p.sample((num_samples,), x=x_o, show_progress_bars=False)
+        )
+
+    log_ratio = _log_prob_normalized(p, p_samples, x_o, "p") - _log_prob_normalized(
+        q, p_samples, x_o, "q"
+    )
+
+    num_nonfinite = int((~torch.isfinite(log_ratio)).sum())
+    if num_nonfinite > 0:
+        raise ValueError(
+            f"{num_nonfinite}/{len(log_ratio)} samples from `p` have non-finite "
+            "log-ratios, i.e. they fall outside the support of `q`. The KL "
+            "divergence is infinite. This typically happens when `q` is "
+            "truncated or has bounded support that `p` exceeds."
+        )
+
+    estimate = log_ratio.mean()
+    standard_error = log_ratio.std() / torch.sqrt(
+        torch.tensor(float(log_ratio.numel()))
+    )
+    return estimate, standard_error
+
+
+class SequentialConvergenceTracker:
+    r"""Tracks how a posterior estimate evolves across rounds of sequential inference.
+
+    Call `update()` once per round with the round's posterior. Each call records
+    three quantities at the observation `x_o`:
+
+    - **compression**, $D_{KL}(q_r \| \pi)$: how far the current estimate has
+      travelled from the prior.
+    - **increment**, $D_{KL}(q_r \| q_{r-1})$: how much the last round moved the
+      estimate. Undefined in round 0.
+    - **ratio**, increment / compression: the fraction of the distance from the
+      prior contributed by the last round. Being dimensionless, it is comparable
+      across problems, whereas an absolute threshold on the compression is not:
+      the compression is bounded above by $D_{KL}(p(\theta \mid x_o) \| \pi)$,
+      the information the observation carries, which is a fixed property of the
+      prior, simulator and observation that no number of rounds can raise.
+
+    If the compression is not significantly greater than zero, the estimate is
+    still indistinguishable from the prior; `update()` then flags the round as
+    `uninformative` and reports the ratio as NaN.
+
+    **This is a diagnostic, not a stopping rule.** All three quantities measure
+    the self-consistency of the sequence of estimates, not the distance to the
+    true posterior. A sequence that stabilizes on a wrong answer -- for instance
+    when the first round concentrates in the wrong region and later rounds
+    reinforce it -- produces the same numbers as one that has converged. To
+    check correctness, use `sbi.diagnostics.run_sbc`, `run_tarp` or `LC2ST`.
+
+    Example:
+        ```python
+        tracker = SequentialConvergenceTracker(prior, x_o)
+        proposal = prior
+        for _ in range(num_rounds):
+            theta = proposal.sample((num_sims,))
+            x = simulator(theta)
+            inference.append_simulations(theta, x, proposal=proposal).train()
+            posterior = inference.build_posterior().set_default_x(x_o)
+            print(tracker.update(posterior))
+            proposal = posterior
+        ```
+
+    Attributes:
+        history: List of the dictionaries returned by `update()`, one per round.
+    """
+
+    def __init__(
+        self,
+        prior: Distribution,
+        x_o: Tensor,
+        num_samples: int = 1000,
+        significance_z: float = 2.0,
+    ) -> None:
+        """
+        Args:
+            prior: The prior the sequential scheme started from.
+            x_o: The observation the posterior is conditioned on.
+            num_samples: Number of Monte Carlo samples drawn per round. Drawn
+                once and reused for both divergences.
+            significance_z: How many standard errors the compression must exceed
+                zero by before a round counts as informative.
+        """
+        self.prior = prior
+        self.x_o = x_o
+        self.num_samples = num_samples
+        self.significance_z = significance_z
+
+        self.history: List[Dict[str, Any]] = []
+        self._previous: Optional[Union[NeuralPosterior, Distribution]] = None
+
+    def update(self, posterior: Union[NeuralPosterior, Distribution]) -> Dict[str, Any]:
+        """Record the diagnostics for one round.
+
+        The posterior is stored by reference for the next round's comparison.
+        `build_posterior()` already returns an estimator that is decoupled from
+        the trainer's network, so retraining does not alter it.
+
+        Args:
+            posterior: The posterior estimate of the current round, conditioned
+                on `x_o` (or with `x_o` set as its `default_x`).
+
+        Returns:
+            Dictionary with keys `round`, `compression`, `compression_sem`,
+            `increment`, `increment_sem`, `ratio` and `uninformative`. The
+            increment entries are None in round 0.
+
+        Raises:
+            NotImplementedError: If `posterior` has no normalized `log_prob()`.
+        """
+        # Probe once on a cheap prior sample, so that an unsupported posterior
+        # fails before any expensive sampling (e.g. MCMC chains) happens.
+        _log_prob_normalized(posterior, self.prior.sample((1,)), self.x_o, "posterior")
+
+        # One sample set for both divergences: paired, and one `sample()` call.
+        samples = (
+            posterior.sample((self.num_samples,))
+            if isinstance(posterior, Distribution)
+            else posterior.sample(
+                (self.num_samples,), x=self.x_o, show_progress_bars=False
+            )
+        )
+
+        compression, compression_sem = kl_divergence_mc(
+            posterior, self.prior, x_o=self.x_o, p_samples=samples
+        )
+        uninformative = bool(compression <= self.significance_z * compression_sem)
+
+        increment: Optional[float] = None
+        increment_sem: Optional[float] = None
+        ratio: Optional[float] = None
+        if self._previous is not None:
+            increment_t, increment_sem_t = kl_divergence_mc(
+                posterior, self._previous, x_o=self.x_o, p_samples=samples
+            )
+            increment = float(increment_t)
+            increment_sem = float(increment_sem_t)
+            # The ratio is meaningless if the denominator is within noise of 0.
+            ratio = float("nan") if uninformative else increment / float(compression)
+
+        record: Dict[str, Any] = {
+            "round": len(self.history),
+            "compression": float(compression),
+            "compression_sem": float(compression_sem),
+            "increment": increment,
+            "increment_sem": increment_sem,
+            "ratio": ratio,
+            "uninformative": uninformative,
+        }
+        self.history.append(record)
+        self._previous = posterior
+        return record
+
+    @property
+    def compressions(self) -> List[float]:
+        """Compression per round, in round order."""
+        return [record["compression"] for record in self.history]
+
+    @property
+    def increments(self) -> List[Optional[float]]:
+        """Increment per round, in round order. None for round 0."""
+        return [record["increment"] for record in self.history]
+
+    @property
+    def ratios(self) -> List[Optional[float]]:
+        """Ratio of increment to compression per round. None for round 0."""
+        return [record["ratio"] for record in self.history]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,10 @@ import pandas as pd
 import pytest
 import torch
 from pytest_harvest import get_session_results_df, get_xdist_worker_id, is_main_process
+from torch.distributions import MultivariateNormal
 
 from sbi.inference.posteriors.posterior_parameters import MCMCPosteriorParameters
+from sbi.simulators.linear_gaussian import linear_gaussian
 from sbi.utils.sbiutils import seed_all_backends
 from sbi.utils.torchutils import gpu_available
 
@@ -283,3 +285,27 @@ def pytest_sessionfinish(session):
             session_results_df.to_csv(results_file)
     else:
         session_results_df.to_csv('./.bm_results/results_%s.csv' % suffix)
+
+
+@pytest.fixture
+def gaussian_setup():
+    """Common linear-Gaussian setup shared by diagnostics tests."""
+    num_dim = 2
+    likelihood_shift = -1.0 * torch.ones(num_dim)
+    likelihood_cov = 0.3 * torch.eye(num_dim)
+    prior_mean = torch.zeros(num_dim)
+    prior_cov = torch.eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    return {
+        "num_dim": num_dim,
+        "prior": prior,
+        "simulator": simulator,
+        "likelihood_shift": likelihood_shift,
+        "likelihood_cov": likelihood_cov,
+        "prior_mean": prior_mean,
+        "prior_cov": prior_cov,
+    }

--- a/tests/sbc_test.py
+++ b/tests/sbc_test.py
@@ -23,28 +23,6 @@ from sbi.utils import BoxUniform, MultipleIndependent
 from tests.test_utils import PosteriorPotential, TractablePosterior
 
 
-@pytest.fixture
-def gaussian_setup():
-    """Fixture for common Gaussian test setup."""
-    num_dim = 2
-    likelihood_shift = -1.0 * ones(num_dim)
-    likelihood_cov = 0.3 * eye(num_dim)
-    prior_mean = zeros(num_dim)
-    prior_cov = eye(num_dim)
-    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
-
-    def simulator(theta):
-        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
-
-    return {
-        "num_dim": num_dim,
-        "prior": prior,
-        "simulator": simulator,
-        "likelihood_shift": likelihood_shift,
-        "likelihood_cov": likelihood_cov,
-    }
-
-
 def train_inference_method(
     method_cls: Callable,
     prior: torch.distributions.Distribution,

--- a/tests/sequential_convergence_test.py
+++ b/tests/sequential_convergence_test.py
@@ -1,0 +1,307 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import warnings
+from typing import Dict
+
+import pytest
+import torch
+from torch import eye, ones, zeros
+from torch.distributions import MultivariateNormal, Normal, kl_divergence
+
+from sbi.diagnostics import SequentialConvergenceTracker, kl_divergence_mc
+from sbi.inference import NPE_C
+from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
+from sbi.simulators.linear_gaussian import (
+    true_posterior_linear_gaussian_mvn_prior,
+)
+from sbi.utils import BoxUniform
+
+from .test_utils import PosteriorPotential, get_dkl_gaussian_prior
+
+
+@pytest.mark.parametrize(
+    "p, q",
+    (
+        (Normal(1.0, 0.5), Normal(0.0, 1.0)),
+        (
+            MultivariateNormal(ones(2), 0.5 * eye(2)),
+            MultivariateNormal(zeros(2), eye(2)),
+        ),
+        (
+            MultivariateNormal(zeros(3), 0.2 * eye(3)),
+            MultivariateNormal(zeros(3), eye(3)),
+        ),
+    ),
+)
+def test_kl_divergence_mc_matches_analytic(p, q):
+    """The MC estimate should agree with the closed-form KL for Gaussians."""
+    estimate, sem = kl_divergence_mc(p, q, num_samples=20_000)
+    exact = kl_divergence(p, q)
+
+    assert torch.isfinite(estimate) and sem > 0
+    assert torch.abs(estimate - exact) < 5 * sem, (
+        f"MC estimate {estimate:.4f} +/- {sem:.4f} is too far from the exact "
+        f"value {float(exact):.4f}."
+    )
+
+
+def test_kl_divergence_mc_is_exactly_zero_for_identical_distributions():
+    """Evaluating both densities on the same samples cancels term by term.
+
+    KL(p || p) is therefore exactly zero rather than zero up to MC noise, which
+    is what makes the increment trustworthy when two rounds barely differ.
+    """
+    p = MultivariateNormal(zeros(2), eye(2))
+    estimate, sem = kl_divergence_mc(p, p, num_samples=5000)
+
+    assert estimate == pytest.approx(0.0, abs=1e-6)
+    assert sem == pytest.approx(0.0, abs=1e-6)
+
+
+def test_kl_divergence_mc_standard_error_shrinks_with_samples():
+    """The standard error should fall roughly as 1/sqrt(num_samples)."""
+    p = MultivariateNormal(ones(2), 0.5 * eye(2))
+    q = MultivariateNormal(zeros(2), eye(2))
+
+    _, sem_small = kl_divergence_mc(p, q, num_samples=1000)
+    _, sem_large = kl_divergence_mc(p, q, num_samples=16_000)
+
+    assert sem_large < sem_small
+
+
+def test_kl_divergence_mc_reuses_provided_samples():
+    """Passing `p_samples` should bypass sampling and be reproducible."""
+    p = MultivariateNormal(zeros(2), eye(2))
+    q = MultivariateNormal(ones(2), eye(2))
+    samples = p.sample((2000,))
+
+    first, _ = kl_divergence_mc(p, q, p_samples=samples)
+    second, _ = kl_divergence_mc(p, q, p_samples=samples)
+
+    assert torch.allclose(first, second)
+
+
+def test_kl_divergence_mc_raises_outside_support():
+    """Samples outside q's support make the divergence infinite."""
+    p = MultivariateNormal(zeros(2), eye(2))
+    q = BoxUniform(low=-0.01 * ones(2), high=0.01 * ones(2))
+
+    with pytest.raises(ValueError, match="outside the support"):
+        kl_divergence_mc(p, q, num_samples=500)
+
+
+def _unnormalized_posterior(gaussian_setup: Dict, x_o):
+    """An `MCMCPosterior` wrapping a closed-form target, for guard tests."""
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o,
+        gaussian_setup["likelihood_shift"],
+        gaussian_setup["likelihood_cov"],
+        gaussian_setup["prior_mean"],
+        gaussian_setup["prior_cov"],
+    )
+    return MCMCPosterior(
+        potential_fn=PosteriorPotential(gt_posterior, gaussian_setup["prior"]),
+        proposal=gaussian_setup["prior"],
+    )
+
+
+def test_kl_divergence_mc_raises_for_unnormalized_posterior(gaussian_setup: Dict):
+    """Posteriors that only give the potential must be refused, not silently used.
+
+    The guard keys on the warning these posteriors emit rather than on a list of
+    classes, so this test is what pins that warning's wording in place. It is
+    exercised at `log_prob`, which is where the guard lives -- sampling from an
+    `MCMCPosterior` is neither needed nor cheap.
+    """
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    unnormalized = _unnormalized_posterior(gaussian_setup, x_o)
+
+    # As the denominator: sampling comes from the prior, so no MCMC is run.
+    with pytest.raises(NotImplementedError, match="c2st"):
+        kl_divergence_mc(prior, unnormalized, x_o=x_o, num_samples=10)
+
+    # As the numerator, with samples supplied so that no MCMC is run.
+    with pytest.raises(NotImplementedError, match="c2st"):
+        kl_divergence_mc(unnormalized, prior, x_o=x_o, p_samples=prior.sample((10,)))
+
+
+def test_tracker_raises_before_sampling_for_unnormalized_posterior(
+    gaussian_setup: Dict,
+):
+    """The tracker probes on a cheap prior sample, so MCMC never starts."""
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    unnormalized = _unnormalized_posterior(gaussian_setup, x_o)
+
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=10)
+    with pytest.raises(NotImplementedError, match="c2st"):
+        tracker.update(unnormalized)
+
+    assert tracker.history == []
+
+
+def test_unnormalized_guard_fires_after_warning_already_shown(gaussian_setup: Dict):
+    """The guard must survive Python's once-per-location warning registry.
+
+    A plain `warnings.warn` is only shown the first time it is reached, so a
+    guard that merely listened for the warning could silently stop firing once
+    the user had called `log_prob()` themselves. Escalating via
+    `filterwarnings` invalidates that registry, so the error is still raised.
+    """
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    unnormalized = _unnormalized_posterior(gaussian_setup, x_o)
+
+    # Trigger the warning once, exactly as a user calling `log_prob()` would.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        unnormalized.log_prob(prior.sample((2,)), x=x_o)
+
+    with pytest.raises(NotImplementedError, match="c2st"):
+        kl_divergence_mc(prior, unnormalized, x_o=x_o, num_samples=10)
+
+
+def test_tracker_first_round_has_no_increment(gaussian_setup: Dict):
+    """Round 0 has no predecessor, so increment and ratio are undefined."""
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o,
+        gaussian_setup["likelihood_shift"],
+        gaussian_setup["likelihood_cov"],
+        gaussian_setup["prior_mean"],
+        gaussian_setup["prior_cov"],
+    )
+
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=2000)
+    record = tracker.update(gt_posterior)
+
+    assert record["round"] == 0
+    assert record["increment"] is None
+    assert record["ratio"] is None
+    assert record["compression"] > 0
+    assert not record["uninformative"]
+
+
+def test_tracker_compression_matches_analytic(gaussian_setup: Dict):
+    """Feeding the true posterior should recover the exact prior-to-posterior KL."""
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o,
+        gaussian_setup["likelihood_shift"],
+        gaussian_setup["likelihood_cov"],
+        gaussian_setup["prior_mean"],
+        gaussian_setup["prior_cov"],
+    )
+    exact = float(kl_divergence(gt_posterior, prior))
+
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=20_000)
+    record = tracker.update(gt_posterior)
+
+    assert abs(record["compression"] - exact) < 5 * record["compression_sem"]
+
+
+def test_tracker_increment_is_zero_for_repeated_posterior(gaussian_setup: Dict):
+    """Passing the same posterior twice means the round changed nothing."""
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o,
+        gaussian_setup["likelihood_shift"],
+        gaussian_setup["likelihood_cov"],
+        gaussian_setup["prior_mean"],
+        gaussian_setup["prior_cov"],
+    )
+
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=5000)
+    tracker.update(gt_posterior)
+    record = tracker.update(gt_posterior)
+
+    assert record["increment"] == pytest.approx(0.0, abs=1e-5)
+    assert record["ratio"] == pytest.approx(0.0, abs=1e-5)
+    assert len(tracker.history) == 2
+
+
+def test_tracker_flags_uninformative_estimate(gaussian_setup: Dict):
+    """An estimate indistinguishable from the prior is flagged, not thresholded."""
+    prior = gaussian_setup["prior"]
+    x_o = zeros(1, gaussian_setup["num_dim"])
+
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=5000)
+    first = tracker.update(prior)
+    second = tracker.update(prior)
+
+    assert first["uninformative"]
+    assert first["compression"] == pytest.approx(0.0, abs=1e-5)
+    # The ratio has a vanishing denominator here, so it must not be reported.
+    assert second["ratio"] != second["ratio"]  # NaN
+
+
+@pytest.mark.slow
+def test_tracker_tracks_true_error_across_rounds(gaussian_setup: Dict):
+    """On a multi-round NPE run the diagnostics should be finite and informative."""
+    prior = gaussian_setup["prior"]
+    simulator = gaussian_setup["simulator"]
+    num_dim = gaussian_setup["num_dim"]
+    x_o = zeros(1, num_dim)
+
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o,
+        gaussian_setup["likelihood_shift"],
+        gaussian_setup["likelihood_cov"],
+        gaussian_setup["prior_mean"],
+        gaussian_setup["prior_cov"],
+    )
+    exact_compression = float(kl_divergence(gt_posterior, prior))
+
+    inference = NPE_C(prior=prior, show_progress_bars=False)
+    tracker = SequentialConvergenceTracker(prior, x_o, num_samples=4000)
+    proposal = prior
+    true_errors = []
+
+    for _ in range(3):
+        theta = proposal.sample((1000,))
+        x = simulator(theta)
+        inference.append_simulations(theta, x, proposal=proposal).train(
+            show_train_summary=False
+        )
+        posterior = inference.build_posterior().set_default_x(x_o)
+
+        tracker.update(posterior)
+        true_errors.append(
+            float(
+                get_dkl_gaussian_prior(
+                    posterior,
+                    x_o[0],
+                    gaussian_setup["likelihood_shift"],
+                    gaussian_setup["likelihood_cov"],
+                    gaussian_setup["prior_mean"],
+                    gaussian_setup["prior_cov"],
+                    num_samples=200,
+                )
+            )
+        )
+        proposal = posterior
+
+    assert len(tracker.history) == 3
+    assert all(
+        record["increment"] is None or record["increment"] >= 0
+        for record in tracker.history
+    )
+    assert tracker.history[0]["increment"] is None
+    assert not any(record["uninformative"] for record in tracker.history)
+
+    # The estimated compression should be in the right ballpark throughout: the
+    # posterior is learned, so allow a generous margin around the exact value.
+    for compression in tracker.compressions:
+        assert abs(compression - exact_compression) < 0.5, (
+            f"compression {compression:.3f} far from exact {exact_compression:.3f}"
+        )
+
+    # The final estimate should be a decent posterior; if it is, the diagnostic
+    # should not be reporting a large remaining increment.
+    assert true_errors[-1] < 0.5
+    assert tracker.ratios[-1] < 0.25


### PR DESCRIPTION
## What does this PR do?

Adds round-level convergence diagnostics for sequential inference, so users can track how their posterior estimate evolves across rounds instead of eyeballing pairplots or guessing how many rounds to run.

Two new exports in `sbi.diagnostics`:

- **`kl_divergence_mc(p, q, x_o=None, num_samples=1000, p_samples=None) -> (estimate, sem)`**  a stateless, vectorised Monte Carlo estimate of $$\text{KL}(p \mid \mid q)$$ from samples drawn from `p`. Works on any object exposing `.sample()` and a normalised `.log_prob()`.
- **`SequentialConvergenceTracker`** — a stateful wrapper that holds the prior, `x_o`, and the previous round's posterior. At each round it reports:

| Quantity | Formula | Meaning |
|---|---|---|
| **compression** | $$\text{KL}(q_r \mid \mid prior)$$ | how far the estimate has travelled from the prior |
| **increment** | $$\text{KL}(q_r \mid \mid q_{r-1})$$ | how much this round moved the estimate |
| **ratio** | increment / compression | fraction of total compression from this round |

All three come with standard errors from the MC estimate. Both KLs use the same sample set from $$q_r$$, so it costs one `sample()` call per round. The increment is exactly zero when two rounds coincide (term-by-term log-density cancellation), not zero up to MC noise.

**Why this matters**

Sequential NPE has no principled guidance on how many rounds to run. The [how-to guide](https://sbi.readthedocs.io/en/latest/how_to_guide/02_multiround_inference.html) says "this process can be repeated arbitrarily often" and leaves scheduling entirely to the user. [PolySwyft (Scheutwinkel et al., 2025)](https://arxiv.org/abs/2512.08316) proposes a KL-based stopping rule for NRE but relies on nested-sampling evidence that SNPE does not have. Issue #840 requested exactly this — tracking KL between sequential proposals — and was endorsed by a maintainer in 2023 but never built. This PR supplies the measurement tool. It intentionally stops short of a `converged()` boolean because the increment is not monotone in practice and the quantities measure self-consistency, not distance to the true posterior. The docstring points users at `run_sbc`/`run_tarp`/`LC2ST` for correctness checks.

## Does this close any issues?

Closes #840 and #1976.

## Anything else we should know?

### Design decisions worth highlighting

**Compression is descriptive, not a threshold.** PolySwyft terminates when $$\text{KL}(q_r \mid \mid q_{r-1}) \approx 0$$  and $$\text{KL}(q_r \mid \mid prior)$$ exceeds an absolute threshold. But compression is bounded above by $$\text{KL}(q_r \mid \mid prior)$$ — a fixed, problem-dependent quantity — so a threshold calibrated on one problem fails on another. Compression is reported for interpretation.

**The ratio compensates for that.** ratio = increment / compression is dimensionless and reads the same whether an observation carries 0.3 nats or 30. Paired with a significance guard (compression > z × sem), it recovers what PolySwyft's threshold was doing without domain calibration. When compression is within noise of zero the round is flagged uninformative and the ratio is `NaN`.

**Unnormalised posteriors are refused, not silently misused.** `MCMCPosterior` and `RejectionPosterior` have an unnormalised `log_prob()` — the constants do not cancel in KL, so using them would produce wrong numbers. Rather than hard-coding a class list, the guard escalates the warning those posteriors already emit into a `NotImplementedError` pointing at `c2st`. This handles `EnsemblePosterior` correctly (its normalisation depends on its components). The tracker probes on a cheap prior sample before any MCMC sampling starts.

### Known limitations

1. No calibration under adaptive stopping. If a user treats the ratio as a stopping rule, they're conditioning the reported posterior on "the sequence happened to stabilise," which is a selection effect whose impact on credible-set calibration is unknown. The docstring defers to SBC/TARP/LC2ST.
2. The warning-based guard against unnormalised posteriors. The check keys on the string "log-probability is unnormalized". If that warning message is reworded, the guard stops firing. Three tests break on it, so it's a CI failure rather than silent wrong numbers. The durable fix is a declarative `has_normalized_log_prob` flag on `NeuralPosterior`, but that touches core inference code, so I left it out of this PR — happy to open a follow-up.


## Checklist

Put an `x` in the boxes that apply. If you are unsure about any of them, just
ask - we are happy to help.

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [x] (If applicable) I reported how long new tests run and marked slow ones
      with `pytest.mark.slow`.

New tests: 14 unit tests covering the estimator against closed-form values, the unnormalised-posterior guard, and the tracker's bookkeeping (unmarked, ~0.6 s total); plus one multi-round NPE-C integration test marked `@pytest.mark.slow` (~30 s), reusing the `gaussian_setup` fixture from `tests/conftest.py`.

<!-- AI assistance: Claude (Anthropic) was used for literature review of sequential SBI stopping rules and for drafting the initial design of the convergence tracker. All code, tests, and documentation were reviewed, and validated by the human author; DeepSeek V4 was used to edit the PR text -->
