### PR TITLE
Add per-model vector field configs for FMPE and NPSE

### DIFF
--- a/sbi/inference/trainers/vfpe/base_vf_inference.py
+++ b/sbi/inference/trainers/vfpe/base_vf_inference.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import asdict, replace
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, ones
@@ -27,8 +27,8 @@ from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.net_builders.estimator_configs import (
     VF_MODELS,
     _ESTIMATOR_CONFIG_BASES,
-    VectorFieldEstimatorBuilder,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import VectorFieldConfigBase
 from sbi.sbi_types import TorchTransform, Tracker
 from sbi.utils import (
     check_estimator_arg,
@@ -48,7 +48,7 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
         prior: Optional[Distribution] = None,
         vector_field_estimator_builder: Union[
             VF_MODELS,
-            VectorFieldEstimatorBuilder,
+            VectorFieldConfigBase,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
             None,
         ] = None,
@@ -69,9 +69,9 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
             prior: Prior distribution.
             vector_field_estimator_builder: The vector-field estimator
                 used for flow-matching or score-matching inference.
-                Subclasses resolve a default ``VectorFieldEstimatorBuilder``
-                before calling the base. A ``VectorFieldEstimatorBuilder``
-                can be passed to configure the estimator. If it is a string
+                Subclasses resolve a default config before calling the base. A
+                vector-field config of the subclass' own family can be passed
+                to configure the estimator. If it is a string
                 (deprecated), use a pre-configured network of the provided
                 type (one of mlp, ada_mlp, transformer,
                 transformer_cross_attn). Alternatively, a function that
@@ -97,18 +97,21 @@ class VectorFieldTrainer(NeuralInference[ConditionalVectorFieldEstimator], ABC):
 
         if isinstance(vector_field_estimator_builder, _ESTIMATOR_CONFIG_BASES):
             if not isinstance(
-                vector_field_estimator_builder, VectorFieldEstimatorBuilder
+                vector_field_estimator_builder, self._ALLOWED_CONFIG_TYPE
             ):
                 raise TypeError(
-                    "VF trainers require a VectorFieldEstimatorBuilder; got "
-                    f"{type(vector_field_estimator_builder).__name__}. Use "
-                    "VectorFieldEstimatorBuilder(model=...)."
+                    f"{type(self).__name__} requires a "
+                    f"{self._ALLOWED_CONFIG_TYPE.__name__}; got "
+                    f"{type(vector_field_estimator_builder).__name__}."
                 )
             self._build_neural_net = self._wrap_builder(vector_field_estimator_builder)
         elif not isinstance(vector_field_estimator_builder, str):
             self._build_neural_net = vector_field_estimator_builder
 
         self._proposal_roundwise = []
+
+    _ALLOWED_CONFIG_TYPE: ClassVar[type] = VectorFieldConfigBase
+    """Config family this trainer accepts, narrowed by each subclass."""
 
     @abstractmethod
     def _build_default_nn_fn(

--- a/sbi/inference/trainers/vfpe/fmpe.py
+++ b/sbi/inference/trainers/vfpe/fmpe.py
@@ -3,8 +3,7 @@
 
 
 import warnings
-from dataclasses import replace
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, ClassVar, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -22,8 +21,8 @@ from sbi.neural_nets.estimators.base import (
 from sbi.neural_nets.factory import posterior_flow_nn
 from sbi.neural_nets.net_builders.estimator_configs import (
     VF_MODELS,
-    VectorFieldEstimatorBuilder,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import FlowMatchingConfig
 from sbi.sbi_types import Tracker
 
 
@@ -70,12 +69,14 @@ class FMPE(VectorFieldTrainer):
         samples = posterior.sample((1000,), x=x_o)
     """
 
+    _ALLOWED_CONFIG_TYPE: ClassVar[type] = FlowMatchingConfig
+
     def __init__(
         self,
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
             VF_MODELS,
-            VectorFieldEstimatorBuilder,
+            FlowMatchingConfig,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
             None,
         ] = None,
@@ -94,8 +95,8 @@ class FMPE(VectorFieldTrainer):
             prior: Prior distribution.
             vf_estimator: The vector-field estimator used for flow-matching
                 inference. If ``None`` (default), uses a
-                ``VectorFieldEstimatorBuilder`` with default settings. A
-                ``VectorFieldEstimatorBuilder`` can be passed to configure
+                ``FlowMatchingConfig`` with default settings. A
+                FlowMatchingConfig can be passed to configure
                 the estimator. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 mlp, ada_mlp, transformer, transformer_cross_attn).
@@ -126,22 +127,12 @@ class FMPE(VectorFieldTrainer):
             vf_estimator = density_estimator
 
         if vf_estimator is None:
-            vf_estimator = VectorFieldEstimatorBuilder(
-                estimator_type="flow",
-            )
-        elif isinstance(vf_estimator, VectorFieldEstimatorBuilder):
-            if vf_estimator.estimator_type is None:
-                vf_estimator = replace(vf_estimator, estimator_type="flow")
-            elif vf_estimator.estimator_type != "flow":
-                raise ValueError(
-                    "FMPE builds flow-matching estimators; got a builder with "
-                    f"estimator_type={vf_estimator.estimator_type!r}."
-                )
+            vf_estimator = FlowMatchingConfig()
         elif isinstance(vf_estimator, str):
             warnings.warn(
                 "Passing a string for `vf_estimator` is deprecated. "
-                "Use VectorFieldEstimatorBuilder(model=...) instead, e.g. "
-                "`from sbi.neural_nets import VectorFieldEstimatorBuilder`.",
+                "Use FlowMatchingConfig() instead, e.g. "
+                "`from sbi.neural_nets import FlowMatchingConfig`.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -2,8 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import warnings
-from dataclasses import replace
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, ClassVar, Dict, Literal, Optional, Union
 
 from torch.distributions import Distribution
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -18,7 +17,10 @@ from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
 from sbi.neural_nets.factory import posterior_score_nn
 from sbi.neural_nets.net_builders.estimator_configs import (
     VF_MODELS,
-    VectorFieldEstimatorBuilder,
+)
+from sbi.neural_nets.net_builders.vector_field_nets import (
+    ScoreConfigBase,
+    _score_config_from_sde_type,
 )
 from sbi.sbi_types import Tracker
 
@@ -66,12 +68,14 @@ class NPSE(VectorFieldTrainer):
         samples = posterior.sample((1000,), x=x_o)
     """
 
+    _ALLOWED_CONFIG_TYPE: ClassVar[type] = ScoreConfigBase
+
     def __init__(
         self,
         prior: Optional[Distribution] = None,
         vf_estimator: Union[
             VF_MODELS,
-            VectorFieldEstimatorBuilder,
+            ScoreConfigBase,
             ConditionalEstimatorBuildFn[ConditionalVectorFieldEstimator],
             None,
         ] = None,
@@ -97,8 +101,8 @@ class NPSE(VectorFieldTrainer):
             prior: Prior distribution.
             vf_estimator: The vector-field estimator used for score-matching
                 inference. If ``None`` (default), uses a
-                ``VectorFieldEstimatorBuilder`` with default settings. A
-                ``VectorFieldEstimatorBuilder`` can be passed to configure
+                ``VEScoreConfig`` with default settings. A
+                score config can be passed to configure
                 the estimator. If it is a string (deprecated), use a
                 pre-configured network of the provided type (one of
                 mlp, ada_mlp, transformer, transformer_cross_attn).
@@ -109,7 +113,7 @@ class NPSE(VectorFieldTrainer):
             sde_type: Type of SDE to use. Must be one of ['vp', 've', 'subvp'].
                 Defaults to ``None`` (resolved to ``"ve"``). When
                 ``vf_estimator`` is ``None``, forwarded to the default
-                builder. When a ``VectorFieldEstimatorBuilder`` is passed,
+                config. When a score config is passed,
                 a non-``None`` ``sde_type`` that differs from the builder's
                 value raises ``ValueError`` (set it on the builder instead).
                 When a string (deprecated), forwarded to
@@ -157,45 +161,25 @@ class NPSE(VectorFieldTrainer):
             )
             vf_estimator = density_estimator
 
-        # Builder owns sde_type; reject only when both are explicitly supplied
-        # and they disagree.
-        if (
-            isinstance(vf_estimator, VectorFieldEstimatorBuilder)
-            and sde_type is not None
-            and vf_estimator.sde_type is not None
-            and sde_type != vf_estimator.sde_type
-        ):
+        # A config carries the SDE as its class, so the deprecated kwarg has
+        # nothing left to say.
+        if isinstance(vf_estimator, ScoreConfigBase) and sde_type is not None:
             raise ValueError(
                 f"Conflicting `sde_type`: trainer received {sde_type!r} but "
-                f"the builder has {vf_estimator.sde_type!r}. Set `sde_type` "
-                "on the builder only: "
-                f"VectorFieldEstimatorBuilder(sde_type={sde_type!r})."
+                f"{type(vf_estimator).__name__} already selects the SDE. Pass "
+                "the config only."
             )
 
-        # Resolve sde_type sentinel for non-builder paths.
+        # Resolve sde_type sentinel for non-config paths.
         resolved_sde_type = sde_type if sde_type is not None else "ve"
 
         if vf_estimator is None:
-            vf_estimator = VectorFieldEstimatorBuilder(
-                estimator_type="score",
-                sde_type=resolved_sde_type,
-            )
-        elif isinstance(vf_estimator, VectorFieldEstimatorBuilder):
-            if vf_estimator.estimator_type is None:
-                vf_estimator = replace(vf_estimator, estimator_type="score")
-            elif vf_estimator.estimator_type != "score":
-                raise ValueError(
-                    "NPSE builds score estimators; got a builder with "
-                    f"estimator_type={vf_estimator.estimator_type!r}."
-                )
-            # Forward trainer's sde_type when the builder's is unset.
-            if vf_estimator.sde_type is None and sde_type is not None:
-                vf_estimator = replace(vf_estimator, sde_type=sde_type)
+            vf_estimator = _score_config_from_sde_type(resolved_sde_type)
         elif isinstance(vf_estimator, str):
             warnings.warn(
                 "Passing a string for `vf_estimator` is deprecated. "
-                "Use VectorFieldEstimatorBuilder(model=...) instead, e.g. "
-                "`from sbi.neural_nets import VectorFieldEstimatorBuilder`.",
+                "Use a score config instead, e.g. "
+                "`from sbi.neural_nets import VEScoreConfig`.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/sbi/inference/trainers/vfpe/npse.py
+++ b/sbi/inference/trainers/vfpe/npse.py
@@ -113,10 +113,9 @@ class NPSE(VectorFieldTrainer):
             sde_type: Type of SDE to use. Must be one of ['vp', 've', 'subvp'].
                 Defaults to ``None`` (resolved to ``"ve"``). When
                 ``vf_estimator`` is ``None``, forwarded to the default
-                config. When a score config is passed,
-                a non-``None`` ``sde_type`` that differs from the builder's
-                value raises ``ValueError`` (set it on the builder instead).
-                When a string (deprecated), forwarded to
+                config. When a score config is passed, any non-``None``
+                ``sde_type`` raises ``ValueError`` because the config class
+                already selects the SDE. When a string (deprecated), forwarded to
                 ``posterior_score_nn``.
             device: Device to run the training on.
             logging_level: Logging level for the training. Can be an integer or a
@@ -161,8 +160,6 @@ class NPSE(VectorFieldTrainer):
             )
             vf_estimator = density_estimator
 
-        # A config carries the SDE as its class, so the deprecated kwarg has
-        # nothing left to say.
         if isinstance(vf_estimator, ScoreConfigBase) and sde_type is not None:
             raise ValueError(
                 f"Conflicting `sde_type`: trainer received {sde_type!r} but "
@@ -170,7 +167,6 @@ class NPSE(VectorFieldTrainer):
                 "the config only."
             )
 
-        # Resolve sde_type sentinel for non-config paths.
         resolved_sde_type = sde_type if sde_type is not None else "ve"
 
         if vf_estimator is None:

--- a/sbi/neural_nets/__init__.py
+++ b/sbi/neural_nets/__init__.py
@@ -32,7 +32,6 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     NSFConfig,
     ResNetClassifierConfig,
     TabPFNConfig,
-    VectorFieldEstimatorBuilder,
     ZukoBPFConfig,
     ZukoGFConfig,
     ZukoMAFConfig,
@@ -43,6 +42,17 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     ZukoSOSPFConfig,
     ZukoUNAFConfig,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import (
+    AdaMLPConfig,
+    FlowMatchingConfig,
+    MLPConfig,
+    ScoreConfigBase,
+    SubVPScoreConfig,
+    TransformerConfig,
+    VEScoreConfig,
+    VPScoreConfig,
+    VectorFieldConfigBase,
+)
 
 __all__ = [
     "classifier_nn",
@@ -51,7 +61,16 @@ __all__ = [
     "posterior_nn",
     "posterior_score_nn",
     "posterior_flow_nn",
-    "VectorFieldEstimatorBuilder",
+    # Vector field estimators (FMPE / NPSE).
+    "VectorFieldConfigBase",
+    "FlowMatchingConfig",
+    "ScoreConfigBase",
+    "VEScoreConfig",
+    "VPScoreConfig",
+    "SubVPScoreConfig",
+    "MLPConfig",
+    "AdaMLPConfig",
+    "TransformerConfig",
     # Conditional density estimators (NPE / NLE).
     "DensityConfigBase",
     "MAFConfig",

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -350,6 +350,8 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
         embedding_net: Optional[nn.Module] = None,
         mean_base: Union[float, Tensor] = 0.0,
         std_base: Union[float, Tensor] = 1.0,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
     ) -> None:
         r"""Base class for vector field estimators.
 
@@ -364,6 +366,11 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
                 condition.
             mean_base: Mean of the base distribution.
             std_base: Standard deviation of the base distribution.
+            compose_shift: Shift of the boundary affine, i.e. the mean of the
+                standardized coordinates the estimator is trained in. Given
+                together with `compose_scale`.
+            compose_scale: Scale of the boundary affine, given together with
+                `compose_shift`.
         """
         super().__init__(input_shape, condition_shape)
         self.net = net
@@ -396,6 +403,14 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
         self.register_buffer(
             "_compose_standardization", torch.tensor(False), persistent=True
         )
+        if (compose_shift is None) != (compose_scale is None):
+            raise ValueError(
+                "`compose_shift` and `compose_scale` have to be given together."
+            )
+        if compose_shift is not None and compose_scale is not None:
+            self._theta_shift.copy_(compose_shift.reshape(1, *self.input_shape).float())
+            self._theta_scale.copy_(compose_scale.reshape(1, *self.input_shape).float())
+            self._compose_standardization.fill_(True)
 
     def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
         r"""Load legacy checkpoints as compose-off and reject partial affines."""

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -408,9 +408,21 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
                 "`compose_shift` and `compose_scale` have to be given together."
             )
         if compose_shift is not None and compose_scale is not None:
-            self._theta_shift.copy_(compose_shift.reshape(1, *self.input_shape).float())
-            self._theta_scale.copy_(compose_scale.reshape(1, *self.input_shape).float())
+            shift = compose_shift.reshape(1, *self.input_shape).float()
+            scale = compose_scale.reshape(1, *self.input_shape).float()
+            self._validate_compose_affine(shift, scale)
+            self._theta_shift.copy_(shift)
+            self._theta_scale.copy_(scale)
             self._compose_standardization.fill_(True)
+
+    @staticmethod
+    def _validate_compose_affine(shift: Tensor, scale: Tensor) -> None:
+        if not torch.isfinite(shift).all():
+            raise ValueError("`compose_shift` must contain only finite values.")
+        if not torch.isfinite(scale).all() or not (scale > 0).all():
+            raise ValueError(
+                "`compose_scale` must contain only finite, strictly positive values."
+            )
 
     def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
         r"""Load legacy checkpoints as compose-off and reject partial affines."""
@@ -433,6 +445,8 @@ class ConditionalVectorFieldEstimator(ConditionalEstimator, ABC):
                 False, device=self._compose_standardization.device
             )
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
+        if self.compose_enabled:
+            self._validate_compose_affine(self._theta_shift, self._theta_scale)
         self._check_compose_internal_stats_unit()
         baseline_check = getattr(self, "_check_compose_baseline_compatible", None)
         if baseline_check is not None:

--- a/sbi/neural_nets/estimators/flowmatching_estimator.py
+++ b/sbi/neural_nets/estimators/flowmatching_estimator.py
@@ -65,6 +65,8 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
         mean_0: float = 0.0,
         std_0: float = 1.0,
         gaussian_baseline: bool = False,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
         **kwargs,
     ) -> None:
         r"""Creates a vector field estimator for Flow Matching.
@@ -83,6 +85,10 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
             gaussian_baseline: If True, use analytical Gaussian baseline velocity
                 derived from Bayes' rule: v = factor * (x - μ_true) - mean.
                 The network then only learns the residual. Default: False.
+            compose_shift: Shift of the boundary affine, given together with
+                `compose_scale`.
+            compose_scale: Scale of the boundary affine, given together with
+                `compose_shift`.
         """
 
         if "num_freqs" in kwargs:
@@ -99,6 +105,8 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
             input_shape=input_shape,
             condition_shape=condition_shape,
             embedding_net=embedding_net,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
         )
         self.noise_scale = noise_scale
         self.gaussian_baseline = gaussian_baseline
@@ -108,6 +116,8 @@ class FlowMatchingEstimator(ConditionalVectorFieldEstimator):
         std_0_tensor = torch.as_tensor(std_0).expand(input_shape).clone()
         self.register_buffer("mean_0", mean_0_tensor)
         self.register_buffer("std_0", std_0_tensor)
+        self._check_compose_internal_stats_unit()
+        self._check_compose_baseline_compatible()
 
     def _check_compose_baseline_compatible(self) -> None:
         """Reject incompatible analytical and composed standardization baselines."""

--- a/sbi/neural_nets/estimators/score_estimator.py
+++ b/sbi/neural_nets/estimators/score_estimator.py
@@ -83,6 +83,8 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         std_0: Union[Tensor, float] = 1.0,
         t_min: float = 1e-3,
         t_max: float = 1.0,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
     ) -> None:
         r"""Score estimator class that estimates the
         conditional score function, i.e.,
@@ -104,6 +106,10 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
             std_0: Starting standard deviation of the target distribution.
             t_min: Minimum time for diffusion (0 can be numerically unstable).
             t_max: Maximum time for diffusion.
+            compose_shift: Shift of the boundary affine, given together with
+                `compose_scale`.
+            compose_scale: Scale of the boundary affine, given together with
+                `compose_shift`.
         """
 
         # Starting mean and std of the target distribution (otherwise assumes 0,1).
@@ -122,6 +128,8 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
             embedding_net=embedding_net,
             t_min=t_min,
             t_max=t_max,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
         )
 
         # Min/max values for noise variance beta
@@ -132,6 +140,7 @@ class ConditionalScoreEstimator(ConditionalVectorFieldEstimator):
         self._set_weight_fn(weight_fn)
         self.register_buffer("mean_0", mean_0.clone().detach())
         self.register_buffer("std_0", std_0.clone().detach())
+        self._check_compose_internal_stats_unit()
 
         # Now that input_shape and mean_0, std_0 is set, we can compute the proper mean
         # and std for the "base" distribution.
@@ -564,6 +573,8 @@ class VPScoreEstimator(ConditionalScoreEstimator):
         std_0: Union[Tensor, float] = 1.0,
         t_min: float = 1e-3,
         t_max: float = 1.0,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
     ) -> None:
         super().__init__(
             net,
@@ -577,6 +588,8 @@ class VPScoreEstimator(ConditionalScoreEstimator):
             beta_max=beta_max,
             t_min=t_min,
             t_max=t_max,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
         )
 
     def mean_t_fn(self, times: Tensor) -> Tensor:
@@ -677,6 +690,8 @@ class SubVPScoreEstimator(ConditionalScoreEstimator):
         std_0: float = 1.0,
         t_min: float = 1e-2,
         t_max: float = 1.0,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
     ) -> None:
         super().__init__(
             net,
@@ -690,6 +705,8 @@ class SubVPScoreEstimator(ConditionalScoreEstimator):
             std_0=std_0,
             t_min=t_min,
             t_max=t_max,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
         )
 
     def mean_t_fn(self, times: Tensor) -> Tensor:
@@ -823,6 +840,8 @@ class VEScoreEstimator(ConditionalScoreEstimator):
         lognormal_mean: float = -1.2,
         lognormal_std: float = 1.2,
         power_law_exponent: float = 7.0,
+        compose_shift: Optional[Tensor] = None,
+        compose_scale: Optional[Tensor] = None,
     ) -> None:
         # Validate sigma bounds (required for VE SDE math and log computations).
         if sigma_min <= 0:
@@ -875,6 +894,8 @@ class VEScoreEstimator(ConditionalScoreEstimator):
             std_0=std_0,
             t_min=t_min,
             t_max=t_max,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
         )
 
         self._warn_on_inappropriate_config()

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -18,9 +18,9 @@ from sbi.neural_nets.net_builders.estimator_configs import (
 )
 from sbi.neural_nets.net_builders.flow import build_zuko_unconditional_flow
 from sbi.neural_nets.net_builders.vector_field_nets import (
-    FlowEstimatorConfig,
-    ScoreEstimatorConfig,
-    build_vector_field_estimator,
+    FlowMatchingConfig,
+    _score_config_from_sde_type,
+    _vf_config_from_factory_kwargs,
 )
 from sbi.utils.nn_utils import check_net_device
 from sbi.utils.vector_field_utils import VectorFieldNet
@@ -440,8 +440,8 @@ def posterior_score_nn(
         compose_standardization: Opt-in per-dim affine standardization theta<->z
             for scale-equivariant calibration. Defaults to False.
         **kwargs: Additional estimator / network arguments.  Valid keys are
-            defined by ``ScoreEstimatorConfig``; unknown keys raise
-            ``TypeError``.
+            the fields of the chosen score config and of the network's config;
+            an unknown key warns and is forwarded to the network builder.
 
     Returns:
         Constructor function for NPSE.
@@ -451,33 +451,31 @@ def posterior_score_nn(
             "compose_standardization=True requires z_score_theta='independent'."
         )
 
-    # Map user-facing parameter names to internal names.
-    # Builder takes batch_x=batch_theta, so its z_score_x is the theta setting.
-    mapped = dict(
-        z_score_x=z_score_theta,
-        z_score_y=z_score_x,
-        hidden_features=hidden_features,
-        num_layers=num_layers,
-        embedding_net=check_net_device(embedding_net, "cpu", embedding_net_warn_msg),
-        time_embedding_dim=t_embedding_dim,
-        time_emb_type=time_emb_type,
-        net=model,
-        compose_standardization=compose_standardization,
+    # The estimator models theta given x, so its input is the theta setting.
+    config = _vf_config_from_factory_kwargs(
+        _score_config_from_sde_type(sde_type),
+        model,
+        named_net=dict(
+            hidden_features=hidden_features,
+            num_layers=num_layers,
+            time_embedding_dim=t_embedding_dim,
+            time_emb_type=time_emb_type,
+        ),
+        named_estimator=_drop_unset_z_scoring(
+            dict(
+                z_score_input=z_score_theta,
+                z_score_condition=z_score_x,
+                embedding_net=check_net_device(
+                    embedding_net, "cpu", embedding_net_warn_msg
+                ),
+                compose_standardization=compose_standardization,
+            )
+        ),
+        extra=kwargs,
     )
 
-    # Validate against known fields — warns on unknown kwargs (typos)
-    # while still forwarding them to the underlying builder.
-    config = ScoreEstimatorConfig.from_kwargs(**mapped, **kwargs)
-    builder_kwargs = config.to_dict()
-
     def build_fn(batch_theta, batch_x):
-        return build_vector_field_estimator(
-            batch_x=batch_theta,
-            batch_y=batch_x,
-            estimator_type="score",
-            sde_type=sde_type,
-            **builder_kwargs,
-        )
+        return config.build(batch_input=batch_theta, batch_condition=batch_x)
 
     return build_fn
 
@@ -533,8 +531,8 @@ def posterior_flow_nn(
         compose_standardization: Opt-in per-dim affine standardization theta<->z
             for scale-equivariant calibration. Defaults to False.
         **kwargs: Additional estimator / network arguments.  Valid keys are
-            defined by ``FlowEstimatorConfig``; unknown keys raise
-            ``TypeError``.
+            the fields of ``FlowMatchingConfig`` and of the network's config;
+            an unknown key warns and is forwarded to the network builder.
 
     Returns:
         Constructor function for FMPE.
@@ -544,32 +542,32 @@ def posterior_flow_nn(
             "compose_standardization=True requires z_score_theta='independent'."
         )
 
-    # Map user-facing parameter names to internal names.
-    mapped = dict(
-        z_score_x=z_score_theta,
-        z_score_y=z_score_x,
-        hidden_features=hidden_features,
-        num_layers=num_layers,
-        embedding_net=check_net_device(embedding_net, "cpu", embedding_net_warn_msg),
-        time_embedding_dim=t_embedding_dim,
-        time_emb_type=time_emb_type,
-        net=model,
-        gaussian_baseline=gaussian_baseline,
-        compose_standardization=compose_standardization,
+    # The estimator models theta given x, so its input is the theta setting.
+    config = _vf_config_from_factory_kwargs(
+        FlowMatchingConfig(),
+        model,
+        named_net=dict(
+            hidden_features=hidden_features,
+            num_layers=num_layers,
+            time_embedding_dim=t_embedding_dim,
+            time_emb_type=time_emb_type,
+        ),
+        named_estimator=_drop_unset_z_scoring(
+            dict(
+                z_score_input=z_score_theta,
+                z_score_condition=z_score_x,
+                embedding_net=check_net_device(
+                    embedding_net, "cpu", embedding_net_warn_msg
+                ),
+                gaussian_baseline=gaussian_baseline,
+                compose_standardization=compose_standardization,
+            )
+        ),
+        extra=kwargs,
     )
 
-    # Validate against known fields — warns on unknown kwargs (typos)
-    # while still forwarding them to the underlying builder.
-    config = FlowEstimatorConfig.from_kwargs(**mapped, **kwargs)
-    builder_kwargs = config.to_dict()
-
     def build_fn(batch_theta, batch_x):
-        return build_vector_field_estimator(
-            batch_x=batch_theta,
-            batch_y=batch_x,
-            estimator_type="flow",
-            **builder_kwargs,
-        )
+        return config.build(batch_input=batch_theta, batch_condition=batch_x)
 
     return build_fn
 

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -451,7 +451,6 @@ def posterior_score_nn(
             "compose_standardization=True requires z_score_theta='independent'."
         )
 
-    # The estimator models theta given x, so its input is the theta setting.
     config = _vf_config_from_factory_kwargs(
         _score_config_from_sde_type(sde_type),
         model,
@@ -461,7 +460,7 @@ def posterior_score_nn(
             time_embedding_dim=t_embedding_dim,
             time_emb_type=time_emb_type,
         ),
-        named_estimator=_drop_unset_z_scoring(
+        named_estimator=_normalize_z_scoring(
             dict(
                 z_score_input=z_score_theta,
                 z_score_condition=z_score_x,
@@ -542,7 +541,6 @@ def posterior_flow_nn(
             "compose_standardization=True requires z_score_theta='independent'."
         )
 
-    # The estimator models theta given x, so its input is the theta setting.
     config = _vf_config_from_factory_kwargs(
         FlowMatchingConfig(),
         model,
@@ -552,7 +550,7 @@ def posterior_flow_nn(
             time_embedding_dim=t_embedding_dim,
             time_emb_type=time_emb_type,
         ),
-        named_estimator=_drop_unset_z_scoring(
+        named_estimator=_normalize_z_scoring(
             dict(
                 z_score_input=z_score_theta,
                 z_score_condition=z_score_x,

--- a/sbi/neural_nets/net_builders/__init__.py
+++ b/sbi/neural_nets/net_builders/__init__.py
@@ -30,7 +30,6 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     NSFConfig,
     ResNetClassifierConfig,
     TabPFNConfig,
-    VectorFieldEstimatorBuilder,
     ZukoBPFConfig,
     ZukoGFConfig,
     ZukoMAFConfig,
@@ -60,6 +59,15 @@ from sbi.neural_nets.net_builders.flow import (
 from sbi.neural_nets.net_builders.mdn import build_mdn
 from sbi.neural_nets.net_builders.mixed_nets import build_mnle, build_mnpe
 from sbi.neural_nets.net_builders.vector_field_nets import (
+    AdaMLPConfig,
+    FlowMatchingConfig,
+    MLPConfig,
+    ScoreConfigBase,
+    SubVPScoreConfig,
+    TransformerConfig,
+    VEScoreConfig,
+    VPScoreConfig,
+    VectorFieldConfigBase,
     build_flow_matching_estimator,
     build_score_matching_estimator,
     build_vector_field_estimator,

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -21,10 +21,10 @@ The legacy ``MarginalFlowConfig`` is the factory-side validator from before
 that change. It keeps a flat field set with ``None`` as the "unset" sentinel,
 and ``from_kwargs()`` warns on unknown names while still forwarding them.
 
-``VectorFieldEstimatorBuilder`` is likewise still a flat builder, with the
-signature-derived ``_reject_inapplicable_fields`` guard that the per-model
-classes make unnecessary.  Its conversion needs its own design round, because
-its build function selects along more than one axis at a time.
+The vector-field configs live next to their build functions in
+``vector_field_nets``, because the estimator and the network it wraps are two
+separate choices and the network configs point at the ``build_*_network``
+functions directly.
 """
 
 import inspect
@@ -51,7 +51,6 @@ from nflows.transforms.splines import (
 from torch import Tensor
 from torch.distributions import Distribution
 
-from sbi.neural_nets.estimators import ConditionalVectorFieldEstimator
 from sbi.neural_nets.estimators.base import (
     ConditionalDensityEstimator,
     ConditionalEstimator,
@@ -319,183 +318,6 @@ class MarginalFlowConfig(_EstimatorBuilderBase):
 VF_MODELS = Literal["mlp", "ada_mlp", "transformer", "transformer_cross_attn"]
 
 _VALID_VF_MODELS = frozenset(get_args(VF_MODELS))
-
-
-def _vector_field_build_fns() -> dict:
-    """Build-function mapping for vector field estimators (per architecture)."""
-    from sbi.neural_nets.net_builders.vector_field_nets import (
-        build_adamlp_network,
-        build_standard_mlp_network,
-        build_transformer_network,
-    )
-
-    return {
-        "mlp": build_standard_mlp_network,
-        "ada_mlp": build_adamlp_network,
-        "transformer": build_transformer_network,
-        "transformer_cross_attn": build_transformer_network,
-    }
-
-
-_SCORE_ONLY_FIELDS: frozenset = frozenset({
-    "sde_type",
-    "train_schedule",
-    "solve_schedule",
-    "sigma_min",
-    "sigma_max",
-    "lognormal_mean",
-    "lognormal_std",
-    "power_law_exponent",
-    "beta_min",
-    "beta_max",
-})
-
-_FLOW_ONLY_FIELDS: frozenset = frozenset({"gaussian_baseline"})
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class VectorFieldEstimatorBuilder(_EstimatorBuilderBase):
-    """Builder for vector-field estimators (FMPE / NPSE).
-
-    Covers MLP, AdaMLP, Transformer, and cross-attention Transformer
-    architectures used by ``FMPE`` (flow matching) and ``NPSE`` (score
-    matching).  ``build()`` forwards to ``build_vector_field_estimator``,
-    which constructs a ``FlowMatchingEstimator`` for ``"flow"`` and a
-    ``ConditionalScoreEstimator`` subclass for ``"score"``.
-    """
-
-    _DISCRIMINATORS: ClassVar[frozenset] = frozenset({
-        "model",
-        "estimator_type",
-    })
-
-    model: VF_MODELS = "mlp"  # type: ignore[valid-type]
-    estimator_type: Optional[Literal["flow", "score"]] = None
-    sde_type: Optional[Literal["vp", "ve", "subvp"]] = None
-
-    # --- Shared fields ---
-    z_score_input: Optional[Literal["none", "independent", "structured"]] = None
-    z_score_condition: Optional[Literal["none", "independent", "structured"]] = None
-    hidden_features: Optional[Union[Sequence[int], int]] = None
-    num_layers: Optional[int] = None
-    time_embedding_dim: Optional[int] = None
-    embedding_net: Optional[nn.Module] = None
-
-    # --- Transformer-specific ---
-    num_heads: Optional[int] = None
-    mlp_ratio: Optional[int] = None
-
-    # --- Flow-matching-specific ---
-    gaussian_baseline: Optional[bool] = None
-
-    # --- Shared estimator option ---
-    compose_standardization: Optional[bool] = None
-
-    # --- Score-matching-specific (VE schedule) ---
-    train_schedule: Optional[Literal["uniform", "lognormal"]] = None
-    solve_schedule: Optional[Literal["uniform", "power_law"]] = None
-    sigma_min: Optional[float] = None
-    sigma_max: Optional[float] = None
-    lognormal_mean: Optional[float] = None
-    lognormal_std: Optional[float] = None
-    power_law_exponent: Optional[float] = None
-
-    # --- Score-matching-specific (VP / SubVP) ---
-    beta_min: Optional[float] = None
-    beta_max: Optional[float] = None
-
-    def __post_init__(self):
-        if self.model not in _VALID_VF_MODELS:
-            raise ValueError(
-                f"Unknown model {self.model!r}. "
-                f"Must be one of {sorted(_VALID_VF_MODELS)}."
-            )
-        super().__post_init__()
-
-        # Reject fields that don't apply to the chosen estimator_type.
-        # Skip this guard when estimator_type is None (resolved by the trainer).
-        if self.estimator_type is not None:
-            blocked = (
-                _SCORE_ONLY_FIELDS
-                if self.estimator_type == "flow"
-                else _FLOW_ONLY_FIELDS
-            )
-            bad = {
-                f.name
-                for f in fields(self)
-                if f.name in blocked and getattr(self, f.name) is not None
-            }
-            if bad:
-                raise ValueError(
-                    f"Field(s) {sorted(bad)} do not apply to "
-                    f"estimator_type={self.estimator_type!r}. Remove them or "
-                    f"change estimator_type."
-                )
-
-        # Reject fields inapplicable to the chosen model architecture.
-        always_ok = (
-            frozenset({"z_score_input", "z_score_condition", "compose_standardization"})
-            | _SCORE_ONLY_FIELDS
-            | _FLOW_ONLY_FIELDS
-        )
-        self._reject_inapplicable_fields(
-            _vector_field_build_fns()[self.model],
-            discriminator="model",
-            always_ok=always_ok,
-        )
-
-    def build(
-        self, batch_input: Tensor, batch_condition: Tensor
-    ) -> ConditionalVectorFieldEstimator:
-        """Build the vector-field estimator by dispatching to
-        ``build_flow_matching_estimator`` or
-        ``build_score_matching_estimator``.
-
-        Args:
-            batch_input: Batch of the modeled variable used for
-                shape inference and z-scoring.
-            batch_condition: Batch of the conditioning variable
-                used for shape inference and z-scoring.
-
-        Returns:
-            A ``ConditionalVectorFieldEstimator``.
-        """
-        from sbi.neural_nets.net_builders.vector_field_nets import (
-            build_vector_field_estimator,
-        )
-
-        if self.estimator_type is None:
-            raise ValueError(
-                "estimator_type is None. The trainer should resolve this "
-                "before calling build(). Use dataclasses.replace() to set "
-                "estimator_type='flow' or 'score'."
-            )
-
-        kwargs = self._build_kwargs()
-        # sde_type is excluded from _build_kwargs() and passed
-        # explicitly to build_vector_field_estimator.
-        sde_type = self.sde_type or "ve"
-
-        return build_vector_field_estimator(
-            batch_x=batch_input,
-            batch_y=batch_condition,
-            estimator_type=self.estimator_type,
-            sde_type=sde_type,
-            **kwargs,
-        )
-
-    def _build_kwargs(self) -> dict:
-        """Non-None fields minus discriminators and sde_type, alias-translated."""
-        excluded = self._DISCRIMINATORS | {"sde_type", "extra_kwargs"}
-        d = {
-            _BUILD_KWARG_ALIASES.get(f.name, f.name): getattr(self, f.name)
-            for f in fields(self)
-            if f.name not in excluded and getattr(self, f.name) is not None
-        }
-        # The build function expects `net` for the architecture name.
-        d["net"] = self.model
-        d.update(self.extra_kwargs)
-        return d
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -1370,6 +1370,10 @@ class _VectorFieldNetConfigBase(_PerModelConfigBase):
 
     def __post_init__(self):
         self._reject_if_abstract(_VectorFieldNetConfigBase, "MLPConfig()")
+        if not isinstance(self.hidden_features, int) or isinstance(
+            self.hidden_features, bool
+        ):
+            raise TypeError("`hidden_features` must be an int.")
         super().__post_init__()
 
     def build(self, batch_input: Tensor, batch_condition: Tensor) -> VectorFieldNet:
@@ -1453,7 +1457,7 @@ class VectorFieldConfigBase(_PerModelConfigBase):
     Neither choice constrains the other, so there is no discriminator field.
 
     Args:
-        net: Config of the network to wrap, or a ready ``VectorFieldNet``.
+        net: Config of the network to wrap, or a ready custom network module.
         z_score_input: Whether to z-score the modeled variable, one of `none`,
             `independent`, or `structured`.
         z_score_condition: Whether to z-score the conditioning variable, same
@@ -1466,9 +1470,7 @@ class VectorFieldConfigBase(_PerModelConfigBase):
             settings belong in ``net.extra_kwargs``.
     """
 
-    net: Union[_VectorFieldNetConfigBase, VectorFieldNet] = field(
-        default_factory=MLPConfig
-    )
+    net: Union[_VectorFieldNetConfigBase, nn.Module] = field(default_factory=MLPConfig)
     z_score_input: Literal["none", "independent", "structured"] = "independent"
     z_score_condition: Literal["none", "independent", "structured"] = "independent"
     embedding_net: nn.Module = field(default_factory=nn.Identity)
@@ -1488,6 +1490,10 @@ class VectorFieldConfigBase(_PerModelConfigBase):
 
     def __post_init__(self):
         self._reject_if_abstract(VectorFieldConfigBase, "FlowMatchingConfig()")
+        if not isinstance(self.net, (_VectorFieldNetConfigBase, nn.Module)):
+            raise TypeError(
+                "`net` must be a vector-field network config or an nn.Module."
+            )
         super().__post_init__()
 
     def _build_kwargs(self) -> dict:
@@ -1517,9 +1523,9 @@ class VectorFieldConfigBase(_PerModelConfigBase):
         check_data_device(batch_input, batch_condition)
 
         if isinstance(self.net, _VectorFieldNetConfigBase):
-            # The network takes the embedded condition only to read its shape,
-            # so the embedding runs once here and lives on the estimator alone.
-            embedded_condition = self.embedding_net(batch_condition[:1])
+            embedded_condition = self.embedding_net.to(batch_condition.device)(
+                batch_condition[:1]
+            )
             vectorfield_net = self.net.build(batch_input, embedded_condition)
         else:
             vectorfield_net = self.net
@@ -1745,8 +1751,6 @@ def _vf_config_from_factory_kwargs(
             net_config, **named_net, **net_kwargs, extra_kwargs=unknown
         )
     else:
-        # A custom network is built by the user, so a network setting it cannot
-        # read would be silently ignored.
         defaults = _net_config_defaults()
         ignored = sorted(
             {k for k, v in named_net.items() if v != defaults[k]}

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -1368,6 +1368,8 @@ class _VectorFieldNetConfigBase(_PerModelConfigBase):
     _BUILD_FN: ClassVar[Callable]
     """Network build function this config feeds, set by each subclass."""
 
+    _SHADOWED_EXTRA_KWARGS: ClassVar[frozenset[str]] = frozenset({"embedding_net"})
+
     def __post_init__(self):
         self._reject_if_abstract(_VectorFieldNetConfigBase, "MLPConfig()")
         if not isinstance(self.hidden_features, int) or isinstance(

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -3,13 +3,14 @@
 
 import math
 import warnings
-from dataclasses import dataclass
-from typing import Any, Literal, Optional, Sequence, Union
+from dataclasses import MISSING, dataclass, field, fields, replace
+from typing import Callable, ClassVar, Literal, Optional, Sequence, Union
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from sbi.neural_nets.estimators.base import ConditionalVectorFieldEstimator
 from sbi.neural_nets.estimators.flowmatching_estimator import FlowMatchingEstimator
 from sbi.neural_nets.estimators.score_estimator import (
     ConditionalScoreEstimator,
@@ -19,7 +20,8 @@ from sbi.neural_nets.estimators.score_estimator import (
 )
 from sbi.neural_nets.net_builders.estimator_configs import (
     VF_MODELS,
-    _EstimatorBuilderBase,
+    _VALID_VF_MODELS,
+    _PerModelConfigBase,
 )
 from sbi.utils.nn_utils import get_numel
 from sbi.utils.sbiutils import (
@@ -30,88 +32,6 @@ from sbi.utils.sbiutils import (
 )
 from sbi.utils.user_input_checks import check_data_device
 from sbi.utils.vector_field_utils import VectorFieldNet
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class _VectorFieldBaseConfig(_EstimatorBuilderBase):
-    """Shared configuration fields for all vector field estimator builders.
-
-    Inherits ``to_dict()`` from ``_EstimatorBuilderBase``.
-    Defaults are ``None`` so that only explicitly-set fields are forwarded — the
-    actual default values live in the estimator / network constructors.
-    """
-
-    # Network architecture extras (shared)
-    activation: Optional[Any] = None
-    sinusoidal_max_freq: Optional[float] = None
-    fourier_scale: Optional[float] = None
-
-    # Apply a per-dimension boundary affine around the vector-field estimator.
-    compose_standardization: Optional[bool] = None
-
-    # MLP-specific
-    layer_norm: Optional[bool] = None
-    skip_connections: Optional[bool] = None
-
-    # AdaMLP-specific
-    condition_emb_dim: Optional[int] = None
-    num_intermediate_mlp_layers: Optional[int] = None
-    adamlp_ratio: Optional[int] = None
-
-    # Transformer-specific
-    is_x_emb_seq: Optional[bool] = None
-
-    # Params that are explicit in build_vector_field_estimator but may be
-    # passed through **kwargs at the factory level
-    net: Optional[Any] = None
-    z_score_x: Optional[Any] = None
-    z_score_y: Optional[Any] = None
-    hidden_features: Optional[Any] = None
-    num_layers: Optional[int] = None
-    time_embedding_dim: Optional[int] = None
-    num_heads: Optional[int] = None
-    mlp_ratio: Optional[int] = None
-    embedding_net: Optional[Any] = None
-    time_emb_type: Optional[str] = None
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class ScoreEstimatorConfig(_VectorFieldBaseConfig):
-    """Configuration for score-matching estimator builders (NPSE).
-
-    Extends the base config with SDE-specific parameters for VE, VP, and SubVP
-    noise schedules.  Unknown parameters raise ``TypeError`` on direct
-    construction but are warned-and-forwarded via ``from_kwargs()``.
-    """
-
-    # VE schedule params (Karras et al. 2022)
-    train_schedule: Optional[Literal["uniform", "lognormal"]] = None
-    solve_schedule: Optional[Literal["uniform", "power_law"]] = None
-    sigma_min: Optional[float] = None
-    sigma_max: Optional[float] = None
-    lognormal_mean: Optional[float] = None
-    lognormal_std: Optional[float] = None
-    power_law_exponent: Optional[float] = None
-
-    # VP / SubVP params
-    beta_min: Optional[float] = None
-    beta_max: Optional[float] = None
-
-    # Note: ``sde_type`` and ``estimator_type`` are intentionally absent.
-    # They are consumed at the factory level (``posterior_score_nn``) before
-    # config construction and are not forwarded through the config.
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class FlowEstimatorConfig(_VectorFieldBaseConfig):
-    """Configuration for flow-matching estimator builders (FMPE).
-
-    Currently identical to the base config.  Unknown parameters raise
-    ``TypeError`` on direct construction but are warned-and-forwarded
-    via ``from_kwargs()``.
-    """
-
-    gaussian_baseline: Optional[bool] = None
 
 
 def _compute_theta_standardization(
@@ -180,9 +100,8 @@ def build_vector_field_estimator(
         compose_standardization: Whether to train and sample in per-dimension
             standardized theta coordinates. Defaults to False.
         **kwargs: Additional arguments forwarded to the estimator and network
-            constructors.  Valid keys are defined by ``ScoreEstimatorConfig``
-            and ``FlowEstimatorConfig``; validation happens in the upstream
-            factory functions (``posterior_score_nn`` / ``posterior_flow_nn``).
+            constructors.  This function backs the deprecated paths only; the
+            configs are the validated surface.
 
     Returns:
         A vector field estimator (either FlowMatchingEstimator or
@@ -1415,3 +1334,432 @@ def build_transformer_network(
     )
 
     return vectorfield_net
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _VectorFieldNetConfigBase(_PerModelConfigBase):
+    """Base configuration for the networks a vector-field estimator wraps.
+
+    Subclasses add the settings their architecture accepts and point
+    ``_BUILD_FN`` at the ``build_*_network`` function that consumes them.  A
+    setting an architecture does not accept is not a field on its config, so it
+    raises ``TypeError`` at construction rather than being ignored.
+
+    Args:
+        hidden_features: Width of the hidden layers.
+        num_layers: Number of layers.
+        time_embedding_dim: Number of dimensions of the time embedding.
+        activation: Activation function.
+        time_emb_type: Type of time embedding.
+        sinusoidal_max_freq: Maximum frequency of the sinusoidal embedding.
+        fourier_scale: Scale of the random Fourier embedding.
+        extra_kwargs: Additional keyword arguments forwarded to the network
+            build function, for settings that have no field of their own.
+    """
+
+    hidden_features: int = 100
+    num_layers: int = 5
+    time_embedding_dim: int = 32
+    activation: type[nn.Module] = nn.GELU
+    time_emb_type: Literal["sinusoidal", "random_fourier"] = "sinusoidal"
+    sinusoidal_max_freq: float = 1000.0
+    fourier_scale: float = 30.0
+
+    _BUILD_FN: ClassVar[Callable]
+    """Network build function this config feeds, set by each subclass."""
+
+    def __post_init__(self):
+        self._reject_if_abstract(_VectorFieldNetConfigBase, "MLPConfig()")
+        super().__post_init__()
+
+    def build(self, batch_input: Tensor, batch_condition: Tensor) -> VectorFieldNet:
+        """Build the network.
+
+        Args:
+            batch_input: Batch of the modeled variable, used for shape
+                inference.
+            batch_condition: Batch of the embedded conditioning variable, used
+                for shape inference. The estimator owns the embedding net, so
+                the network never holds one.
+
+        Returns:
+            A ``VectorFieldNet``.
+        """
+        self._warn_unknown_extra_kwargs(self._BUILD_FN)
+        return self._BUILD_FN(
+            batch_x=batch_input, batch_y=batch_condition, **self._build_kwargs()
+        )
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class MLPConfig(_VectorFieldNetConfigBase):
+    """Standard vector-field MLP.
+
+    Args:
+        layer_norm: Whether to apply layer normalization.
+        skip_connections: Whether to use skip connections between layers.
+    """
+
+    layer_norm: bool = True
+    skip_connections: bool = True
+
+    _BUILD_FN: ClassVar[Callable] = staticmethod(build_standard_mlp_network)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class AdaMLPConfig(_VectorFieldNetConfigBase):
+    """MLP with adaptive layer normalization conditioned on time.
+
+    Args:
+        condition_emb_dim: Dimension of the condition embedding.
+        num_intermediate_mlp_layers: Number of intermediate blocks in the global
+            embedding MLP.
+        adamlp_ratio: Ratio of the hidden dimension in each AdaMLP block.
+        mlp_ratio: Ratio of the hidden dimension in the global embedding MLP.
+    """
+
+    condition_emb_dim: int = 100
+    num_intermediate_mlp_layers: int = 0
+    adamlp_ratio: int = 4
+    mlp_ratio: int = 4
+
+    _BUILD_FN: ClassVar[Callable] = staticmethod(build_adamlp_network)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class TransformerConfig(_VectorFieldNetConfigBase):
+    """Diffusion transformer.
+
+    Args:
+        num_heads: Number of attention heads per block.
+        mlp_ratio: Ratio of the hidden dimension in each block's MLP.
+        is_x_emb_seq: Whether the embedded condition is a sequence, which
+            selects cross-attention instead of adaptive layer normalization.
+    """
+
+    num_heads: int = 10
+    mlp_ratio: int = 4
+    is_x_emb_seq: bool = False
+
+    _BUILD_FN: ClassVar[Callable] = staticmethod(build_transformer_network)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class VectorFieldConfigBase(_PerModelConfigBase):
+    """Base configuration for vector-field estimators (FMPE / NPSE).
+
+    The estimator and the network it wraps are configured separately: the
+    subclass selects the estimator, and ``net`` selects the architecture.
+    Neither choice constrains the other, so there is no discriminator field.
+
+    Args:
+        net: Config of the network to wrap, or a ready ``VectorFieldNet``.
+        z_score_input: Whether to z-score the modeled variable, one of `none`,
+            `independent`, or `structured`.
+        z_score_condition: Whether to z-score the conditioning variable, same
+            options as `z_score_input`.
+        embedding_net: Embedding network for the conditioning variable.
+        compose_standardization: Whether to train and sample in per-dimension
+            standardized coordinates of the modeled variable.
+        extra_kwargs: Additional keyword arguments forwarded to the estimator
+            constructor, for settings that have no field of their own. Network
+            settings belong in ``net.extra_kwargs``.
+    """
+
+    net: Union[_VectorFieldNetConfigBase, VectorFieldNet] = field(
+        default_factory=MLPConfig
+    )
+    z_score_input: Literal["none", "independent", "structured"] = "independent"
+    z_score_condition: Literal["none", "independent", "structured"] = "independent"
+    embedding_net: nn.Module = field(default_factory=nn.Identity)
+    compose_standardization: bool = False
+
+    _ESTIMATOR_CLS: ClassVar[type]
+    """Estimator class this config builds, set by each subclass."""
+
+    _SHARED_FIELDS: ClassVar[frozenset] = frozenset({
+        "net",
+        "z_score_input",
+        "z_score_condition",
+        "embedding_net",
+        "compose_standardization",
+        "extra_kwargs",
+    })
+
+    def __post_init__(self):
+        self._reject_if_abstract(VectorFieldConfigBase, "FlowMatchingConfig()")
+        super().__post_init__()
+
+    def _build_kwargs(self) -> dict:
+        """The estimator-specific fields, with ``extra_kwargs`` merged in."""
+        d = {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in self._SHARED_FIELDS
+        }
+        d.update(self.extra_kwargs)
+        return d
+
+    def build(
+        self, batch_input: Tensor, batch_condition: Tensor
+    ) -> ConditionalVectorFieldEstimator:
+        """Build the vector-field estimator.
+
+        Args:
+            batch_input: Batch of the modeled variable, used for shape
+                inference and z-scoring.
+            batch_condition: Batch of the conditioning variable, used for shape
+                inference and z-scoring.
+
+        Returns:
+            A ``ConditionalVectorFieldEstimator``.
+        """
+        check_data_device(batch_input, batch_condition)
+
+        if isinstance(self.net, _VectorFieldNetConfigBase):
+            # The network takes the embedded condition only to read its shape,
+            # so the embedding runs once here and lives on the estimator alone.
+            embedded_condition = self.embedding_net(batch_condition[:1])
+            vectorfield_net = self.net.build(batch_input, embedded_condition)
+        else:
+            vectorfield_net = self.net
+
+        mean_0, std_0, compose_shift, compose_scale = _compute_theta_standardization(
+            batch_input, self.z_score_input, self.compose_standardization
+        )
+
+        z_score_condition_bool, structured_condition = z_score_parser(
+            self.z_score_condition
+        )
+        embedding_net = (
+            nn.Sequential(
+                standardizing_net(batch_condition, structured_condition),
+                self.embedding_net,
+            )
+            if z_score_condition_bool
+            else self.embedding_net
+        )
+
+        self._warn_unknown_extra_kwargs(self._ESTIMATOR_CLS.__init__)
+        return self._ESTIMATOR_CLS(
+            net=vectorfield_net,
+            input_shape=batch_input[0].shape,
+            condition_shape=batch_condition[0].shape,
+            embedding_net=embedding_net,
+            mean_0=mean_0,
+            std_0=std_0,
+            compose_shift=compose_shift,
+            compose_scale=compose_scale,
+            **self._build_kwargs(),
+        )
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class FlowMatchingConfig(VectorFieldConfigBase):
+    """Flow-matching estimator, used by ``FMPE``.
+
+    Args:
+        gaussian_baseline: Whether to use the analytical Gaussian baseline
+            velocity, so that the network only learns the residual.
+    """
+
+    gaussian_baseline: bool = False
+
+    _ESTIMATOR_CLS: ClassVar[type] = FlowMatchingEstimator
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class ScoreConfigBase(VectorFieldConfigBase):
+    """Base configuration for the score-matching estimators, used by ``NPSE``.
+
+    The subclass selects the SDE, so there is no ``sde_type`` field.
+    """
+
+    def __post_init__(self):
+        self._reject_if_abstract(ScoreConfigBase, "VEScoreConfig()")
+        super().__post_init__()
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class VEScoreConfig(ScoreConfigBase):
+    """Variance-exploding score estimator.
+
+    Args:
+        sigma_min: Lowest noise level.
+        sigma_max: Highest noise level.
+        train_schedule: Distribution the training times are drawn from.
+        solve_schedule: Spacing of the time steps used when solving.
+        lognormal_mean: Mean of the lognormal training schedule.
+        lognormal_std: Standard deviation of the lognormal training schedule.
+        power_law_exponent: Exponent of the power-law solve schedule.
+    """
+
+    sigma_min: float = 1e-4
+    sigma_max: float = 10.0
+    train_schedule: Literal["uniform", "lognormal"] = "uniform"
+    solve_schedule: Literal["uniform", "power_law"] = "uniform"
+    lognormal_mean: float = -1.2
+    lognormal_std: float = 1.2
+    power_law_exponent: float = 7.0
+
+    _ESTIMATOR_CLS: ClassVar[type] = VEScoreEstimator
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _BetaScoreConfigBase(ScoreConfigBase):
+    """Shared noise schedule of the variance-preserving score estimators.
+
+    Args:
+        beta_min: Lowest value of the noise schedule.
+        beta_max: Highest value of the noise schedule.
+    """
+
+    beta_min: float = 0.01
+    beta_max: float = 10.0
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class VPScoreConfig(_BetaScoreConfigBase):
+    """Variance-preserving score estimator."""
+
+    _ESTIMATOR_CLS: ClassVar[type] = VPScoreEstimator
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class SubVPScoreConfig(_BetaScoreConfigBase):
+    """Sub-variance-preserving score estimator."""
+
+    _ESTIMATOR_CLS: ClassVar[type] = SubVPScoreEstimator
+
+
+_VF_NET_CONFIGS: dict = {
+    "mlp": MLPConfig,
+    "ada_mlp": AdaMLPConfig,
+    "transformer": TransformerConfig,
+}
+
+_SDE_CONFIGS: dict = {
+    "ve": VEScoreConfig,
+    "vp": VPScoreConfig,
+    "subvp": SubVPScoreConfig,
+}
+
+
+def _vf_net_config_from_model(model: str) -> _VectorFieldNetConfigBase:
+    """Return the default network config of an architecture given its name.
+
+    Args:
+        model: Name of the architecture.
+
+    Returns:
+        A default-constructed config for that architecture. The cross-attention
+        name selects the transformer with a sequence condition.
+    """
+    if model == "transformer_cross_attn":
+        return TransformerConfig(is_x_emb_seq=True)
+    try:
+        return _VF_NET_CONFIGS[model]()
+    except KeyError:
+        raise ValueError(
+            f"Unknown vector field model {model!r}. "
+            f"Must be one of {sorted(_VALID_VF_MODELS)}."
+        ) from None
+
+
+def _score_config_from_sde_type(sde_type: str) -> ScoreConfigBase:
+    """Return the default score config of an SDE given its name.
+
+    Args:
+        sde_type: Name of the SDE.
+
+    Returns:
+        A default-constructed config for that SDE.
+    """
+    try:
+        return _SDE_CONFIGS[sde_type]()
+    except KeyError:
+        raise ValueError(
+            f"Unknown SDE type {sde_type!r}. Must be one of {sorted(_SDE_CONFIGS)}."
+        ) from None
+
+
+def _net_config_defaults() -> dict:
+    """Default of every field shared by the network configs."""
+    return {
+        f.name: (f.default_factory() if f.default_factory is not MISSING else f.default)
+        for f in fields(MLPConfig)
+        if f.name != "extra_kwargs"
+    }
+
+
+def _vf_config_from_factory_kwargs(
+    estimator_config: "VectorFieldConfigBase",
+    model: Union[VF_MODELS, VectorFieldNet],
+    named_net: dict,
+    named_estimator: dict,
+    extra: dict,
+) -> "VectorFieldConfigBase":
+    """Assemble a vector-field config from a factory's arguments.
+
+    The factories predate the split between the estimator and the network it
+    wraps, so their arguments and ``**kwargs`` span both. Each name is routed
+    to the config that owns it; a name neither owns keeps the factories' old
+    warn-and-forward behaviour towards the network builder.
+
+    Args:
+        estimator_config: Default config of the estimator to configure.
+        model: Name of the architecture, or a ready ``VectorFieldNet``.
+        named_net: The factory's named arguments that belong to the network.
+        named_estimator: The factory's named arguments that belong to the
+            estimator.
+        extra: The factory's ``**kwargs``.
+
+    Returns:
+        The assembled estimator config.
+    """
+    net_config = _vf_net_config_from_model(model) if isinstance(model, str) else model
+    is_config = isinstance(net_config, _VectorFieldNetConfigBase)
+
+    net_fields = {f.name for f in fields(net_config)} if is_config else set()
+    estimator_fields = {
+        f.name for f in fields(estimator_config)
+    } - VectorFieldConfigBase._SHARED_FIELDS
+    net_kwargs, estimator_kwargs, unknown = {}, {}, {}
+    for name, value in extra.items():
+        if name in net_fields:
+            net_kwargs[name] = value
+        elif name in estimator_fields:
+            estimator_kwargs[name] = value
+        else:
+            unknown[name] = value
+    if unknown:
+        warnings.warn(
+            f"Unknown kwargs passed to {type(estimator_config).__name__}: "
+            f"{sorted(unknown)}. These will be forwarded to the underlying "
+            f"builder. If this is unintentional, check for typos.",
+            stacklevel=3,
+        )
+
+    if is_config:
+        net_config = replace(
+            net_config, **named_net, **net_kwargs, extra_kwargs=unknown
+        )
+    else:
+        # A custom network is built by the user, so a network setting it cannot
+        # read would be silently ignored.
+        defaults = _net_config_defaults()
+        ignored = sorted(
+            {k for k, v in named_net.items() if v != defaults[k]}
+            | set(net_kwargs)
+            | set(unknown)
+        )
+        if ignored:
+            raise ValueError(
+                f"Argument(s) {ignored} are not used by a custom "
+                f"`VectorFieldNet` and would be silently ignored. Configure "
+                f"the network before passing it."
+            )
+
+    return replace(
+        estimator_config, net=net_config, **named_estimator, **estimator_kwargs
+    )

--- a/sbi/neural_nets/net_builders/vector_field_nets.py
+++ b/sbi/neural_nets/net_builders/vector_field_nets.py
@@ -1726,18 +1726,40 @@ def _vf_config_from_factory_kwargs(
     net_config = _vf_net_config_from_model(model) if isinstance(model, str) else model
     is_config = isinstance(net_config, _VectorFieldNetConfigBase)
 
-    net_fields = {f.name for f in fields(net_config)} if is_config else set()
+    net_fields = (
+        {f.name for f in fields(net_config)} - {"extra_kwargs"} if is_config else set()
+    )
     estimator_fields = {
         f.name for f in fields(estimator_config)
     } - VectorFieldConfigBase._SHARED_FIELDS
-    net_kwargs, estimator_kwargs, unknown = {}, {}, {}
+    net_family_fields = {
+        f.name
+        for config_cls in set(_VF_NET_CONFIGS.values())
+        for f in fields(config_cls)
+        if f.name != "extra_kwargs"
+    }
+    estimator_family_fields = {
+        f.name
+        for config_cls in {FlowMatchingConfig, *_SDE_CONFIGS.values()}
+        for f in fields(config_cls)
+    } - VectorFieldConfigBase._SHARED_FIELDS
+    net_kwargs, estimator_kwargs, unknown, ignored = {}, {}, {}, []
     for name, value in extra.items():
         if name in net_fields:
             net_kwargs[name] = value
         elif name in estimator_fields:
             estimator_kwargs[name] = value
+        elif name in net_family_fields or name in estimator_family_fields:
+            ignored.append(name)
         else:
             unknown[name] = value
+    if ignored:
+        raise ValueError(
+            f"Argument(s) {sorted(ignored)} are not used by "
+            f"{type(estimator_config).__name__} with {type(net_config).__name__} "
+            "and would be silently ignored. Configure the estimator and network "
+            "directly with their per-model configs."
+        )
     if unknown:
         warnings.warn(
             f"Unknown kwargs passed to {type(estimator_config).__name__}: "

--- a/tests/compose_standardization_test.py
+++ b/tests/compose_standardization_test.py
@@ -11,6 +11,7 @@ from torch.distributions import Independent, Normal
 
 from sbi.inference.posteriors.vector_field_posterior import VectorFieldPosterior
 from sbi.inference.potentials.vector_field_potential import VectorFieldBasedPotential
+from sbi.neural_nets.estimators.flowmatching_estimator import FlowMatchingEstimator
 from sbi.neural_nets.factory import posterior_flow_nn, posterior_score_nn
 from sbi.neural_nets.net_builders.vector_field_nets import (
     build_vector_field_estimator,
@@ -104,6 +105,29 @@ def test_affine_contract():
     )
 
 
+def test_compose_shift_must_be_finite():
+    with pytest.raises(ValueError, match="compose_shift"):
+        FlowMatchingEstimator(
+            net=torch.nn.Identity(),
+            input_shape=torch.Size([NUM_DIM]),
+            condition_shape=torch.Size([NUM_DIM]),
+            compose_shift=torch.tensor([0.0, float("nan"), 0.0]),
+            compose_scale=torch.ones(NUM_DIM),
+        )
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf")])
+def test_compose_scale_must_be_positive_and_finite(value):
+    with pytest.raises(ValueError, match="compose_scale"):
+        FlowMatchingEstimator(
+            net=torch.nn.Identity(),
+            input_shape=torch.Size([NUM_DIM]),
+            condition_shape=torch.Size([NUM_DIM]),
+            compose_shift=torch.zeros(NUM_DIM),
+            compose_scale=torch.full((NUM_DIM,), value),
+        )
+
+
 @pytest.mark.gpu
 def test_affine_contract_cuda():
     estimator = _build().cuda()
@@ -170,6 +194,14 @@ def test_checkpoint_loading(case):
     assert destination.compose_enabled
     assert torch.equal(destination._theta_shift, source._theta_shift)
     assert torch.equal(destination._theta_scale, source._theta_scale)
+
+
+def test_checkpoint_loading_rejects_invalid_compose_affine():
+    state_dict = _build().state_dict()
+    state_dict["_theta_scale"][0, 0] = 0.0
+
+    with pytest.raises(ValueError, match="compose_scale"):
+        _build(compose=False).load_state_dict(state_dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/compose_standardization_test.py
+++ b/tests/compose_standardization_test.py
@@ -105,26 +105,30 @@ def test_affine_contract():
     )
 
 
-def test_compose_shift_must_be_finite():
-    with pytest.raises(ValueError, match="compose_shift"):
+@pytest.mark.parametrize(
+    "affine_name,value",
+    [
+        ("compose_shift", float("nan")),
+        ("compose_shift", float("inf")),
+        ("compose_scale", 0.0),
+        ("compose_scale", -1.0),
+        ("compose_scale", float("nan")),
+        ("compose_scale", float("inf")),
+    ],
+)
+def test_compose_affine_rejects_invalid_values(affine_name, value):
+    affine_kwargs = {
+        "compose_shift": torch.zeros(NUM_DIM),
+        "compose_scale": torch.ones(NUM_DIM),
+    }
+    affine_kwargs[affine_name] = torch.full((NUM_DIM,), value)
+
+    with pytest.raises(ValueError, match=affine_name):
         FlowMatchingEstimator(
             net=torch.nn.Identity(),
             input_shape=torch.Size([NUM_DIM]),
             condition_shape=torch.Size([NUM_DIM]),
-            compose_shift=torch.tensor([0.0, float("nan"), 0.0]),
-            compose_scale=torch.ones(NUM_DIM),
-        )
-
-
-@pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf")])
-def test_compose_scale_must_be_positive_and_finite(value):
-    with pytest.raises(ValueError, match="compose_scale"):
-        FlowMatchingEstimator(
-            net=torch.nn.Identity(),
-            input_shape=torch.Size([NUM_DIM]),
-            condition_shape=torch.Size([NUM_DIM]),
-            compose_shift=torch.zeros(NUM_DIM),
-            compose_scale=torch.full((NUM_DIM,), value),
+            **affine_kwargs,
         )
 
 
@@ -196,11 +200,20 @@ def test_checkpoint_loading(case):
     assert torch.equal(destination._theta_scale, source._theta_scale)
 
 
-def test_checkpoint_loading_rejects_invalid_compose_affine():
+@pytest.mark.parametrize(
+    "buffer_name,value,error_match",
+    [
+        ("_theta_shift", float("nan"), "compose_shift"),
+        ("_theta_scale", 0.0, "compose_scale"),
+    ],
+)
+def test_checkpoint_loading_rejects_invalid_compose_affine(
+    buffer_name, value, error_match
+):
     state_dict = _build().state_dict()
-    state_dict["_theta_scale"][0, 0] = 0.0
+    state_dict[buffer_name][0, 0] = value
 
-    with pytest.raises(ValueError, match="compose_scale"):
+    with pytest.raises(ValueError, match=error_match):
         _build(compose=False).load_state_dict(state_dict)
 
 

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -66,7 +66,6 @@ def test_factory_field_maps_name_real_parameters(factory_fn, fields):
         (marginal_nn, (ZukoFlowType.NSF,), {"num_tranforms": 3}),
         (posterior_score_nn, (), {"sigmaMin": 0.01}),
         (posterior_flow_nn, (), {"hiden_features": 64}),
-        (posterior_flow_nn, (), {"sigma_min": 0.01}),  # score-only param
     ],
 )
 def test_factory_warns_on_unknown_kwargs(factory_fn, factory_args, bad_kwarg):
@@ -84,6 +83,13 @@ def test_factory_warns_on_unknown_kwargs(factory_fn, factory_args, bad_kwarg):
         (classifier_nn, "linear", {"hidden_features": 64}),
         (posterior_nn, "mdn", {"num_blocks": 7}),
         (classifier_nn, "linear", {"num_blocks": 7}),
+        (posterior_flow_nn, "mlp", {"sigma_min": 0.01}),
+        (posterior_flow_nn, "mlp", {"num_heads": 2}),
+        (
+            posterior_score_nn,
+            "mlp",
+            {"sde_type": "vp", "sigma_max": 20.0},
+        ),
     ],
     ids=[
         "mdn-bins",
@@ -93,6 +99,9 @@ def test_factory_warns_on_unknown_kwargs(factory_fn, factory_args, bad_kwarg):
         "linear-width",
         "mdn-other-model-field",
         "linear-other-model-field",
+        "flow-score-field",
+        "mlp-transformer-field",
+        "vp-ve-field",
     ],
 )
 def test_factory_rejects_a_setting_the_model_does_not_use(factory_fn, model, kwarg):

--- a/tests/marginal_builder_integration_test.py
+++ b/tests/marginal_builder_integration_test.py
@@ -28,7 +28,6 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     MarginalNICEConfig,
     MarginalNSFConfig,
     MarginalSOSPFConfig,
-    VectorFieldEstimatorBuilder,
 )
 from sbi.neural_nets.net_builders.flow import (
     build_zuko_bpf,
@@ -44,6 +43,7 @@ from sbi.neural_nets.net_builders.flow import (
     build_zuko_unconditional_flow,
     nflow_specific_kwargs,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import FlowMatchingConfig
 
 # The conditional build functions carry the defaults sbi has chosen for each
 # Zuko flow. The marginal configs must reproduce them, under Zuko's own
@@ -402,7 +402,7 @@ def test_unknown_model_string_raises():
 
 
 @pytest.mark.parametrize(
-    "config", [MAFConfig(), VectorFieldEstimatorBuilder()], ids=["density", "vector"]
+    "config", [MAFConfig(), FlowMatchingConfig()], ids=["density", "vector"]
 )
 def test_conditional_builder_raises(config):
     """A builder for a conditional estimator cannot build a marginal one."""

--- a/tests/npe_nle_builder_integration_test.py
+++ b/tests/npe_nle_builder_integration_test.py
@@ -19,9 +19,9 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     NSFConfig,
     ResNetClassifierConfig,
     TabPFNConfig,
-    VectorFieldEstimatorBuilder,
     ZukoNSFConfig,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import FlowMatchingConfig
 from sbi.utils import BoxUniform
 from sbi.utils.user_input_checks import check_estimator_arg
 
@@ -326,7 +326,7 @@ def test_check_estimator_arg_rejects_module():
         check_estimator_arg(torch.nn.Linear(3, 3))
 
 
-@pytest.mark.parametrize("config_cls", [MAFConfig, VectorFieldEstimatorBuilder])
+@pytest.mark.parametrize("config_cls", [MAFConfig, FlowMatchingConfig])
 def test_check_estimator_arg_rejects_config_class(config_cls):
     """A forgotten pair of parentheses must fail before training."""
     with pytest.raises(TypeError, match="not an instance"):
@@ -357,7 +357,7 @@ def test_trainer_rejects_legacy_config_of_the_wrong_family(trainer_cls):
     with pytest.raises(TypeError):
         trainer_cls(
             prior,
-            density_estimator=VectorFieldEstimatorBuilder(),
+            density_estimator=FlowMatchingConfig(),
             show_progress_bars=False,
         )
 

--- a/tests/npe_nle_builder_integration_test.py
+++ b/tests/npe_nle_builder_integration_test.py
@@ -351,8 +351,7 @@ def test_wrong_config_family_raises(trainer_cls, config):
     [NPE_C, NLE_A, MNPE, MNLE, NPE_PFN],
     ids=["npe", "nle", "mnpe", "mnle", "npe_pfn"],
 )
-def test_trainer_rejects_legacy_config_of_the_wrong_family(trainer_cls):
-    """The remaining flat vector-field config must not fall through as callable."""
+def test_trainer_rejects_vector_field_config(trainer_cls):
     prior = MultivariateNormal(zeros(2), eye(2))
     with pytest.raises(TypeError):
         trainer_cls(

--- a/tests/nre_builder_integration_test.py
+++ b/tests/nre_builder_integration_test.py
@@ -63,8 +63,7 @@ def test_wrong_config_family_raises(trainer_cls):
         trainer_cls(prior, classifier=MAFConfig(), show_progress_bars=False)
 
 
-def test_rejects_legacy_config_of_the_wrong_family():
-    """The flat vector-field config must not fall through as a callable."""
+def test_rejects_vector_field_config():
     prior = MultivariateNormal(zeros(2), eye(2))
     with pytest.raises(TypeError, match="ClassifierConfigBase"):
         NRE_A(

--- a/tests/nre_builder_integration_test.py
+++ b/tests/nre_builder_integration_test.py
@@ -15,8 +15,8 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     MAFConfig,
     MLPClassifierConfig,
     ResNetClassifierConfig,
-    VectorFieldEstimatorBuilder,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import FlowMatchingConfig
 from sbi.neural_nets.ratio_estimators import RatioEstimator
 from sbi.utils.user_input_checks import check_estimator_arg
 
@@ -69,7 +69,7 @@ def test_rejects_legacy_config_of_the_wrong_family():
     with pytest.raises(TypeError, match="ClassifierConfigBase"):
         NRE_A(
             prior,
-            classifier=VectorFieldEstimatorBuilder(),
+            classifier=FlowMatchingConfig(),
             show_progress_bars=False,
         )
 

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -456,6 +456,19 @@ def test_factory_warns_on_an_unknown_name():
         posterior_flow_nn(hiden_features=64)
 
 
+@pytest.mark.parametrize(
+    "factory_fn, kwargs",
+    [
+        (posterior_flow_nn, {"model": "mlp", "num_heads": 2}),
+        (posterior_score_nn, {"sde_type": "vp", "sigma_max": 20.0}),
+        (posterior_flow_nn, {"beta_min": 0.1}),
+    ],
+)
+def test_factory_rejects_settings_for_another_config(factory_fn, kwargs):
+    with pytest.raises(ValueError, match="silently ignored"):
+        factory_fn(**kwargs)
+
+
 def test_factory_rejects_network_settings_for_a_custom_network(batches):
     """A custom network is built by the user, so a setting it cannot read raises."""
     theta, x = batches

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -1,13 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-"""Tests for the per-model vector-field configs.
-
-The estimator and the network it wraps are two independent choices, each made
-by picking a class. A setting that belongs to the other axis, or to a sibling
-model, is not a field of the config, so it raises at construction instead of
-being dropped on the way to the network.
-"""
+"""Tests for per-model vector-field configs."""
 
 import inspect
 import warnings
@@ -77,11 +71,6 @@ def _assert_same_state(actual, expected):
         torch.testing.assert_close(value, expected.state_dict()[name])
 
 
-# --------------------------------------------------------------------------
-# The two axes
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "config_cls, estimator_cls",
     [
@@ -92,14 +81,12 @@ def _assert_same_state(actual, expected):
     ],
 )
 def test_config_class_selects_the_estimator(config_cls, estimator_cls, batches):
-    """The config class is the choice of estimator, so there is no discriminator."""
     assert isinstance(config_cls().build(*batches), estimator_cls)
 
 
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS)
 @pytest.mark.parametrize("net_cls", NET_CONFIGS)
 def test_net_choice_is_independent_of_the_estimator(config_cls, net_cls, batches):
-    """Every network combines with every estimator, so the axes do not multiply."""
     estimator = config_cls(net=net_cls()).build(*batches)
     assert type(estimator.net).__name__ == NET_CLASS_NAMES[net_cls]
 
@@ -117,7 +104,6 @@ def test_net_choice_is_independent_of_the_estimator(config_cls, net_cls, batches
     ],
 )
 def test_estimator_config_rejects_a_setting_it_does_not_have(config_cls, bad_kwarg):
-    """A setting of a sibling estimator used to be accepted and dropped."""
     with pytest.raises(TypeError):
         config_cls(**bad_kwarg)
 
@@ -128,6 +114,7 @@ def test_estimator_config_rejects_a_setting_it_does_not_have(config_cls, bad_kwa
         (MLPConfig, {"num_heads": 4}),
         (MLPConfig, {"mlp_ratio": 2}),
         (MLPConfig, {"adamlp_ratio": 2}),
+        (MLPConfig, {"hidden_features": [16, 32]}),
         (AdaMLPConfig, {"layer_norm": False}),
         (AdaMLPConfig, {"num_heads": 4}),
         (TransformerConfig, {"layer_norm": False}),
@@ -135,19 +122,12 @@ def test_estimator_config_rejects_a_setting_it_does_not_have(config_cls, bad_kwa
     ],
 )
 def test_net_config_rejects_a_setting_it_does_not_have(net_cls, bad_kwarg):
-    """The per-architecture guard is now the field set itself."""
     with pytest.raises(TypeError):
         net_cls(**bad_kwarg)
 
 
-def test_net_config_rejects_a_sequence_width():
-    with pytest.raises(TypeError, match="hidden_features"):
-        MLPConfig(hidden_features=[16, 32])
-
-
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS + NET_CONFIGS)
 def test_invalid_literal_value_raises(config_cls):
-    """Fail-fast on `Literal` values, which the type checker cannot see at runtime."""
     field = "z_score_input" if config_cls in ALL_CONFIGS else "time_emb_type"
     with pytest.raises(ValueError, match=field):
         config_cls(**{field: "not_a_value"})
@@ -155,19 +135,12 @@ def test_invalid_literal_value_raises(config_cls):
 
 @pytest.mark.parametrize("base_cls", [VectorFieldConfigBase, _VectorFieldNetConfigBase])
 def test_role_base_cannot_be_instantiated(base_cls):
-    """A role base selects no model, so it is not a usable config."""
     with pytest.raises(TypeError, match="per-model config"):
         base_cls()
 
 
-# --------------------------------------------------------------------------
-# Networks
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("model", sorted(_VALID_VF_MODELS))
 def test_every_advertised_model_maps_to_a_net_config(model):
-    """The deprecated string path must cover the whole `VF_MODELS` Literal."""
     net_config = _vf_net_config_from_model(model)
     assert isinstance(net_config, _VectorFieldNetConfigBase)
     if model == "transformer_cross_attn":
@@ -181,7 +154,6 @@ def test_unknown_model_name_raises():
 
 @pytest.mark.parametrize("net_cls", NET_CONFIGS)
 def test_net_config_builds_the_network_alone(net_cls, batches):
-    """The network configs are usable on their own, without an estimator."""
     assert isinstance(net_cls().build(*batches), nn.Module)
 
 
@@ -194,7 +166,6 @@ def test_cross_attention_takes_a_sequence_condition():
 
 
 def test_custom_network_module_is_accepted(batches):
-    """A user with their own architecture must still be able to pass it."""
     theta, x = batches
 
     class CustomNet(nn.Module):
@@ -215,14 +186,8 @@ def test_net_config_rejects_embedding_net_in_extra_kwargs():
         MLPConfig(extra_kwargs={"embedding_net": nn.Identity()})
 
 
-# --------------------------------------------------------------------------
-# Wiring
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS)
 def test_embedding_net_is_wired_once(config_cls, batches):
-    """The network only reads the embedded shape, so it must not hold the net."""
     theta, x = batches
     embedding_net = nn.Linear(3, 7)
     estimator = config_cls(embedding_net=embedding_net).build(theta, x)
@@ -233,7 +198,6 @@ def test_embedding_net_is_wired_once(config_cls, batches):
 
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS)
 def test_compose_standardization_is_set_by_the_constructor(config_cls, batches):
-    """The boundary affine arrives as an argument, not by writing into buffers."""
     estimator = config_cls(compose_standardization=True).build(*batches)
 
     assert estimator.compose_enabled
@@ -249,18 +213,12 @@ def test_compose_standardization_rejects_the_gaussian_baseline(batches):
 
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS)
 def test_z_scoring_of_the_condition_wraps_the_embedding(config_cls, batches):
-    """`z_score_condition` standardizes the variable conditioned on."""
     theta, x = batches
     without = config_cls(z_score_condition="none").build(theta, x)
     with_zscore = config_cls(z_score_condition="independent").build(theta, x)
 
     assert isinstance(without._embedding_net, nn.Identity)
     assert isinstance(with_zscore._embedding_net, nn.Sequential)
-
-
-# --------------------------------------------------------------------------
-# Trainer dispatch
-# --------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -290,27 +248,24 @@ def test_trainer_trains_with_a_config(
         (FMPE, VEScoreConfig()),
         (FMPE, VPScoreConfig()),
         (NPSE, FlowMatchingConfig()),
+        (FMPE, MAFConfig()),
+        (NPSE, MAFConfig()),
     ],
 )
 def test_trainer_rejects_the_wrong_family(trainer_cls, wrong_config, gaussian_sims):
-    """A plain isinstance check against the family base, so a TypeError."""
     prior, _, _ = gaussian_sims
     with pytest.raises(TypeError, match="requires a"):
         trainer_cls(prior, wrong_config, show_progress_bars=False)
 
 
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_trainer_rejects_a_config_of_another_role(trainer_cls, gaussian_sims):
-    prior, _, _ = gaussian_sims
-    with pytest.raises(TypeError, match="requires a"):
-        trainer_cls(prior, MAFConfig(), show_progress_bars=False)
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_trainer_rejects_a_config_class(trainer_cls, gaussian_sims):
+@pytest.mark.parametrize(
+    "trainer_cls, config_cls",
+    [(FMPE, FlowMatchingConfig), (NPSE, VEScoreConfig)],
+)
+def test_trainer_rejects_a_config_class(trainer_cls, config_cls, gaussian_sims):
     prior, _, _ = gaussian_sims
     with pytest.raises(TypeError, match="not an instance"):
-        trainer_cls(prior, FlowMatchingConfig, show_progress_bars=False)
+        trainer_cls(prior, config_cls, show_progress_bars=False)
 
 
 @pytest.mark.parametrize(
@@ -322,7 +277,6 @@ def test_trainer_rejects_a_config_class(trainer_cls, gaussian_sims):
     ],
 )
 def test_npse_sde_type_selects_the_config(sde_type, estimator_cls, gaussian_sims):
-    """Without a config, the deprecated kwarg still picks the SDE."""
     prior, theta, x = gaussian_sims
     trainer = NPSE(prior, sde_type=sde_type, show_progress_bars=False)
     trainer.append_simulations(theta, x)
@@ -330,22 +284,31 @@ def test_npse_sde_type_selects_the_config(sde_type, estimator_cls, gaussian_sims
 
 
 def test_npse_rejects_sde_type_together_with_a_config(gaussian_sims):
-    """The config carries the SDE as its class, so the kwarg has nothing to say."""
     prior, _, _ = gaussian_sims
     with pytest.raises(ValueError, match="already selects the SDE"):
         NPSE(prior, VEScoreConfig(), sde_type="vp", show_progress_bars=False)
 
 
+@pytest.mark.parametrize("input_kind", ["default", "config", "callable"])
 @pytest.mark.parametrize(
-    "trainer_cls, config",
-    [(FMPE, FlowMatchingConfig()), (NPSE, VEScoreConfig())],
+    "trainer_cls, config", [(FMPE, FlowMatchingConfig()), (NPSE, VEScoreConfig())]
 )
-def test_supported_estimator_inputs_do_not_warn(trainer_cls, config, gaussian_sims):
+def test_supported_estimator_inputs_do_not_warn(
+    trainer_cls, config, input_kind, gaussian_sims
+):
     prior, _, _ = gaussian_sims
-    for estimator in (None, config, lambda theta, x: None):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            trainer_cls(prior, vf_estimator=estimator, show_progress_bars=False)
+    estimators = {
+        "default": None,
+        "config": config,
+        "callable": lambda theta, x: None,
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        trainer_cls(
+            prior,
+            vf_estimator=estimators[input_kind],
+            show_progress_bars=False,
+        )
 
 
 @pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
@@ -387,7 +350,6 @@ def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
 
 @pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
 def test_role_shapes_are_not_swapped(trainer_cls):
-    """FMPE and NPSE model theta given x, so input is theta and condition is x."""
     prior = MultivariateNormal(zeros(2), torch.eye(2))
     theta, x = prior.sample((100,)), torch.randn(100, 5)
     trainer = trainer_cls(prior, show_progress_bars=False)
@@ -398,21 +360,10 @@ def test_role_shapes_are_not_swapped(trainer_cls):
     assert estimator.condition_shape == torch.Size([5])
 
 
-# --------------------------------------------------------------------------
-# Factory path
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "factory_fn", [posterior_flow_nn, posterior_score_nn], ids=["flow", "score"]
 )
 def test_advertised_time_emb_types_all_build(factory_fn):
-    """Every value the factory's `time_emb_type` Literal advertises must build.
-
-    The annotation advertised `"fourier"` while the networks only accept
-    `"random_fourier"`, so the annotated value crashed at build time and the
-    working value failed type checking.
-    """
     annotation = inspect.signature(factory_fn).parameters["time_emb_type"].annotation
     values = get_args(annotation)
     assert values, "time_emb_type lost its Literal annotation"
@@ -445,7 +396,6 @@ def test_factory_sde_type_maps_to_the_config(
 
 
 def test_factory_routes_settings_to_the_axis_that_owns_them(batches):
-    """A factory argument reaches the network or the estimator, not both."""
     estimator = posterior_score_nn(
         model="transformer", hidden_features=64, num_heads=2, sigma_max=20.0
     )(*batches)
@@ -456,26 +406,7 @@ def test_factory_routes_settings_to_the_axis_that_owns_them(batches):
     } == {2}
 
 
-def test_factory_warns_on_an_unknown_name():
-    with pytest.warns(UserWarning, match="Unknown kwargs"):
-        posterior_flow_nn(hiden_features=64)
-
-
-@pytest.mark.parametrize(
-    "factory_fn, kwargs",
-    [
-        (posterior_flow_nn, {"model": "mlp", "num_heads": 2}),
-        (posterior_score_nn, {"sde_type": "vp", "sigma_max": 20.0}),
-        (posterior_flow_nn, {"beta_min": 0.1}),
-    ],
-)
-def test_factory_rejects_settings_for_another_config(factory_fn, kwargs):
-    with pytest.raises(ValueError, match="silently ignored"):
-        factory_fn(**kwargs)
-
-
 def test_factory_rejects_network_settings_for_a_custom_network(batches):
-    """A custom network is built by the user, so a setting it cannot read raises."""
     theta, x = batches
     custom = build_standard_mlp_network(theta, x)
     with pytest.raises(ValueError, match="silently ignored"):
@@ -495,11 +426,6 @@ def test_factory_rejects_network_settings_for_a_custom_network(batches):
 def test_estimator_config_defaults_match_the_factory(
     factory_fn, factory_kwargs, config_cls, batches
 ):
-    """The configs document what the public path has always produced.
-
-    Pinned against the dispatcher-effective values rather than the inner build
-    signatures, which are allowed to differ.
-    """
     torch.manual_seed(0)
     from_factory = factory_fn(**factory_kwargs)(*batches)
     torch.manual_seed(0)
@@ -558,7 +484,6 @@ def test_factory_none_means_no_z_scoring(factory_fn):
     [(FMPE, FlowMatchingConfig), (NPSE, VEScoreConfig)],
 )
 def test_trainer_default_matches_the_config_default(trainer_cls, config_cls, batches):
-    """`FMPE(prior)` and `NPSE(prior)` must keep producing today's network."""
     theta, x = batches
     prior = MultivariateNormal(zeros(2), torch.eye(2))
     trainer = trainer_cls(prior, show_progress_bars=False)
@@ -569,20 +494,13 @@ def test_trainer_default_matches_the_config_default(trainer_cls, config_cls, bat
     assert isinstance(from_trainer.net, VectorFieldMLP)
 
 
-# --------------------------------------------------------------------------
-# extra_kwargs
-# --------------------------------------------------------------------------
-
-
 def test_extra_kwargs_has_one_bucket_per_axis(batches):
-    """Estimator extras reach the estimator, which the flat bucket never did."""
     estimator = VEScoreConfig(extra_kwargs={"t_max": 0.9}).build(*batches)
     assert estimator.t_max == 0.9
 
 
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS + NET_CONFIGS)
 def test_extra_kwargs_rejects_a_name_that_is_a_field(config_cls):
-    """There must be one place a setting can come from."""
     name = dc_fields(config_cls)[0].name
     with pytest.raises(ValueError, match="Pass the"):
         config_cls(extra_kwargs={name: None})

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -210,6 +210,11 @@ def test_estimator_config_rejects_an_invalid_network():
         FlowMatchingConfig(net="mlp")
 
 
+def test_net_config_rejects_embedding_net_in_extra_kwargs():
+    with pytest.raises(ValueError, match="embedding_net"):
+        MLPConfig(extra_kwargs={"embedding_net": nn.Identity()})
+
+
 # --------------------------------------------------------------------------
 # Wiring
 # --------------------------------------------------------------------------

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -10,6 +10,7 @@ being dropped on the way to the network.
 """
 
 import inspect
+import warnings
 from dataclasses import fields as dc_fields
 from typing import get_args
 
@@ -66,6 +67,14 @@ def gaussian_sims():
 @pytest.fixture
 def batches():
     return torch.randn(32, 2), torch.randn(32, 3)
+
+
+def _assert_same_state(actual, expected):
+    assert type(actual) is type(expected)
+    assert type(actual.net) is type(expected.net)
+    assert actual.state_dict().keys() == expected.state_dict().keys()
+    for name, value in actual.state_dict().items():
+        torch.testing.assert_close(value, expected.state_dict()[name])
 
 
 # --------------------------------------------------------------------------
@@ -131,6 +140,11 @@ def test_net_config_rejects_a_setting_it_does_not_have(net_cls, bad_kwarg):
         net_cls(**bad_kwarg)
 
 
+def test_net_config_rejects_a_sequence_width():
+    with pytest.raises(TypeError, match="hidden_features"):
+        MLPConfig(hidden_features=[16, 32])
+
+
 @pytest.mark.parametrize("config_cls", ALL_CONFIGS + NET_CONFIGS)
 def test_invalid_literal_value_raises(config_cls):
     """Fail-fast on `Literal` values, which the type checker cannot see at runtime."""
@@ -182,8 +196,18 @@ def test_cross_attention_takes_a_sequence_condition():
 def test_custom_network_module_is_accepted(batches):
     """A user with their own architecture must still be able to pass it."""
     theta, x = batches
-    custom = build_standard_mlp_network(theta, x)
+
+    class CustomNet(nn.Module):
+        def forward(self, input, condition, time):
+            return torch.zeros_like(input)
+
+    custom = CustomNet()
     assert FlowMatchingConfig(net=custom).build(theta, x).net is custom
+
+
+def test_estimator_config_rejects_an_invalid_network():
+    with pytest.raises(TypeError, match="nn.Module"):
+        FlowMatchingConfig(net="mlp")
 
 
 # --------------------------------------------------------------------------
@@ -307,6 +331,18 @@ def test_npse_rejects_sde_type_together_with_a_config(gaussian_sims):
         NPSE(prior, VEScoreConfig(), sde_type="vp", show_progress_bars=False)
 
 
+@pytest.mark.parametrize(
+    "trainer_cls, config",
+    [(FMPE, FlowMatchingConfig()), (NPSE, VEScoreConfig())],
+)
+def test_supported_estimator_inputs_do_not_warn(trainer_cls, config, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    for estimator in (None, config, lambda theta, x: None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            trainer_cls(prior, vf_estimator=estimator, show_progress_bars=False)
+
+
 @pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
 def test_string_path_warns_and_names_the_import(trainer_cls, gaussian_sims):
     prior, _, _ = gaussian_sims
@@ -316,7 +352,11 @@ def test_string_path_warns_and_names_the_import(trainer_cls, gaussian_sims):
 
 @pytest.mark.parametrize(
     "trainer_cls, kwarg",
-    [(FMPE, "density_estimator"), (NPSE, "score_estimator")],
+    [
+        (FMPE, "density_estimator"),
+        (NPSE, "score_estimator"),
+        (NPSE, "density_estimator"),
+    ],
 )
 def test_legacy_kwarg_warns(trainer_cls, kwarg, gaussian_sims):
     prior, _, _ = gaussian_sims
@@ -326,7 +366,11 @@ def test_legacy_kwarg_warns(trainer_cls, kwarg, gaussian_sims):
 
 @pytest.mark.parametrize(
     "trainer_cls, kwarg",
-    [(FMPE, "density_estimator"), (NPSE, "score_estimator")],
+    [
+        (FMPE, "density_estimator"),
+        (NPSE, "score_estimator"),
+        (NPSE, "density_estimator"),
+    ],
 )
 def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
     prior, _, _ = gaussian_sims
@@ -421,24 +465,74 @@ def test_factory_rejects_network_settings_for_a_custom_network(batches):
 
 
 @pytest.mark.parametrize(
-    "factory_fn, config_cls",
-    [(posterior_flow_nn, FlowMatchingConfig), (posterior_score_nn, VEScoreConfig)],
-    ids=["flow", "score"],
+    "factory_fn, factory_kwargs, config_cls",
+    [
+        (posterior_flow_nn, {}, FlowMatchingConfig),
+        (posterior_score_nn, {"sde_type": "ve"}, VEScoreConfig),
+        (posterior_score_nn, {"sde_type": "vp"}, VPScoreConfig),
+        (posterior_score_nn, {"sde_type": "subvp"}, SubVPScoreConfig),
+    ],
+    ids=["flow", "ve", "vp", "subvp"],
 )
-def test_factory_defaults_match_the_config_defaults(factory_fn, config_cls, batches):
+def test_estimator_config_defaults_match_the_factory(
+    factory_fn, factory_kwargs, config_cls, batches
+):
     """The configs document what the public path has always produced.
 
     Pinned against the dispatcher-effective values rather than the inner build
     signatures, which are allowed to differ.
     """
-    from_factory = factory_fn()(*batches)
+    torch.manual_seed(0)
+    from_factory = factory_fn(**factory_kwargs)(*batches)
+    torch.manual_seed(0)
     from_config = config_cls().build(*batches)
 
-    assert type(from_factory) is type(from_config)
-    assert type(from_factory.net) is type(from_config.net)
-    assert sum(p.numel() for p in from_factory.parameters()) == sum(
-        p.numel() for p in from_config.parameters()
-    )
+    _assert_same_state(from_factory, from_config)
+
+
+@pytest.mark.parametrize(
+    "model, net_config, sequence_condition",
+    [
+        ("mlp", MLPConfig(), False),
+        ("ada_mlp", AdaMLPConfig(), False),
+        ("transformer", TransformerConfig(), False),
+        (
+            "transformer_cross_attn",
+            TransformerConfig(is_x_emb_seq=True),
+            True,
+        ),
+    ],
+)
+def test_network_config_defaults_match_the_factory(
+    model, net_config, sequence_condition, batches
+):
+    theta, condition = batches
+    if sequence_condition:
+        condition = torch.randn(32, 5, 3)
+
+    torch.manual_seed(0)
+    from_factory = posterior_flow_nn(model=model)(theta, condition)
+    torch.manual_seed(0)
+    from_config = FlowMatchingConfig(net=net_config).build(theta, condition)
+
+    _assert_same_state(from_factory, from_config)
+
+
+@pytest.mark.parametrize("factory_fn", [posterior_flow_nn, posterior_score_nn])
+def test_factory_none_means_no_z_scoring(factory_fn):
+    theta = torch.randn(32, 2) + 5.0
+    x = torch.randn(32, 3) + 7.0
+
+    from_none = factory_fn(z_score_theta=None, z_score_x=None)(theta, x)
+    explicit = factory_fn(z_score_theta="none", z_score_x="none")(theta, x)
+    default = factory_fn()(theta, x)
+
+    assert torch.equal(from_none.mean_0, explicit.mean_0)
+    assert torch.equal(from_none.std_0, explicit.std_0)
+    assert isinstance(from_none._embedding_net, nn.Identity)
+    assert isinstance(explicit._embedding_net, nn.Identity)
+    assert not torch.equal(default.mean_0, from_none.mean_0)
+    assert isinstance(default._embedding_net, nn.Sequential)
 
 
 @pytest.mark.parametrize(

--- a/tests/vf_builder_integration_test.py
+++ b/tests/vf_builder_integration_test.py
@@ -1,24 +1,357 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+"""Tests for the per-model vector-field configs.
+
+The estimator and the network it wraps are two independent choices, each made
+by picking a class. A setting that belongs to the other axis, or to a sibling
+model, is not a field of the config, so it raises at construction instead of
+being dropped on the way to the network.
+"""
+
 import inspect
-import warnings
 from dataclasses import fields as dc_fields
 from typing import get_args
 
 import pytest
 import torch
-from torch import zeros
+from torch import nn, zeros
 from torch.distributions import MultivariateNormal
 
 from sbi.inference import FMPE, NPSE
+from sbi.neural_nets.estimators.flowmatching_estimator import FlowMatchingEstimator
+from sbi.neural_nets.estimators.score_estimator import (
+    SubVPScoreEstimator,
+    VEScoreEstimator,
+    VPScoreEstimator,
+)
 from sbi.neural_nets.factory import posterior_flow_nn, posterior_score_nn
 from sbi.neural_nets.net_builders.estimator_configs import (
-    _FLOW_ONLY_FIELDS,
-    _SCORE_ONLY_FIELDS,
+    _VALID_VF_MODELS,
     MAFConfig,
-    VectorFieldEstimatorBuilder,
 )
+from sbi.neural_nets.net_builders.vector_field_nets import (
+    AdaMLPConfig,
+    FlowMatchingConfig,
+    MLPConfig,
+    SubVPScoreConfig,
+    TransformerConfig,
+    VEScoreConfig,
+    VPScoreConfig,
+    VectorFieldConfigBase,
+    VectorFieldMLP,
+    _VectorFieldNetConfigBase,
+    _vf_net_config_from_model,
+    build_standard_mlp_network,
+)
+
+NET_CONFIGS = [MLPConfig, AdaMLPConfig, TransformerConfig]
+SCORE_CONFIGS = [VEScoreConfig, VPScoreConfig, SubVPScoreConfig]
+ALL_CONFIGS = [FlowMatchingConfig, *SCORE_CONFIGS]
+NET_CLASS_NAMES = {
+    MLPConfig: "VectorFieldMLP",
+    AdaMLPConfig: "VectorFieldAdaMLP",
+    TransformerConfig: "VectorFieldTransformer",
+}
+
+
+@pytest.fixture
+def gaussian_sims():
+    prior = MultivariateNormal(zeros(2), torch.eye(2))
+    theta = prior.sample((200,))
+    x = theta + 0.1 * torch.randn_like(theta)
+    return prior, theta, x
+
+
+@pytest.fixture
+def batches():
+    return torch.randn(32, 2), torch.randn(32, 3)
+
+
+# --------------------------------------------------------------------------
+# The two axes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "config_cls, estimator_cls",
+    [
+        (FlowMatchingConfig, FlowMatchingEstimator),
+        (VEScoreConfig, VEScoreEstimator),
+        (VPScoreConfig, VPScoreEstimator),
+        (SubVPScoreConfig, SubVPScoreEstimator),
+    ],
+)
+def test_config_class_selects_the_estimator(config_cls, estimator_cls, batches):
+    """The config class is the choice of estimator, so there is no discriminator."""
+    assert isinstance(config_cls().build(*batches), estimator_cls)
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+@pytest.mark.parametrize("net_cls", NET_CONFIGS)
+def test_net_choice_is_independent_of_the_estimator(config_cls, net_cls, batches):
+    """Every network combines with every estimator, so the axes do not multiply."""
+    estimator = config_cls(net=net_cls()).build(*batches)
+    assert type(estimator.net).__name__ == NET_CLASS_NAMES[net_cls]
+
+
+@pytest.mark.parametrize(
+    "config_cls, bad_kwarg",
+    [
+        (FlowMatchingConfig, {"sigma_min": 0.1}),
+        (FlowMatchingConfig, {"beta_min": 0.1}),
+        (FlowMatchingConfig, {"sde_type": "vp"}),
+        (VEScoreConfig, {"gaussian_baseline": True}),
+        (VEScoreConfig, {"beta_min": 0.1}),
+        (VPScoreConfig, {"sigma_max": 5.0}),
+        (SubVPScoreConfig, {"train_schedule": "lognormal"}),
+    ],
+)
+def test_estimator_config_rejects_a_setting_it_does_not_have(config_cls, bad_kwarg):
+    """A setting of a sibling estimator used to be accepted and dropped."""
+    with pytest.raises(TypeError):
+        config_cls(**bad_kwarg)
+
+
+@pytest.mark.parametrize(
+    "net_cls, bad_kwarg",
+    [
+        (MLPConfig, {"num_heads": 4}),
+        (MLPConfig, {"mlp_ratio": 2}),
+        (MLPConfig, {"adamlp_ratio": 2}),
+        (AdaMLPConfig, {"layer_norm": False}),
+        (AdaMLPConfig, {"num_heads": 4}),
+        (TransformerConfig, {"layer_norm": False}),
+        (TransformerConfig, {"adamlp_ratio": 2}),
+    ],
+)
+def test_net_config_rejects_a_setting_it_does_not_have(net_cls, bad_kwarg):
+    """The per-architecture guard is now the field set itself."""
+    with pytest.raises(TypeError):
+        net_cls(**bad_kwarg)
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS + NET_CONFIGS)
+def test_invalid_literal_value_raises(config_cls):
+    """Fail-fast on `Literal` values, which the type checker cannot see at runtime."""
+    field = "z_score_input" if config_cls in ALL_CONFIGS else "time_emb_type"
+    with pytest.raises(ValueError, match=field):
+        config_cls(**{field: "not_a_value"})
+
+
+@pytest.mark.parametrize("base_cls", [VectorFieldConfigBase, _VectorFieldNetConfigBase])
+def test_role_base_cannot_be_instantiated(base_cls):
+    """A role base selects no model, so it is not a usable config."""
+    with pytest.raises(TypeError, match="per-model config"):
+        base_cls()
+
+
+# --------------------------------------------------------------------------
+# Networks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", sorted(_VALID_VF_MODELS))
+def test_every_advertised_model_maps_to_a_net_config(model):
+    """The deprecated string path must cover the whole `VF_MODELS` Literal."""
+    net_config = _vf_net_config_from_model(model)
+    assert isinstance(net_config, _VectorFieldNetConfigBase)
+    if model == "transformer_cross_attn":
+        assert net_config.is_x_emb_seq
+
+
+def test_unknown_model_name_raises():
+    with pytest.raises(ValueError, match="Unknown vector field model"):
+        _vf_net_config_from_model("not_a_model")
+
+
+@pytest.mark.parametrize("net_cls", NET_CONFIGS)
+def test_net_config_builds_the_network_alone(net_cls, batches):
+    """The network configs are usable on their own, without an estimator."""
+    assert isinstance(net_cls().build(*batches), nn.Module)
+
+
+def test_cross_attention_takes_a_sequence_condition():
+    theta, x_seq = torch.randn(32, 2), torch.randn(32, 5, 4)
+    estimator = FlowMatchingConfig(net=TransformerConfig(is_x_emb_seq=True)).build(
+        theta, x_seq
+    )
+    assert estimator.condition_shape == torch.Size([5, 4])
+
+
+def test_custom_network_module_is_accepted(batches):
+    """A user with their own architecture must still be able to pass it."""
+    theta, x = batches
+    custom = build_standard_mlp_network(theta, x)
+    assert FlowMatchingConfig(net=custom).build(theta, x).net is custom
+
+
+# --------------------------------------------------------------------------
+# Wiring
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+def test_embedding_net_is_wired_once(config_cls, batches):
+    """The network only reads the embedded shape, so it must not hold the net."""
+    theta, x = batches
+    embedding_net = nn.Linear(3, 7)
+    estimator = config_cls(embedding_net=embedding_net).build(theta, x)
+
+    assert not any(m is embedding_net for m in estimator.net.modules())
+    assert any(m is embedding_net for m in estimator._embedding_net.modules())
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+def test_compose_standardization_is_set_by_the_constructor(config_cls, batches):
+    """The boundary affine arrives as an argument, not by writing into buffers."""
+    estimator = config_cls(compose_standardization=True).build(*batches)
+
+    assert estimator.compose_enabled
+    assert (estimator.mean_0 == 0).all() and (estimator.std_0 == 1).all()
+
+
+def test_compose_standardization_rejects_the_gaussian_baseline(batches):
+    with pytest.raises(ValueError, match="gaussian_baseline"):
+        FlowMatchingConfig(compose_standardization=True, gaussian_baseline=True).build(
+            *batches
+        )
+
+
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS)
+def test_z_scoring_of_the_condition_wraps_the_embedding(config_cls, batches):
+    """`z_score_condition` standardizes the variable conditioned on."""
+    theta, x = batches
+    without = config_cls(z_score_condition="none").build(theta, x)
+    with_zscore = config_cls(z_score_condition="independent").build(theta, x)
+
+    assert isinstance(without._embedding_net, nn.Identity)
+    assert isinstance(with_zscore._embedding_net, nn.Sequential)
+
+
+# --------------------------------------------------------------------------
+# Trainer dispatch
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "trainer_cls, config_cls, estimator_cls",
+    [
+        (FMPE, FlowMatchingConfig, FlowMatchingEstimator),
+        (NPSE, VEScoreConfig, VEScoreEstimator),
+        (NPSE, VPScoreConfig, VPScoreEstimator),
+        (NPSE, SubVPScoreConfig, SubVPScoreEstimator),
+    ],
+)
+def test_trainer_trains_with_a_config(
+    trainer_cls, config_cls, estimator_cls, gaussian_sims
+):
+    prior, theta, x = gaussian_sims
+    config = config_cls(net=MLPConfig(hidden_features=16, num_layers=2))
+    trainer = trainer_cls(prior, config, show_progress_bars=False)
+    estimator = trainer.append_simulations(theta, x).train(
+        max_num_epochs=1, training_batch_size=100
+    )
+    assert isinstance(estimator, estimator_cls)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls, wrong_config",
+    [
+        (FMPE, VEScoreConfig()),
+        (FMPE, VPScoreConfig()),
+        (NPSE, FlowMatchingConfig()),
+    ],
+)
+def test_trainer_rejects_the_wrong_family(trainer_cls, wrong_config, gaussian_sims):
+    """A plain isinstance check against the family base, so a TypeError."""
+    prior, _, _ = gaussian_sims
+    with pytest.raises(TypeError, match="requires a"):
+        trainer_cls(prior, wrong_config, show_progress_bars=False)
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_trainer_rejects_a_config_of_another_role(trainer_cls, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.raises(TypeError, match="requires a"):
+        trainer_cls(prior, MAFConfig(), show_progress_bars=False)
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_trainer_rejects_a_config_class(trainer_cls, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.raises(TypeError, match="not an instance"):
+        trainer_cls(prior, FlowMatchingConfig, show_progress_bars=False)
+
+
+@pytest.mark.parametrize(
+    "sde_type, estimator_cls",
+    [
+        ("ve", VEScoreEstimator),
+        ("vp", VPScoreEstimator),
+        ("subvp", SubVPScoreEstimator),
+    ],
+)
+def test_npse_sde_type_selects_the_config(sde_type, estimator_cls, gaussian_sims):
+    """Without a config, the deprecated kwarg still picks the SDE."""
+    prior, theta, x = gaussian_sims
+    trainer = NPSE(prior, sde_type=sde_type, show_progress_bars=False)
+    trainer.append_simulations(theta, x)
+    assert isinstance(trainer._build_neural_net(theta, x), estimator_cls)
+
+
+def test_npse_rejects_sde_type_together_with_a_config(gaussian_sims):
+    """The config carries the SDE as its class, so the kwarg has nothing to say."""
+    prior, _, _ = gaussian_sims
+    with pytest.raises(ValueError, match="already selects the SDE"):
+        NPSE(prior, VEScoreConfig(), sde_type="vp", show_progress_bars=False)
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_string_path_warns_and_names_the_import(trainer_cls, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.warns(FutureWarning, match="from sbi.neural_nets import"):
+        trainer_cls(prior, "mlp", show_progress_bars=False)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls, kwarg",
+    [(FMPE, "density_estimator"), (NPSE, "score_estimator")],
+)
+def test_legacy_kwarg_warns(trainer_cls, kwarg, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.warns(FutureWarning, match="deprecated"):
+        trainer_cls(prior, **{kwarg: "mlp"}, show_progress_bars=False)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls, kwarg",
+    [(FMPE, "density_estimator"), (NPSE, "score_estimator")],
+)
+def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
+    prior, _, _ = gaussian_sims
+    with pytest.raises(ValueError, match="Cannot pass both"):
+        trainer_cls(
+            prior, vf_estimator="mlp", **{kwarg: "mlp"}, show_progress_bars=False
+        )
+
+
+@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
+def test_role_shapes_are_not_swapped(trainer_cls):
+    """FMPE and NPSE model theta given x, so input is theta and condition is x."""
+    prior = MultivariateNormal(zeros(2), torch.eye(2))
+    theta, x = prior.sample((100,)), torch.randn(100, 5)
+    trainer = trainer_cls(prior, show_progress_bars=False)
+    trainer.append_simulations(theta, x)
+    estimator = trainer._build_neural_net(theta, x)
+
+    assert estimator.input_shape == torch.Size([2])
+    assert estimator.condition_shape == torch.Size([5])
+
+
+# --------------------------------------------------------------------------
+# Factory path
+# --------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -39,356 +372,105 @@ def test_advertised_time_emb_types_all_build(factory_fn):
         builder(torch.randn(10, 2), torch.randn(10, 3))
 
 
-@pytest.fixture
-def gaussian_sims():
+@pytest.mark.parametrize("model", sorted(_VALID_VF_MODELS - {"transformer_cross_attn"}))
+@pytest.mark.parametrize(
+    "factory_fn", [posterior_flow_nn, posterior_score_nn], ids=["flow", "score"]
+)
+def test_factory_builds_every_model(factory_fn, model, batches):
+    assert factory_fn(model=model)(*batches) is not None
+
+
+@pytest.mark.parametrize(
+    "factory_fn, sde_kwargs, estimator_cls",
+    [
+        (posterior_flow_nn, {}, FlowMatchingEstimator),
+        (posterior_score_nn, {"sde_type": "ve"}, VEScoreEstimator),
+        (posterior_score_nn, {"sde_type": "vp"}, VPScoreEstimator),
+        (posterior_score_nn, {"sde_type": "subvp"}, SubVPScoreEstimator),
+    ],
+)
+def test_factory_sde_type_maps_to_the_config(
+    factory_fn, sde_kwargs, estimator_cls, batches
+):
+    assert isinstance(factory_fn(**sde_kwargs)(*batches), estimator_cls)
+
+
+def test_factory_routes_settings_to_the_axis_that_owns_them(batches):
+    """A factory argument reaches the network or the estimator, not both."""
+    estimator = posterior_score_nn(
+        model="transformer", hidden_features=64, num_heads=2, sigma_max=20.0
+    )(*batches)
+
+    assert estimator.sigma_max == 20.0
+    assert {
+        m.num_heads for m in estimator.net.modules() if hasattr(m, "num_heads")
+    } == {2}
+
+
+def test_factory_warns_on_an_unknown_name():
+    with pytest.warns(UserWarning, match="Unknown kwargs"):
+        posterior_flow_nn(hiden_features=64)
+
+
+def test_factory_rejects_network_settings_for_a_custom_network(batches):
+    """A custom network is built by the user, so a setting it cannot read raises."""
+    theta, x = batches
+    custom = build_standard_mlp_network(theta, x)
+    with pytest.raises(ValueError, match="silently ignored"):
+        posterior_flow_nn(model=custom, hidden_features=64)
+
+
+@pytest.mark.parametrize(
+    "factory_fn, config_cls",
+    [(posterior_flow_nn, FlowMatchingConfig), (posterior_score_nn, VEScoreConfig)],
+    ids=["flow", "score"],
+)
+def test_factory_defaults_match_the_config_defaults(factory_fn, config_cls, batches):
+    """The configs document what the public path has always produced.
+
+    Pinned against the dispatcher-effective values rather than the inner build
+    signatures, which are allowed to differ.
+    """
+    from_factory = factory_fn()(*batches)
+    from_config = config_cls().build(*batches)
+
+    assert type(from_factory) is type(from_config)
+    assert type(from_factory.net) is type(from_config.net)
+    assert sum(p.numel() for p in from_factory.parameters()) == sum(
+        p.numel() for p in from_config.parameters()
+    )
+
+
+@pytest.mark.parametrize(
+    "trainer_cls, config_cls",
+    [(FMPE, FlowMatchingConfig), (NPSE, VEScoreConfig)],
+)
+def test_trainer_default_matches_the_config_default(trainer_cls, config_cls, batches):
+    """`FMPE(prior)` and `NPSE(prior)` must keep producing today's network."""
+    theta, x = batches
     prior = MultivariateNormal(zeros(2), torch.eye(2))
-    theta = prior.sample((200,))
-    x = theta + 0.1 * torch.randn_like(theta)
-    return prior, theta, x
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_no_warning_for_valid_inputs(trainer_cls, gaussian_sims):
-    """None, builder, and callable should not emit FutureWarning."""
-    prior, _, _ = gaussian_sims
-    for inp in [None, VectorFieldEstimatorBuilder(model="mlp"), lambda t, x: None]:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            trainer_cls(prior=prior, vf_estimator=inp)
-
-
-@pytest.mark.parametrize(
-    "trainer_cls,kwarg,match",
-    [
-        (NPSE, {"score_estimator": "mlp"}, "score_estimator"),
-        (FMPE, {"density_estimator": lambda t, x: None}, "density_estimator"),
-    ],
-    ids=["npse-score", "fmpe-density"],
-)
-def test_legacy_kwarg_warns(trainer_cls, kwarg, match, gaussian_sims):
-    prior, _, _ = gaussian_sims
-    with pytest.warns(FutureWarning, match=match):
-        trainer_cls(prior=prior, **kwarg)
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_wrong_builder_type_raises(trainer_cls, gaussian_sims):
-    prior, _, _ = gaussian_sims
-    with pytest.raises(TypeError, match="VectorFieldEstimatorBuilder"):
-        trainer_cls(prior=prior, vf_estimator=MAFConfig())
-
-
-def test_builder_invalid_model():
-    with pytest.raises(ValueError, match="Unknown model"):
-        VectorFieldEstimatorBuilder(model="invalid")
-
-
-@pytest.mark.parametrize(
-    "est_type,bad_field",
-    [("flow", {"sigma_min": 0.01}), ("score", {"gaussian_baseline": True})],
-    ids=["flow-rejects-score", "score-rejects-flow"],
-)
-def test_estimator_type_field_guard(est_type, bad_field):
-    with pytest.raises(ValueError, match="do not apply"):
-        VectorFieldEstimatorBuilder(estimator_type=est_type, **bad_field)
-
-
-def test_estimator_type_none_skips_field_guard():
-    """When estimator_type is None, flow/score field guard is skipped."""
-    # Should NOT raise even though sigma_min is a score-only field,
-    # because the guard is deferred to the trainer.
-    builder = VectorFieldEstimatorBuilder(model="mlp", sigma_min=0.01)
-    assert builder.estimator_type is None
-    assert builder.sigma_min == 0.01
-
-
-def test_estimator_type_none_build_raises():
-    """build() must raise if estimator_type is still None."""
-    builder = VectorFieldEstimatorBuilder(model="mlp")
-    with pytest.raises(ValueError, match="estimator_type is None"):
-        builder.build(
-            batch_input=torch.randn(10, 2),
-            batch_condition=torch.randn(10, 2),
-        )
-
-
-@pytest.mark.parametrize(
-    "trainer_cls,expected_type",
-    [(FMPE, "FlowMatchingEstimator"), (NPSE, "ScoreEstimator")],
-    ids=["fmpe-resolves-flow", "npse-resolves-score"],
-)
-def test_trainer_resolves_none_estimator_type(
-    trainer_cls, expected_type, gaussian_sims
-):
-    """Trainers must resolve estimator_type=None to the correct type."""
-    prior, theta, x = gaussian_sims
-    builder = VectorFieldEstimatorBuilder(model="mlp")
-    assert builder.estimator_type is None
-    trainer = trainer_cls(prior=prior, vf_estimator=builder)
+    trainer = trainer_cls(prior, show_progress_bars=False)
     trainer.append_simulations(theta, x)
-    est = trainer.train(max_num_epochs=1, training_batch_size=100)
-    assert expected_type in type(est).__name__
+
+    from_trainer = trainer._build_neural_net(theta, x)
+    assert type(from_trainer) is type(config_cls().build(theta, x))
+    assert isinstance(from_trainer.net, VectorFieldMLP)
 
 
-@pytest.mark.parametrize(
-    "trainer_cls,wrong_type,match",
-    [
-        (FMPE, "score", "flow-matching"),
-        (NPSE, "flow", "score estimators"),
-    ],
-    ids=["fmpe-rejects-score", "npse-rejects-flow"],
-)
-def test_trainer_rejects_wrong_estimator_type(
-    trainer_cls, wrong_type, match, gaussian_sims
-):
-    """Trainer must raise when given a builder with the wrong estimator_type."""
-    prior, _, _ = gaussian_sims
-    with pytest.raises(ValueError, match=match):
-        trainer_cls(
-            prior=prior,
-            vf_estimator=VectorFieldEstimatorBuilder(
-                model="mlp", estimator_type=wrong_type
-            ),
-        )
+# --------------------------------------------------------------------------
+# extra_kwargs
+# --------------------------------------------------------------------------
 
 
-def test_per_arch_validation_rejects_num_heads_on_mlp():
-    """num_heads is transformer-only; must be rejected for model='mlp'."""
-    with pytest.raises(ValueError, match="num_heads"):
-        VectorFieldEstimatorBuilder(model="mlp", num_heads=8)
+def test_extra_kwargs_has_one_bucket_per_axis(batches):
+    """Estimator extras reach the estimator, which the flat bucket never did."""
+    estimator = VEScoreConfig(extra_kwargs={"t_max": 0.9}).build(*batches)
+    assert estimator.t_max == 0.9
 
 
-def test_score_accepts_score_fields():
-    builder = VectorFieldEstimatorBuilder(
-        estimator_type="score",
-        sde_type="ve",
-        sigma_min=0.01,
-        sigma_max=50.0,
-    )
-    assert builder.sigma_min == 0.01
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_train_with_builder(trainer_cls, gaussian_sims):
-    """End-to-end: train with VectorFieldEstimatorBuilder and sample."""
-    prior, theta, x = gaussian_sims
-    est_type = "score" if trainer_cls is NPSE else "flow"
-    builder_kwargs = {"model": "mlp", "estimator_type": est_type}
-    if trainer_cls is NPSE:
-        builder_kwargs["sde_type"] = "ve"
-
-    trainer = trainer_cls(
-        prior=prior,
-        vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
-    )
-    trainer.append_simulations(theta, x)
-    estimator = trainer.train(max_num_epochs=2, training_batch_size=100)
-
-    assert estimator is not None
-    posterior = trainer.build_posterior(estimator)
-    samples = posterior.sample((10,), x=torch.randn(1, 2))
-    assert samples.shape == (10, 2)
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_builder_role_shapes(trainer_cls):
-    """Asymmetric dims catch silent role swaps (Decision 10/13)."""
-    prior = MultivariateNormal(zeros(2), torch.eye(2))
-    theta = prior.sample((200,))
-    x = theta.sum(dim=-1, keepdim=True) + 0.1 * torch.randn(200, 5)
-
-    est_type = "score" if trainer_cls is NPSE else "flow"
-    builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
-    trainer = trainer_cls(prior=prior, vf_estimator=builder)
-    trainer.append_simulations(theta, x)
-    estimator = trainer.train(max_num_epochs=1, training_batch_size=100)
-
-    assert estimator.input_shape == torch.Size([2])
-    assert estimator.condition_shape == torch.Size([5])
-
-
-@pytest.mark.parametrize("trainer_cls", [FMPE, NPSE])
-def test_warning_includes_import_path(trainer_cls, gaussian_sims):
-    prior, _, _ = gaussian_sims
-    with pytest.warns(FutureWarning, match="from sbi.neural_nets import"):
-        trainer_cls(prior=prior, vf_estimator="mlp")
-
-
-def test_score_only_fields_match_config():
-    """_SCORE_ONLY_FIELDS must stay in sync with ScoreEstimatorConfig."""
-    from sbi.neural_nets.net_builders.vector_field_nets import (
-        ScoreEstimatorConfig,
-        _VectorFieldBaseConfig,
-    )
-
-    score_diff = {f.name for f in dc_fields(ScoreEstimatorConfig)} - {
-        f.name for f in dc_fields(_VectorFieldBaseConfig)
-    }
-    assert score_diff | {"sde_type"} == _SCORE_ONLY_FIELDS
-
-
-def test_flow_only_fields_match_config():
-    """_FLOW_ONLY_FIELDS must stay in sync with FlowEstimatorConfig."""
-    from sbi.neural_nets.net_builders.vector_field_nets import (
-        FlowEstimatorConfig,
-        _VectorFieldBaseConfig,
-    )
-
-    flow_diff = {f.name for f in dc_fields(FlowEstimatorConfig)} - {
-        f.name for f in dc_fields(_VectorFieldBaseConfig)
-    }
-    assert flow_diff == _FLOW_ONLY_FIELDS
-
-
-@pytest.mark.parametrize(
-    "trainer_cls,kwarg",
-    [
-        (NPSE, {"score_estimator": "mlp"}),
-        (NPSE, {"density_estimator": lambda t, x: None}),
-        (FMPE, {"density_estimator": lambda t, x: None}),
-    ],
-    ids=["npse-score", "npse-density", "fmpe-density"],
-)
-def test_legacy_and_vf_estimator_conflict(trainer_cls, kwarg, gaussian_sims):
-    """Passing a deprecated kwarg alongside vf_estimator should raise."""
-    prior, _, _ = gaussian_sims
-    est_type = "score" if trainer_cls is NPSE else "flow"
-    with pytest.raises(ValueError, match="Cannot pass both"):
-        trainer_cls(
-            prior=prior,
-            vf_estimator=VectorFieldEstimatorBuilder(estimator_type=est_type),
-            **kwarg,
-        )
-
-
-@pytest.mark.parametrize(
-    "builder_sde,trainer_sde,should_raise,expected_cls",
-    [
-        # values agree then no error, uses the agreed value
-        ("ve", "ve", False, "VEScoreEstimator"),
-        # values conflict then must raise
-        ("ve", "vp", True, None),
-        # builder only (trainer omits) then no error, builder's value wins
-        ("vp", None, False, "VPScoreEstimator"),
-        # builder sde_type unset, trainer explicit then trainer's value forwarded
-        (None, "vp", False, "VPScoreEstimator"),
-    ],
-    ids=["agree", "conflict", "builder-only", "trainer-only"],
-)
-def test_npse_sde_type_interactions(
-    builder_sde, trainer_sde, should_raise, expected_cls, gaussian_sims
-):
-    """sde_type must raise only when both are supplied and they disagree."""
-    prior, theta, x = gaussian_sims
-
-    builder_kwargs = {"estimator_type": "score"}
-    if builder_sde is not None:
-        builder_kwargs["sde_type"] = builder_sde
-
-    trainer_kwargs = {"prior": prior}
-    if trainer_sde is not None:
-        trainer_kwargs["sde_type"] = trainer_sde
-
-    if should_raise:
-        with pytest.raises(ValueError, match="sde_type"):
-            NPSE(
-                vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
-                **trainer_kwargs,
-            )
-    else:
-        trainer = NPSE(
-            vf_estimator=VectorFieldEstimatorBuilder(**builder_kwargs),
-            **trainer_kwargs,
-        )
-        trainer.append_simulations(theta, x)
-        estimator = trainer.train(max_num_epochs=1, training_batch_size=100)
-        assert type(estimator).__name__ == expected_cls, (
-            f"Expected {expected_cls}, got {type(estimator).__name__}"
-        )
-
-
-@pytest.mark.parametrize("est_type", ["flow", "score"])
-def test_default_builder_matches_factory_z_scoring(est_type):
-    """Builder and factory must produce identical z-scoring buffers."""
-    theta = torch.randn(200, 2) + 5.0
-    x = theta + 0.1 * torch.randn_like(theta)
-
-    # Build via builder.
-    builder = VectorFieldEstimatorBuilder(model="mlp", estimator_type=est_type)
-    est_builder = builder.build(batch_input=theta, batch_condition=x)
-
-    # Build via factory.
-    if est_type == "flow":
-        from sbi.neural_nets.factory import posterior_flow_nn
-
-        factory_fn = posterior_flow_nn(model="mlp")
-    else:
-        from sbi.neural_nets.factory import posterior_score_nn
-
-        factory_fn = posterior_score_nn(model="mlp")
-    est_factory = factory_fn(theta, x)
-
-    # Compare z-scoring buffers on the input (theta) side.
-    assert torch.allclose(est_builder.mean_0, est_factory.mean_0), (
-        "mean_0 mismatch between builder and factory"
-    )
-    assert torch.allclose(est_builder.std_0, est_factory.std_0), (
-        "std_0 mismatch between builder and factory"
-    )
-
-    # Compare z-scoring on the condition (x) side.
-    from sbi.utils.sbiutils import Standardize
-
-    def _get_standardize(module):
-        for m in module.modules():
-            if isinstance(m, Standardize):
-                return m
-        return None
-
-    std_builder = _get_standardize(est_builder.embedding_net)
-    std_factory = _get_standardize(est_factory.embedding_net)
-    assert std_builder is not None, "Builder embedding_net missing Standardize"
-    assert std_factory is not None, "Factory embedding_net missing Standardize"
-    assert torch.allclose(std_builder.mean, std_factory.mean), (
-        "embedding_net Standardize mean mismatch"
-    )
-    assert torch.allclose(std_builder.std, std_factory.std), (
-        "embedding_net Standardize std mismatch"
-    )
-
-
-@pytest.mark.parametrize(
-    "net,batch_y_3d,is_x_emb_seq_kwarg",
-    [
-        ("mlp", False, None),
-        ("ada_mlp", False, None),
-        ("transformer", False, None),
-        ("transformer_cross_attn", True, None),
-        # net="transformer" plus explicit is_x_emb_seq=True via kwargs
-        ("transformer", True, True),
-    ],
-    ids=["mlp", "ada_mlp", "transformer", "cross_attn", "transformer+is_x_emb_seq"],
-)
-def test_all_architectures_build(net, batch_y_3d, is_x_emb_seq_kwarg):
-    """All four architectures must build without error."""
-    from sbi.neural_nets.net_builders.vector_field_nets import (
-        build_vector_field_estimator,
-    )
-
-    batch_x = torch.randn(10, 3)
-    # Cross-attention needs sequence-shaped conditioning.
-    batch_y = torch.randn(10, 4, 8) if batch_y_3d else torch.randn(10, 5)
-
-    extra = {}
-    if is_x_emb_seq_kwarg is not None:
-        extra["is_x_emb_seq"] = is_x_emb_seq_kwarg
-
-    estimator = build_vector_field_estimator(
-        batch_x=batch_x,
-        batch_y=batch_y,
-        net=net,
-        estimator_type="flow",
-        **extra,
-    )
-    assert estimator is not None
-    assert estimator.input_shape == torch.Size([3])
+@pytest.mark.parametrize("config_cls", ALL_CONFIGS + NET_CONFIGS)
+def test_extra_kwargs_rejects_a_name_that_is_a_field(config_cls):
+    """There must be one place a setting can come from."""
+    name = dc_fields(config_cls)[0].name
+    with pytest.raises(ValueError, match="Pass the"):
+        config_cls(extra_kwargs={name: None})


### PR DESCRIPTION
## What does this PR do?

This PR continues the [GSoC 2026 Neural Network Builder API refactor](https://summerofcode.withgoogle.com/programs/2026/projects/P5QOhl9F) by converting the final estimator family, the vector field estimators, to the per-model configuration design. It adds per-model estimator and network configurations for FMPE and NPSE, integrates them with the trainers and legacy factories, and updates the corresponding tests.

## Does this close any issues?

N/A

## Anything else we should know?

### AI usage

Claude Opus 5 Ultracode via Claude Code CLI was used for the initial scaffolding and subsequent iterations under my supervision. ChatGPT 6 Astra via Codex was used for verification and helped identify and fix default-handling and legacy-factory compatibility issues. I reviewed every line of the resulting changes.

## Checklist

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [ ] (If applicable) I reported how long new tests run and marked slow ones
  with `pytest.mark.slow`.