### PR TITLE
Build the mixed estimators from a typed config

### DIFF
--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -16,25 +16,7 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     _factory_defaults,
     _mixed_config_from_factory_kwargs,
 )
-from sbi.neural_nets.net_builders.flow import (
-    build_made,
-    build_maf,
-    build_maf_rqs,
-    build_nsf,
-    build_tabpfn_flow,
-    build_zuko_bpf,
-    build_zuko_gf,
-    build_zuko_maf,
-    build_zuko_naf,
-    build_zuko_ncsf,
-    build_zuko_nice,
-    build_zuko_nsf,
-    build_zuko_sospf,
-    build_zuko_unaf,
-    build_zuko_unconditional_flow,
-)
-from sbi.neural_nets.net_builders.mdn import build_mdn
-from sbi.neural_nets.net_builders.mixed_nets import build_mnle, build_mnpe
+from sbi.neural_nets.net_builders.flow import build_zuko_unconditional_flow
 from sbi.neural_nets.net_builders.vector_field_nets import (
     FlowEstimatorConfig,
     ScoreEstimatorConfig,
@@ -42,26 +24,6 @@ from sbi.neural_nets.net_builders.vector_field_nets import (
 )
 from sbi.utils.nn_utils import check_net_device
 from sbi.utils.vector_field_utils import VectorFieldNet
-
-model_builders = {
-    "mdn": build_mdn,
-    "made": build_made,
-    "maf": build_maf,
-    "maf_rqs": build_maf_rqs,
-    "nsf": build_nsf,
-    "mnle": build_mnle,
-    "mnpe": build_mnpe,
-    "zuko_nice": build_zuko_nice,
-    "zuko_maf": build_zuko_maf,
-    "zuko_nsf": build_zuko_nsf,
-    "zuko_ncsf": build_zuko_ncsf,
-    "zuko_sospf": build_zuko_sospf,
-    "zuko_naf": build_zuko_naf,
-    "zuko_unaf": build_zuko_unaf,
-    "zuko_gf": build_zuko_gf,
-    "zuko_bpf": build_zuko_bpf,
-    "tabpfn": build_tabpfn_flow,
-}
 
 
 # TODO: currently only used for marginal_nn, adapt to use for all
@@ -277,6 +239,7 @@ def likelihood_nn(
     )
     if model in ("mnle", "mnpe"):
         config = _mixed_config_from_factory_kwargs(
+            model=model,
             family_args=family_args,
             factory_defaults=_factory_defaults(
                 likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS
@@ -397,6 +360,7 @@ def posterior_nn(
 
     if model in ("mnle", "mnpe"):
         config = _mixed_config_from_factory_kwargs(
+            model=model,
             family_args=family_args,
             factory_defaults=_factory_defaults(posterior_nn, _POSTERIOR_FACTORY_FIELDS),
             extra=kwargs,

--- a/sbi/neural_nets/factory.py
+++ b/sbi/neural_nets/factory.py
@@ -9,13 +9,12 @@ from torch import Tensor, nn
 
 from sbi.neural_nets.net_builders.estimator_configs import (
     VF_MODELS,
-    _BUILD_KWARG_ALIASES,
     _CLASSIFIER_CONFIGS,
     _DENSITY_CONFIGS,
-    ConditionalFlowConfig,
     MarginalFlowConfig,
     _config_from_factory_kwargs,
     _factory_defaults,
+    _mixed_config_from_factory_kwargs,
 )
 from sbi.neural_nets.net_builders.flow import (
     build_made,
@@ -139,34 +138,11 @@ def _density_family_args(embedding_net: nn.Module, **family_args: Any) -> dict:
     )
 
 
-def _legacy_density_build_fn(
-    model: str,
-    family_args: dict,
-    extra: dict,
-    input_is_theta: bool,
-) -> Callable:
-    """Return a build function for the models that have no config yet.
-
-    ``mnle`` and ``mnpe`` are reached through the density factories by the
-    deprecated string path of MNLE and MNPE, and are built from flat kwargs by
-    ``build_mnle`` / ``build_mnpe`` rather than from a config.
-    """
-    config = ConditionalFlowConfig.from_kwargs(
-        **{_BUILD_KWARG_ALIASES.get(k, k): v for k, v in family_args.items()},
-        **extra,
-    )
-    builder_kwargs = config.to_dict()
+def _unknown_density_build_fn(model: str) -> Callable:
+    """Preserve the factories' build-time error for unknown model names."""
 
     def build_fn(batch_theta, batch_x):
-        if model not in model_builders:
-            raise NotImplementedError(f"Model {model} is not implemented")
-
-        modeled, condition = (
-            (batch_theta, batch_x) if input_is_theta else (batch_x, batch_theta)
-        )
-        return model_builders[model](
-            batch_x=modeled, batch_y=condition, **builder_kwargs
-        )
+        raise NotImplementedError(f"Model {model} is not implemented")
 
     return build_fn
 
@@ -299,19 +275,27 @@ def likelihood_nn(
         embedding_net=embedding_net,
         num_components=num_components,
     )
-    if model not in _DENSITY_CONFIGS:
-        return _legacy_density_build_fn(
-            model, family_args, kwargs, input_is_theta=False
+    if model in ("mnle", "mnpe"):
+        config = _mixed_config_from_factory_kwargs(
+            family_args=family_args,
+            factory_defaults=_factory_defaults(
+                likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS
+            ),
+            extra=kwargs,
         )
-
-    config = _config_from_factory_kwargs(
-        model,
-        _DENSITY_CONFIGS,
-        "density",
-        family_args=family_args,
-        factory_defaults=_factory_defaults(likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS),
-        extra=kwargs,
-    )
+    elif model in _DENSITY_CONFIGS:
+        config = _config_from_factory_kwargs(
+            model,
+            _DENSITY_CONFIGS,
+            "density",
+            family_args=family_args,
+            factory_defaults=_factory_defaults(
+                likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS
+            ),
+            extra=kwargs,
+        )
+    else:
+        return _unknown_density_build_fn(model)
 
     def build_fn(batch_theta, batch_x):
         # NLE models p(x|theta), so the modeled variable is x.
@@ -411,17 +395,23 @@ def posterior_nn(
 
         return build_fn_snpe_a
 
-    if model not in _DENSITY_CONFIGS:
-        return _legacy_density_build_fn(model, family_args, kwargs, input_is_theta=True)
-
-    config = _config_from_factory_kwargs(
-        model,
-        _DENSITY_CONFIGS,
-        "density",
-        family_args=family_args,
-        factory_defaults=_factory_defaults(posterior_nn, _POSTERIOR_FACTORY_FIELDS),
-        extra=kwargs,
-    )
+    if model in ("mnle", "mnpe"):
+        config = _mixed_config_from_factory_kwargs(
+            family_args=family_args,
+            factory_defaults=_factory_defaults(posterior_nn, _POSTERIOR_FACTORY_FIELDS),
+            extra=kwargs,
+        )
+    elif model in _DENSITY_CONFIGS:
+        config = _config_from_factory_kwargs(
+            model,
+            _DENSITY_CONFIGS,
+            "density",
+            family_args=family_args,
+            factory_defaults=_factory_defaults(posterior_nn, _POSTERIOR_FACTORY_FIELDS),
+            extra=kwargs,
+        )
+    else:
+        return _unknown_density_build_fn(model)
 
     def build_fn(batch_theta, batch_x):
         # NPE models p(theta|x), so the modeled variable is theta.

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -17,10 +17,9 @@ therefore not a field on its config, and raises ``TypeError`` at construction
 rather than being ignored.  Fields carry real defaults, which makes the class
 the reference for the values a build actually uses.
 
-The legacy ``*Config`` classes above them are the factory-side validators from
-before that change.  They keep one flat field set per family with ``None`` as
-the "unset" sentinel, and ``from_kwargs()`` warns on unknown names while still
-forwarding them.  Only the paths without a per-model config still use them.
+The legacy ``MarginalFlowConfig`` is the factory-side validator from before
+that change. It keeps a flat field set with ``None`` as the "unset" sentinel,
+and ``from_kwargs()`` warns on unknown names while still forwarding them.
 
 ``VectorFieldEstimatorBuilder`` is likewise still a flat builder, with the
 signature-derived ``_reject_inapplicable_fields`` guard that the per-model
@@ -292,86 +291,6 @@ class _EstimatorBuilderBase:
         }
         d.update(self.extra_kwargs)
         return d
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class ConditionalFlowConfig(_EstimatorBuilderBase):
-    """Configuration for conditional normalizing-flow density estimator builders.
-
-    Used by ``posterior_nn`` and ``likelihood_nn``.  Fields cover all parameters
-    accepted by any downstream builder (NFlows, Zuko, MDN, MADE, MNLE, MNPE).
-    """
-
-    # --- Shared across most builders ---
-    z_score_x: Optional[Any] = None
-    z_score_y: Optional[Any] = None
-    hidden_features: Optional[Any] = None
-    num_transforms: Optional[int] = None
-    # num_bins: used by NFlows builders directly; Zuko wrappers (build_zuko_nsf,
-    # build_zuko_ncsf) translate it to 'bins' before calling build_zuko_flow.
-    num_bins: Optional[int] = None
-    embedding_net: Optional[Any] = None
-    num_components: Optional[int] = None
-
-    # --- NFlows-specific (MAF, NSF, MAF-RQS) ---
-    num_blocks: Optional[int] = None
-    dropout_probability: Optional[float] = None
-    use_batch_norm: Optional[bool] = None
-    tail_bound: Optional[float] = None
-    hidden_layers_spline_context: Optional[int] = None
-    tails: Optional[str] = None
-    min_bin_width: Optional[float] = None
-    min_bin_height: Optional[float] = None
-    min_derivative: Optional[float] = None
-
-    # --- MADE-specific ---
-    num_mixture_components: Optional[int] = None
-
-    # --- Zuko shared ---
-    x_dist: Optional[Any] = None
-
-    # --- Zuko per-model kwargs (model-specific; ignored by models that don't use them)
-    randperm: Optional[bool] = None  # zuko_maf, zuko_naf, zuko_unaf
-    randmask: Optional[bool] = None  # zuko_nice
-    signal: Optional[int] = None  # zuko_naf, zuko_unaf
-    degree: Optional[int] = None  # zuko_sospf, zuko_bpf
-    polynomials: Optional[int] = None  # zuko_sospf
-    components: Optional[int] = None  # zuko_gf
-
-    # --- Mixed-net specific (MNLE / MNPE) ---
-    flow_model: Optional[str] = None
-    log_transform_x: Optional[bool] = None
-    num_categories_per_variable: Optional[Any] = None
-    combined_embedding_net: Optional[Any] = None
-    discrete_hidden_features: Optional[int] = None
-    discrete_hidden_layers: Optional[int] = None
-    continuous_hidden_features: Optional[int] = None
-
-    # --- TabPFN-specific ---
-    regressor_init_kwargs: Optional[dict] = None
-
-    # --- Base distribution ---
-    dtype: Optional[Any] = None
-
-
-@dataclass(frozen=True, eq=False, repr=False)
-class ClassifierConfig(_EstimatorBuilderBase):
-    """Configuration for classifier builders (NRE).
-
-    Covers parameters accepted by ``build_linear_classifier``,
-    ``build_mlp_classifier``, and ``build_resnet_classifier``.
-    """
-
-    z_score_x: Optional[Any] = None
-    z_score_y: Optional[Any] = None
-    hidden_features: Optional[int] = None
-    embedding_net_x: Optional[Any] = None
-    embedding_net_y: Optional[Any] = None
-
-    # --- ResNet-specific ---
-    num_blocks: Optional[int] = None
-    dropout_probability: Optional[float] = None
-    use_batch_norm: Optional[bool] = None
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1560,6 +1479,8 @@ def _config_from_factory_kwargs(
     family_args: dict,
     factory_defaults: dict,
     extra: dict,
+    error_model: Optional[str] = None,
+    config_guidance: Optional[str] = None,
 ) -> _PerModelConfigBase:
     """Build a per-model config from a factory's arguments.
 
@@ -1579,6 +1500,10 @@ def _config_from_factory_kwargs(
             field names.
         factory_defaults: Default of each family-wide argument.
         extra: The factory's ``**kwargs``.
+        error_model: Model name to show for rejected arguments. Defaults to
+            ``model``.
+        config_guidance: Replacement configuration guidance for rejected
+            arguments.
 
     Returns:
         The config for that model.
@@ -1612,11 +1537,14 @@ def _config_from_factory_kwargs(
         else:
             unknown[name] = value
     if ignored:
+        model_for_error = model if error_model is None else error_model
+        guidance = config_guidance or (
+            f"Configure the model directly with {config_cls.__name__}, or use "
+            "`extra_kwargs` to forward library-specific options."
+        )
         raise ValueError(
-            f"Argument(s) {sorted(ignored)} are not used by model={model!r} "
-            f"and would be silently ignored. Configure the model directly with "
-            f"{config_cls.__name__}, or use `extra_kwargs` to forward "
-            f"library-specific options."
+            f"Argument(s) {sorted(ignored)} are not used by "
+            f"model={model_for_error!r} and would be silently ignored. {guidance}"
         )
     if unknown:
         warnings.warn(
@@ -1634,8 +1562,26 @@ def _mixed_config_from_factory_kwargs(
     family_args: dict,
     factory_defaults: dict,
     extra: dict,
+    model: str = "mixed",
 ) -> MixedConfig:
-    """Build a mixed config from the deprecated factories' flat arguments."""
+    """Translate deprecated flat mixed-estimator arguments into a typed config.
+
+    The ``mnle`` and ``mnpe`` string paths expose settings for both the mixed
+    estimator and every supported continuous estimator in one flat argument
+    list. This function separates the mixed settings, selects and configures
+    the nested continuous model, and preserves the legacy defaults and ``None``
+    handling. Model-specific validation is delegated to the continuous config,
+    while errors refer to the outer model selected by the caller.
+
+    Args:
+        family_args: Named arguments shared by the density-estimator factory.
+        factory_defaults: Defaults for the entries in ``family_args``.
+        extra: Additional flat mixed or continuous-model arguments.
+        model: Mixed estimator name selected by the caller.
+
+    Returns:
+        A typed mixed-estimator configuration.
+    """
     extra = dict(extra)
     flow_model = extra.pop("flow_model", None)
     if flow_model is None:
@@ -1651,10 +1597,6 @@ def _mixed_config_from_factory_kwargs(
         "combined_embedding_features",
         "dropout_probability",
     )
-    # The flat path dropped a recognised None before building, so it still
-    # means unset, for any name the family knows rather than only the chosen
-    # model's. A name no model knows keeps its None, and with it the warning
-    # that catches a typo. A real value still raises for the wrong model.
     recognised = {"continuous_hidden_features", *mixed_fields}
     recognised |= {f.name for cls in _DENSITY_CONFIGS.values() for f in fields(cls)}
     extra = {
@@ -1664,8 +1606,9 @@ def _mixed_config_from_factory_kwargs(
     }
 
     mixed_kwargs = {
-        "z_score_condition": family_args["z_score_condition"],
-        "embedding_net": family_args["embedding_net"],
+        name: family_args[name]
+        for name in ("z_score_condition", "embedding_net")
+        if family_args[name] != factory_defaults[name]
     }
     for name in mixed_fields:
         if name in extra:
@@ -1688,8 +1631,6 @@ def _mixed_config_from_factory_kwargs(
     }
 
     if "continuous_hidden_features" in extra:
-        # The flat API let this override only the continuous width while the
-        # categorical width kept falling back to `hidden_features`.
         mixed_kwargs.setdefault(
             "discrete_hidden_features", continuous_args["hidden_features"]
         )
@@ -1703,11 +1644,15 @@ def _mixed_config_from_factory_kwargs(
     ):
         extra["dropout_probability"] = dropout_probability
 
-    # The flat mixed API passed `tail_bound` to every builder, so the models
-    # that read it saw 10.0 rather than their own narrower default.
     if config_cls is not None and "tail_bound" in {f.name for f in fields(config_cls)}:
         extra.setdefault("tail_bound", 10.0)
 
+    config_guidance = None
+    if config_cls is not None:
+        config_guidance = (
+            "Configure the continuous model through "
+            f"MixedConfig(continuous={config_cls.__name__}(...))."
+        )
     continuous = _config_from_factory_kwargs(
         flow_model,
         _DENSITY_CONFIGS,
@@ -1715,5 +1660,7 @@ def _mixed_config_from_factory_kwargs(
         family_args=continuous_args,
         factory_defaults=continuous_defaults,
         extra=extra,
+        error_model=model,
+        config_guidance=config_guidance,
     )
     return MixedConfig(continuous=continuous, **mixed_kwargs)

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -1652,11 +1652,11 @@ def _mixed_config_from_factory_kwargs(
         "dropout_probability",
     )
     # The flat path dropped a recognised None before building, so it still
-    # means unset. A name no model knows keeps its None, and with it the
-    # warning that catches a typo.
+    # means unset, for any name the family knows rather than only the chosen
+    # model's. A name no model knows keeps its None, and with it the warning
+    # that catches a typo. A real value still raises for the wrong model.
     recognised = {"continuous_hidden_features", *mixed_fields}
-    if config_cls is not None:
-        recognised |= {f.name for f in fields(config_cls)}
+    recognised |= {f.name for cls in _DENSITY_CONFIGS.values() for f in fields(cls)}
     extra = {
         name: value
         for name, value in extra.items()

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -1636,7 +1636,18 @@ def _mixed_config_from_factory_kwargs(
     extra: dict,
 ) -> MixedConfig:
     """Build a mixed config from the deprecated factories' flat arguments."""
-    extra = dict(extra)
+    # The flat API typed these as `Optional[int] = None`, so an explicit None
+    # meant "unset" and has to keep behaving like omitting the argument.
+    unset_if_none = (
+        "continuous_hidden_features",
+        "discrete_hidden_features",
+        "combined_embedding_features",
+    )
+    extra = {
+        name: value
+        for name, value in extra.items()
+        if value is not None or name not in unset_if_none
+    }
     flow_model = extra.pop("flow_model", "nsf")
 
     mixed_kwargs = {

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -1636,18 +1636,9 @@ def _mixed_config_from_factory_kwargs(
     extra: dict,
 ) -> MixedConfig:
     """Build a mixed config from the deprecated factories' flat arguments."""
-    # The flat API typed these as `Optional[int] = None`, so an explicit None
-    # meant "unset" and has to keep behaving like omitting the argument.
-    unset_if_none = (
-        "continuous_hidden_features",
-        "discrete_hidden_features",
-        "combined_embedding_features",
-    )
-    extra = {
-        name: value
-        for name, value in extra.items()
-        if value is not None or name not in unset_if_none
-    }
+    # The flat path dropped every None before building, so an explicit None
+    # has to keep behaving like omitting the argument.
+    extra = {name: value for name, value in extra.items() if value is not None}
     flow_model = extra.pop("flow_model", "nsf")
 
     mixed_kwargs = {
@@ -1678,6 +1669,10 @@ def _mixed_config_from_factory_kwargs(
         )
     }
     continuous_defaults = {name: factory_defaults[name] for name in continuous_args}
+    continuous_args = {
+        name: continuous_defaults[name] if value is None else value
+        for name, value in continuous_args.items()
+    }
 
     if "continuous_hidden_features" in extra:
         # The flat API let this override only the continuous width while the

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -1535,16 +1535,7 @@ class MixedConfig(_PerModelConfigBase):
         return _build_mixed_density_estimator(
             batch_x=batch_input,
             batch_y=batch_condition,
-            continuous_config=self.continuous,
-            z_score_y=self.z_score_condition,
-            num_categories_per_variable=self.num_categories_per_variable,
-            embedding_net=self.embedding_net,
-            combined_embedding_net=self.combined_embedding_net,
-            log_transform_x=self.log_transform_x,
-            discrete_hidden_features=self.discrete_hidden_features,
-            discrete_hidden_layers=self.discrete_hidden_layers,
-            combined_embedding_features=self.combined_embedding_features,
-            dropout_probability=self.dropout_probability,
+            config=self,
         )
 
 
@@ -1637,3 +1628,74 @@ def _config_from_factory_kwargs(
         )
 
     return config_cls(**accepted, extra_kwargs=unknown)
+
+
+def _mixed_config_from_factory_kwargs(
+    family_args: dict,
+    factory_defaults: dict,
+    extra: dict,
+) -> MixedConfig:
+    """Build a mixed config from the deprecated factories' flat arguments."""
+    extra = dict(extra)
+    flow_model = extra.pop("flow_model", "nsf")
+
+    mixed_kwargs = {
+        "z_score_condition": family_args["z_score_condition"],
+        "embedding_net": family_args["embedding_net"],
+    }
+    mixed_fields = (
+        "num_categories_per_variable",
+        "combined_embedding_net",
+        "log_transform_x",
+        "discrete_hidden_features",
+        "discrete_hidden_layers",
+        "combined_embedding_features",
+        "dropout_probability",
+    )
+    for name in mixed_fields:
+        if name in extra:
+            mixed_kwargs[name] = extra.pop(name)
+
+    continuous_args = {
+        name: family_args[name]
+        for name in (
+            "z_score_input",
+            "hidden_features",
+            "num_transforms",
+            "num_bins",
+            "num_components",
+        )
+    }
+    continuous_defaults = {name: factory_defaults[name] for name in continuous_args}
+
+    if "continuous_hidden_features" in extra:
+        # The flat API let this override only the continuous width while the
+        # categorical width kept falling back to `hidden_features`.
+        mixed_kwargs.setdefault(
+            "discrete_hidden_features", continuous_args["hidden_features"]
+        )
+        continuous_args["hidden_features"] = extra.pop("continuous_hidden_features")
+
+    dropout_probability = mixed_kwargs.get("dropout_probability")
+    config_cls = _DENSITY_CONFIGS.get(flow_model)
+    if (
+        dropout_probability is not None
+        and config_cls is not None
+        and "dropout_probability" in {f.name for f in fields(config_cls)}
+    ):
+        extra["dropout_probability"] = dropout_probability
+
+    # The flat mixed API passed `tail_bound` to every builder, so the models
+    # that read it saw 10.0 rather than their own narrower default.
+    if config_cls is not None and "tail_bound" in {f.name for f in fields(config_cls)}:
+        extra.setdefault("tail_bound", 10.0)
+
+    continuous = _config_from_factory_kwargs(
+        flow_model,
+        _DENSITY_CONFIGS,
+        "mixed continuous density",
+        family_args=continuous_args,
+        factory_defaults=continuous_defaults,
+        extra=extra,
+    )
+    return MixedConfig(continuous=continuous, **mixed_kwargs)

--- a/sbi/neural_nets/net_builders/estimator_configs.py
+++ b/sbi/neural_nets/net_builders/estimator_configs.py
@@ -1636,15 +1636,12 @@ def _mixed_config_from_factory_kwargs(
     extra: dict,
 ) -> MixedConfig:
     """Build a mixed config from the deprecated factories' flat arguments."""
-    # The flat path dropped every None before building, so an explicit None
-    # has to keep behaving like omitting the argument.
-    extra = {name: value for name, value in extra.items() if value is not None}
-    flow_model = extra.pop("flow_model", "nsf")
+    extra = dict(extra)
+    flow_model = extra.pop("flow_model", None)
+    if flow_model is None:
+        flow_model = "nsf"
+    config_cls = _DENSITY_CONFIGS.get(flow_model)
 
-    mixed_kwargs = {
-        "z_score_condition": family_args["z_score_condition"],
-        "embedding_net": family_args["embedding_net"],
-    }
     mixed_fields = (
         "num_categories_per_variable",
         "combined_embedding_net",
@@ -1654,6 +1651,22 @@ def _mixed_config_from_factory_kwargs(
         "combined_embedding_features",
         "dropout_probability",
     )
+    # The flat path dropped a recognised None before building, so it still
+    # means unset. A name no model knows keeps its None, and with it the
+    # warning that catches a typo.
+    recognised = {"continuous_hidden_features", *mixed_fields}
+    if config_cls is not None:
+        recognised |= {f.name for f in fields(config_cls)}
+    extra = {
+        name: value
+        for name, value in extra.items()
+        if value is not None or name not in recognised
+    }
+
+    mixed_kwargs = {
+        "z_score_condition": family_args["z_score_condition"],
+        "embedding_net": family_args["embedding_net"],
+    }
     for name in mixed_fields:
         if name in extra:
             mixed_kwargs[name] = extra.pop(name)
@@ -1683,7 +1696,6 @@ def _mixed_config_from_factory_kwargs(
         continuous_args["hidden_features"] = extra.pop("continuous_hidden_features")
 
     dropout_probability = mixed_kwargs.get("dropout_probability")
-    config_cls = _DENSITY_CONFIGS.get(flow_model)
     if (
         dropout_probability is not None
         and config_cls is not None

--- a/sbi/neural_nets/net_builders/mixed_nets.py
+++ b/sbi/neural_nets/net_builders/mixed_nets.py
@@ -17,6 +17,7 @@ from sbi.neural_nets.net_builders.categorial import (
 )
 from sbi.neural_nets.net_builders.estimator_configs import (
     MixedConfig,
+    _factory_defaults,
     _mixed_config_from_factory_kwargs,
 )
 from sbi.utils.sbiutils import standardizing_net, z_score_parser
@@ -123,22 +124,14 @@ def _build_mixed_density_estimator(
 
 def _config_from_flat_kwargs(log_transform_x: bool, kwargs: dict) -> MixedConfig:
     """Translate the exported mixed builders' legacy flat arguments."""
+    from sbi.neural_nets.factory import _LIKELIHOOD_FACTORY_FIELDS, likelihood_nn
+
     extra = dict(kwargs)
-    family_defaults = {
-        "z_score_input": "independent",
-        "hidden_features": 50,
-        "num_transforms": 5,
-        "num_bins": 10,
-        "num_components": 10,
-    }
+    family_defaults = _factory_defaults(likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS)
+    flat_names = {"z_score_input": "z_score_x", "z_score_condition": "z_score_y"}
     family_args = {
-        "z_score_input": extra.pop("z_score_x", "independent"),
-        "z_score_condition": extra.pop("z_score_y", "independent"),
-        "hidden_features": extra.pop("hidden_features", 50),
-        "num_transforms": extra.pop("num_transforms", 5),
-        "num_bins": extra.pop("num_bins", 10),
-        "embedding_net": extra.pop("embedding_net", nn.Identity()),
-        "num_components": extra.pop("num_components", 10),
+        name: extra.pop(flat_names.get(name, name), default)
+        for name, default in family_defaults.items()
     }
     for name in ("z_score_input", "z_score_condition"):
         if family_args[name] is None:

--- a/sbi/neural_nets/net_builders/mixed_nets.py
+++ b/sbi/neural_nets/net_builders/mixed_nets.py
@@ -3,7 +3,6 @@
 
 import warnings
 from dataclasses import replace
-from typing import TYPE_CHECKING, Optional
 
 import torch
 from torch import Tensor, nn
@@ -16,162 +15,39 @@ from sbi.neural_nets.estimators.mixed_density_estimator import (
 from sbi.neural_nets.net_builders.categorial import (
     build_categoricalmassestimator,
 )
-from sbi.neural_nets.net_builders.flow import (
-    build_made,
-    build_maf,
-    build_maf_rqs,
-    build_nsf,
-    build_zuko_bpf,
-    build_zuko_gf,
-    build_zuko_maf,
-    build_zuko_naf,
-    build_zuko_ncsf,
-    build_zuko_nice,
-    build_zuko_nsf,
-    build_zuko_sospf,
-    build_zuko_unaf,
+from sbi.neural_nets.net_builders.estimator_configs import (
+    MixedConfig,
+    _mixed_config_from_factory_kwargs,
 )
-from sbi.neural_nets.net_builders.mdn import build_mdn
 from sbi.utils.sbiutils import standardizing_net, z_score_parser
 from sbi.utils.user_input_checks import check_data_device
-
-if TYPE_CHECKING:
-    # Imported for typing only: the config module imports this one at build time.
-    from sbi.neural_nets.net_builders.estimator_configs import DensityConfigBase
-
-model_builders = {
-    "mdn": build_mdn,
-    "made": build_made,
-    "maf": build_maf,
-    "maf_rqs": build_maf_rqs,
-    "nsf": build_nsf,
-    "zuko_nice": build_zuko_nice,
-    "zuko_maf": build_zuko_maf,
-    "zuko_nsf": build_zuko_nsf,
-    "zuko_ncsf": build_zuko_ncsf,
-    "zuko_sospf": build_zuko_sospf,
-    "zuko_naf": build_zuko_naf,
-    "zuko_unaf": build_zuko_unaf,
-    "zuko_gf": build_zuko_gf,
-    "zuko_bpf": build_zuko_bpf,
-}
 
 
 def _build_mixed_density_estimator(
     batch_x: Tensor,
     batch_y: Tensor,
-    z_score_x: Optional[str] = "independent",
-    z_score_y: Optional[str] = "independent",
-    flow_model: str = "nsf",
-    continuous_config: Optional["DensityConfigBase"] = None,
-    num_categories_per_variable: Optional[Tensor] = None,
-    embedding_net: nn.Module = nn.Identity(),
-    combined_embedding_net: Optional[nn.Module] = None,
-    num_transforms: int = 5,
-    num_components: int = 10,
-    num_bins: int = 10,
-    hidden_features: int = 50,
-    tail_bound: float = 10.0,
-    log_transform_x: bool = False,
-    discrete_hidden_features: Optional[int] = None,
-    discrete_hidden_layers: int = 2,
-    combined_embedding_features: Optional[int] = None,
-    dropout_probability: float = 0.0,
-    continuous_hidden_features: Optional[int] = None,
-    **kwargs,
+    config: MixedConfig,
 ) -> MixedDensityEstimator:
-    """Base function for building mixed neural density estimators.
+    """Build a mixed density estimator from its typed configuration.
 
     This function contains the shared logic between MNLE and MNPE.
-
-    Returns a density estimator for mixed data types.
-
-    Uses an autoregressive categorical density estimator to model the discrete part
-    and a conditional density estimator to model the continuous part of the data.
-
-    Note: If the condition y is > 1D, an embedding net must be provided. Then,
-    during inference, we need to combine the embedded condition with the
-    discrete part of the input data. To do this, we use a combined embedding net
-    that takes the discrete part of the input and the embedded condition as
-    input and passes it on to the flow model.
-    To this end, we build the z-scoring and the embedding net in this function
-    here, i.e., outside of the flow model, and then pass z_score_x="none" to the
-    flow builder.
-    The y-embedding is passed to MixedDensityEstimator, which then uses it to
-    embed the continuous part and concatenate it with the discrete part during
-    log_prob evaluation and sampling.
-    The combined embedding net is passed to the flow model, which then uses it
-    to combine the already embedded and combined condition.
 
     Args:
         batch_x: Batch of xs, used to infer dimensionality.
         batch_y: Batch of ys, used to infer dimensionality and (optional)
             z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can be one of:
-            - `none`, or None: do not z-score.
-            - `independent`: z-score each dimension independently.
-            - `structured`: treat dimensions as related, therefore compute mean
-              and std
-            over the entire batch, instead of per-dimension. Should be used when
-            each sample is, for example, a time series or an image. For MNLE,
-            this applies to the continuous part of the data only.
-        z_score_y: Whether to z-score ys passing into the network, same options
-            as z_score_x.
-        flow_model: type of flow model to use for the continuous part of the
-            data. Ignored when ``continuous_config`` is given.
-        continuous_config: Config of the model for the continuous part of the
-            data. When given, it replaces ``flow_model`` and the flat
-            continuous settings (``z_score_x``, ``num_transforms``,
-            ``num_components``, ``num_bins``, ``tail_bound``,
-            ``continuous_hidden_features``), which the config carries itself.
-        num_categories_per_variable: number of categorical columns of each variable in
-            the input data. If None, the function will infer this from the data.
-        embedding_net: Optional embedding network for y, required if y is > 1D.
-        combined_embedding_net: Optional embedding for combining the discrete
-            part of the input and the embedded condition into a joined
-            condition. If None, a shallow MLP is used.
-        num_transforms: number of transforms in the flow model.
-        num_components: number of components in the mixture model.
-        num_bins: bins per spline for NSF.
-        hidden_features: number of hidden features shared across discrete and
-            continuous sub-nets. Use ``discrete_hidden_features`` and
-            ``continuous_hidden_features`` for independent control.
-        tail_bound: spline tail bound for NSF.
-        log_transform_x: whether to apply a log-transform to x to move it to unbounded
-            space, e.g., in case x consists of reaction time data (bounded by
-            zero).
-        discrete_hidden_features: number of hidden features for the discrete
-            (categorical) net. Defaults to ``hidden_features`` if not set.
-        discrete_hidden_layers: number of hidden layers for the discrete
-            (categorical) net.
-        combined_embedding_features: number of hidden features for the combined
-            embedding net. Defaults to the continuous net's width.
-        dropout_probability: Dropout probability of the categorical net. On
-            the legacy flat path it is also passed to compatible continuous nets.
-        continuous_hidden_features: number of hidden features for the continuous
-            (flow) net and the fallback combined embedding MLP. Defaults to
-            ``hidden_features`` if not set.
-        kwargs: additional keyword arguments passed to the flow model and the
-            categorical net.
+        config: Mixed estimator configuration.
 
     Returns:
         MixedDensityEstimator: nn.Module for performing MNLE or MNPE.
     """
     check_data_device(batch_x, batch_y)
 
-    # Resolve decoupled parameters, falling back to shared defaults. A
-    # continuous config carries the continuous width itself, which then also
-    # sizes the fallback combined embedding net.
-    if continuous_config is not None:
-        _continuous_hf = continuous_config.hidden_features  # type: ignore[attr-defined]
-    else:
-        _continuous_hf = continuous_hidden_features or hidden_features
+    continuous_hidden_features = config.continuous.hidden_features  # type: ignore[attr-defined]
     _discrete_hf = (
-        discrete_hidden_features
-        if discrete_hidden_features is not None
-        else _continuous_hf
-        if continuous_config is not None
-        else hidden_features
+        config.discrete_hidden_features
+        if config.discrete_hidden_features is not None
+        else continuous_hidden_features
     )
 
     warnings.warn(
@@ -182,22 +58,19 @@ def _build_mixed_density_estimator(
     )
 
     # Separate continuous and discrete data.
-    if num_categories_per_variable is None:
+    if config.num_categories_per_variable is None:
         num_disc = int(torch.sum(_is_discrete(batch_x)))
     else:
-        num_disc = len(num_categories_per_variable)
+        num_disc = len(config.num_categories_per_variable)
     cont_x, disc_x = _separate_input(batch_x, num_discrete_columns=num_disc)
 
-    # The embeedding net is applied to the continuous part of the inputs
-    z_score_y_bool, structured_y = z_score_parser(z_score_y)
+    embedding_net = config.embedding_net
+    z_score_y_bool, structured_y = z_score_parser(config.z_score_condition)
     if z_score_y_bool:
         embedding_net = nn.Sequential(
             standardizing_net(batch_y, structured_y), embedding_net
         )
-    else:
-        embedding_net = embedding_net
 
-    # embed
     embedded_batch_y = embedding_net(batch_y)
     combined_condition = torch.cat([disc_x, embedded_batch_y], dim=-1)
 
@@ -208,19 +81,18 @@ def _build_mixed_density_estimator(
         z_score_x="none",  # discrete data should not be z-scored
         z_score_y="none",  # y-embedding net already z-scores
         num_hidden=_discrete_hf,
-        num_layers=discrete_hidden_layers,
+        num_layers=config.discrete_hidden_layers,
         embedding_net=embedding_net,
-        num_categories_per_variable=num_categories_per_variable,
-        dropout_probability=dropout_probability,
+        num_categories_per_variable=config.num_categories_per_variable,
+        dropout_probability=config.dropout_probability,
     )
 
+    combined_embedding_net = config.combined_embedding_net
     if combined_embedding_net is None:
-        # set up linear embedding net for combining discrete and continuous
-        # data.
         _combined_hf = (
-            combined_embedding_features
-            if combined_embedding_features is not None
-            else _continuous_hf
+            config.combined_embedding_features
+            if config.combined_embedding_features is not None
+            else continuous_hidden_features
         )
         combined_embedding_net = nn.Sequential(
             nn.Linear(combined_condition.shape[-1], _combined_hf),
@@ -230,48 +102,52 @@ def _build_mixed_density_estimator(
         )
 
     # TODO: add support for optional log-transform in flow builders.
-    continuous_x = (
-        torch.log(cont_x + 1e-10)
-        if log_transform_x  # can apply log transform if data is strictly positive
-        else cont_x
-    )
+    continuous_x = torch.log(cont_x + 1e-10) if config.log_transform_x else cont_x
 
-    # Set up a flow for modelling the continuous data, conditioned on the discrete data.
-    if continuous_config is not None:
-        # The combined condition is already z-scored and is embedded by the
-        # combined embedding net, so those two settings are not the user's here.
-        continuous_net = replace(
-            continuous_config,
-            z_score_condition="none",
-            embedding_net=combined_embedding_net,
-        ).build(batch_input=continuous_x, batch_condition=combined_condition)
-    else:
-        # On the legacy path, nflows uses the same dropout for both sub-nets.
-        if not flow_model.startswith("zuko"):
-            kwargs["dropout_probability"] = dropout_probability
-
-        continuous_net = model_builders[flow_model](
-            batch_x=continuous_x,
-            batch_y=combined_condition,
-            z_score_x=z_score_x,
-            z_score_y="none",  # combined condition is already z-scored
-            # combined embedding net for discrete and continuous data.
-            embedding_net=combined_embedding_net,
-            num_bins=num_bins,
-            num_transforms=num_transforms,
-            num_components=num_components,
-            tail_bound=tail_bound,
-            hidden_features=_continuous_hf,
-            **kwargs,
-        )
+    # The combined condition is already z-scored and embedded here.
+    continuous_net = replace(
+        config.continuous,
+        z_score_condition="none",
+        embedding_net=combined_embedding_net,
+    ).build(batch_input=continuous_x, batch_condition=combined_condition)
 
     return MixedDensityEstimator(
         discrete_net=discrete_net,
         continuous_net=continuous_net,
         embedding_net=embedding_net,  # pass embedding for continuous condition part.
-        log_transform_input=log_transform_x,
+        log_transform_input=config.log_transform_x,
         input_shape=batch_x[0].shape,
         condition_shape=batch_y[0].shape,
+    )
+
+
+def _config_from_flat_kwargs(log_transform_x: bool, kwargs: dict) -> MixedConfig:
+    """Translate the exported mixed builders' legacy flat arguments."""
+    extra = dict(kwargs)
+    family_defaults = {
+        "z_score_input": "independent",
+        "hidden_features": 50,
+        "num_transforms": 5,
+        "num_bins": 10,
+        "num_components": 10,
+    }
+    family_args = {
+        "z_score_input": extra.pop("z_score_x", "independent"),
+        "z_score_condition": extra.pop("z_score_y", "independent"),
+        "hidden_features": extra.pop("hidden_features", 50),
+        "num_transforms": extra.pop("num_transforms", 5),
+        "num_bins": extra.pop("num_bins", 10),
+        "embedding_net": extra.pop("embedding_net", nn.Identity()),
+        "num_components": extra.pop("num_components", 10),
+    }
+    for name in ("z_score_input", "z_score_condition"):
+        if family_args[name] is None:
+            family_args[name] = "none"
+    extra["log_transform_x"] = log_transform_x
+    return _mixed_config_from_factory_kwargs(
+        family_args=family_args,
+        factory_defaults=family_defaults,
+        extra=extra,
     )
 
 
@@ -290,14 +166,12 @@ def build_mnle(
         batch_y: Batch of ys (parameters), used to infer dimensionality.
         log_transform_x: whether to apply a log-transform to x. This is by default false
             because x has to be strictly positive to apply log-transform.
-        **kwargs: Additional arguments passed to _build_mixed_density_estimator.
+        **kwargs: Legacy flat mixed-estimator arguments.
 
     Returns:
         MixedDensityEstimator for MNLE.
     """
-    return _build_mixed_density_estimator(
-        batch_x=batch_x, batch_y=batch_y, log_transform_x=log_transform_x, **kwargs
-    )
+    return _config_from_flat_kwargs(log_transform_x, kwargs).build(batch_x, batch_y)
 
 
 def build_mnpe(
@@ -315,11 +189,9 @@ def build_mnpe(
         batch_y: Batch of ys (data), used to infer dimensionality.
         log_transform_x: whether to apply a log-transform to x. This is by default false
             because x has to be strictly positive to apply log-transform.
-        **kwargs: Additional arguments passed to _build_mixed_density_estimator.
+        **kwargs: Legacy flat mixed-estimator arguments.
 
     Returns:
         MixedDensityEstimator for MNPE.
     """
-    return _build_mixed_density_estimator(
-        batch_x=batch_x, batch_y=batch_y, log_transform_x=log_transform_x, **kwargs
-    )
+    return _config_from_flat_kwargs(log_transform_x, kwargs).build(batch_x, batch_y)

--- a/sbi/neural_nets/net_builders/mixed_nets.py
+++ b/sbi/neural_nets/net_builders/mixed_nets.py
@@ -1,6 +1,13 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+"""Builders for density estimators over mixed continuous and discrete data.
+
+The conditioning variable ``y`` is z-scored and embedded here, then concatenated
+with the discrete columns. The combined net becomes the continuous flow's
+``embedding_net``, so the flow disables its own condition z-scoring.
+"""
+
 import warnings
 from dataclasses import replace
 
@@ -122,7 +129,9 @@ def _build_mixed_density_estimator(
     )
 
 
-def _config_from_flat_kwargs(log_transform_x: bool, kwargs: dict) -> MixedConfig:
+def _config_from_flat_kwargs(
+    log_transform_x: bool, kwargs: dict, model: str = "mixed"
+) -> MixedConfig:
     """Translate the exported mixed builders' legacy flat arguments."""
     from sbi.neural_nets.factory import _LIKELIHOOD_FACTORY_FIELDS, likelihood_nn
 
@@ -140,6 +149,7 @@ def _config_from_flat_kwargs(log_transform_x: bool, kwargs: dict) -> MixedConfig
             family_args[name] = "none"
     extra["log_transform_x"] = log_transform_x
     return _mixed_config_from_factory_kwargs(
+        model=model,
         family_args=family_args,
         factory_defaults=family_defaults,
         extra=extra,
@@ -166,7 +176,9 @@ def build_mnle(
     Returns:
         MixedDensityEstimator for MNLE.
     """
-    return _config_from_flat_kwargs(log_transform_x, kwargs).build(batch_x, batch_y)
+    return _config_from_flat_kwargs(log_transform_x, kwargs, model="mnle").build(
+        batch_x, batch_y
+    )
 
 
 def build_mnpe(
@@ -189,4 +201,6 @@ def build_mnpe(
     Returns:
         MixedDensityEstimator for MNPE.
     """
-    return _config_from_flat_kwargs(log_transform_x, kwargs).build(batch_x, batch_y)
+    return _config_from_flat_kwargs(log_transform_x, kwargs, model="mnpe").build(
+        batch_x, batch_y
+    )

--- a/sbi/neural_nets/net_builders/mixed_nets.py
+++ b/sbi/neural_nets/net_builders/mixed_nets.py
@@ -127,6 +127,8 @@ def _config_from_flat_kwargs(log_transform_x: bool, kwargs: dict) -> MixedConfig
     from sbi.neural_nets.factory import _LIKELIHOOD_FACTORY_FIELDS, likelihood_nn
 
     extra = dict(kwargs)
+    # The flat API names the modeled variable `x` whichever one the trainer
+    # models, so the likelihood mapping fits both builders.
     family_defaults = _factory_defaults(likelihood_nn, _LIKELIHOOD_FACTORY_FIELDS)
     flat_names = {"z_score_input": "z_score_x", "z_score_condition": "z_score_y"}
     family_args = {

--- a/tests/build_context_test.py
+++ b/tests/build_context_test.py
@@ -18,7 +18,7 @@ from sbi.neural_nets.build_context import (
     compute_z_score_stats,
 )
 from sbi.neural_nets.estimators.base import ConditionalEstimatorBuildFn
-from sbi.neural_nets.net_builders.estimator_configs import ConditionalFlowConfig
+from sbi.neural_nets.net_builders.estimator_configs import MarginalFlowConfig
 
 
 def test_zscore_config_defaults():
@@ -141,7 +141,7 @@ def test_compute_z_score_stats_matches_z_standardization():
 
 def test_estimator_builder_base_build_raises():
     """Subclasses that don't override build() raise NotImplementedError."""
-    cfg = ConditionalFlowConfig(hidden_features=64)
+    cfg = MarginalFlowConfig(hidden_features=64)
     theta = torch.randn(10, 5)
     x = torch.randn(10, 3)
     with pytest.raises(NotImplementedError, match="does not implement build"):
@@ -150,16 +150,14 @@ def test_estimator_builder_base_build_raises():
 
 def test_estimator_builder_base_from_kwargs():
     """The existing from_kwargs() + to_dict() contract is preserved."""
-    cfg = ConditionalFlowConfig(hidden_features=64)
+    cfg = MarginalFlowConfig(hidden_features=64)
     d = cfg.to_dict()
     assert d == {"hidden_features": 64}
 
 
 def test_estimator_builder_base_extra_warns():
     with pytest.warns(UserWarning, match="Unknown kwargs"):
-        cfg = ConditionalFlowConfig.from_kwargs(
-            hidden_features=64, some_zuko_param=True
-        )
+        cfg = MarginalFlowConfig.from_kwargs(hidden_features=64, some_zuko_param=True)
     d = cfg.to_dict()
     assert d == {"hidden_features": 64, "some_zuko_param": True}
 

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -2,12 +2,13 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import inspect
-from dataclasses import MISSING, FrozenInstanceError, fields
+from dataclasses import FrozenInstanceError
 
 import pytest
 import torch
 from torch import nn
 
+from sbi.neural_nets import likelihood_nn
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.net_builders.estimator_configs import (
     _CLASSIFIER_CONFIGS,
@@ -165,27 +166,25 @@ def test_classifier_defaults_match_the_build_functions(model):
         assert _defaults_agree(value, params[name].default), f"{model}.{name} drifted"
 
 
-def test_mixed_defaults_match_the_build_function():
+def test_mixed_defaults_match_the_factory():
     """Mixed is the family where a default drift shipped once.
 
     The builder path gave `num_transforms=2` and `num_bins=5` against the
-    factory's 5 and 10, so the defaults are pinned here too.
+    factory's 5 and 10, so compare the two complete networks.
     """
-    from sbi.neural_nets.net_builders.mixed_nets import (
-        _build_mixed_density_estimator,
+    theta = torch.randn(100, 3)
+    mixed_x = torch.cat(
+        [torch.randn(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
     )
 
-    params = _params(_build_mixed_density_estimator)
-    # `continuous` is a nested config rather than a value the builder defaults.
-    to_builder = {"z_score_condition": "z_score_y"}
+    torch.manual_seed(0)
+    configured = MixedConfig().build(mixed_x, theta)
+    torch.manual_seed(0)
+    from_factory = likelihood_nn("mnle")(theta, mixed_x)
 
-    for f in fields(MixedConfig):
-        if f.name in ("continuous", "extra_kwargs"):
-            continue
-        name = to_builder.get(f.name, f.name)
-        assert name in params, f"`{name}` is not accepted by the mixed builder"
-        value = f.default_factory() if f.default_factory is not MISSING else f.default
-        assert _defaults_agree(value, params[name].default), f"mixed.{name} drifted"
+    assert configured.state_dict().keys() == from_factory.state_dict().keys()
+    for name, value in configured.state_dict().items():
+        assert torch.equal(value, from_factory.state_dict()[name]), name
 
 
 def test_legacy_public_builder_registry_remains_complete():

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -170,31 +170,26 @@ def test_mixed_defaults_match_the_factory():
     """Mixed is the family where a default drift shipped once.
 
     The builder path gave `num_transforms=2` and `num_bins=5` against the
-    factory's 5 and 10, so pin every advertised factory default directly.
+    factory's 5 and 10, so compare the two complete networks.
     """
+    theta = torch.randn(100, 3)
+    mixed_x = torch.cat(
+        [torch.randn(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
+    )
+
     config = MixedConfig()
-    continuous = config.continuous
-    assert isinstance(continuous, NSFConfig)
+    assert isinstance(config.continuous, NSFConfig)
+    torch.manual_seed(0)
+    configured = config.build(mixed_x, theta)
+    torch.manual_seed(0)
+    from_factory = likelihood_nn("mnle")(theta, mixed_x)
 
-    factory_defaults = _params(likelihood_nn)
-    expected = {
-        "z_score_theta": config.z_score_condition,
-        "z_score_x": continuous.z_score_input,
-        "hidden_features": continuous.hidden_features,
-        "num_transforms": continuous.num_transforms,
-        "num_bins": continuous.num_bins,
-        "embedding_net": config.embedding_net,
-        "num_components": MDNConfig().num_components,
-    }
-    for name, value in expected.items():
-        assert _defaults_agree(value, factory_defaults[name].default), name
+    assert configured.state_dict().keys() == from_factory.state_dict().keys()
+    for name, value in configured.state_dict().items():
+        assert torch.equal(value, from_factory.state_dict()[name]), name
 
-
-def test_legacy_public_builder_registry_remains_complete():
-    """Keep compatibility for callers that import ``factory.model_builders``."""
-    from sbi.neural_nets.factory import model_builders
-
-    assert set(model_builders) == set(_DENSITY_CONFIGS) | {"mnle", "mnpe"}
+    assert config.continuous.tail_bound == 10.0
+    assert config.dropout_probability == 0.0
 
 
 def test_every_classifier_model_has_a_config():

--- a/tests/density_estimator_builder_test.py
+++ b/tests/density_estimator_builder_test.py
@@ -170,21 +170,24 @@ def test_mixed_defaults_match_the_factory():
     """Mixed is the family where a default drift shipped once.
 
     The builder path gave `num_transforms=2` and `num_bins=5` against the
-    factory's 5 and 10, so compare the two complete networks.
+    factory's 5 and 10, so pin every advertised factory default directly.
     """
-    theta = torch.randn(100, 3)
-    mixed_x = torch.cat(
-        [torch.randn(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
-    )
+    config = MixedConfig()
+    continuous = config.continuous
+    assert isinstance(continuous, NSFConfig)
 
-    torch.manual_seed(0)
-    configured = MixedConfig().build(mixed_x, theta)
-    torch.manual_seed(0)
-    from_factory = likelihood_nn("mnle")(theta, mixed_x)
-
-    assert configured.state_dict().keys() == from_factory.state_dict().keys()
-    for name, value in configured.state_dict().items():
-        assert torch.equal(value, from_factory.state_dict()[name]), name
+    factory_defaults = _params(likelihood_nn)
+    expected = {
+        "z_score_theta": config.z_score_condition,
+        "z_score_x": continuous.z_score_input,
+        "hidden_features": continuous.hidden_features,
+        "num_transforms": continuous.num_transforms,
+        "num_bins": continuous.num_bins,
+        "embedding_net": config.embedding_net,
+        "num_components": MDNConfig().num_components,
+    }
+    for name, value in expected.items():
+        assert _defaults_agree(value, factory_defaults[name].default), name
 
 
 def test_legacy_public_builder_registry_remains_complete():

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -255,6 +255,39 @@ def _assert_same_net(expected, actual):
         assert torch.equal(value, actual.state_dict()[key]), key
 
 
+@pytest.mark.parametrize(
+    "flow_model,name",
+    [
+        ("mdn", "num_blocks"),
+        ("mdn", "tail_bound"),
+        ("zuko_maf", "num_blocks"),
+        ("nsf", "num_components"),
+    ],
+)
+def test_mixed_treats_another_models_field_set_to_none_as_unset(flow_model, name):
+    """The flat path dropped a None for any name the family knows."""
+    mixed, theta = _mixed_batches()
+
+    torch.manual_seed(0)
+    omitted = build_mnle(mixed, theta, flow_model=flow_model)
+    torch.manual_seed(0)
+    explicit_none = build_mnle(mixed, theta, flow_model=flow_model, **{name: None})
+
+    _assert_same_net(omitted, explicit_none)
+
+
+@pytest.mark.parametrize(
+    "flow_model,kwarg",
+    [("mdn", {"num_blocks": 3}), ("zuko_maf", {"num_blocks": 3})],
+)
+def test_mixed_still_rejects_another_models_field_with_a_value(flow_model, kwarg):
+    """Only a None is unset. A real value the model cannot read still raises."""
+    mixed, theta = _mixed_batches()
+
+    with pytest.raises(ValueError, match="would be silently ignored"):
+        build_mnle(mixed, theta, flow_model=flow_model, **kwarg)
+
+
 @pytest.mark.parametrize("value", [64, None], ids=["value", "none"])
 def test_mixed_still_warns_on_an_unknown_name(value):
     """Dropping a recognised None must not swallow a typo that carries one."""

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -229,10 +229,16 @@ def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
         assert torch.equal(value, actual.state_dict()[name]), name
 
 
-_UNSET_IF_NONE = [
+_NONE_IS_UNSET = [
+    "flow_model",
+    "hidden_features",
+    "num_transforms",
+    "num_bins",
     "continuous_hidden_features",
     "discrete_hidden_features",
     "combined_embedding_features",
+    "num_categories_per_variable",
+    "combined_embedding_net",
 ]
 
 
@@ -243,9 +249,34 @@ def _mixed_batches():
     return mixed, THETA
 
 
-@pytest.mark.parametrize("name", _UNSET_IF_NONE)
-def test_mixed_treats_an_explicit_none_width_as_unset(name):
-    """The flat API typed these as `Optional[int] = None`, so None means unset."""
+def _assert_same_net(expected, actual):
+    assert expected.state_dict().keys() == actual.state_dict().keys()
+    for key, value in expected.state_dict().items():
+        assert torch.equal(value, actual.state_dict()[key]), key
+
+
+@pytest.mark.parametrize("name", _NONE_IS_UNSET)
+@pytest.mark.parametrize(
+    "factory_fn,model",
+    [(posterior_nn, "mnpe"), (likelihood_nn, "mnle")],
+    ids=["posterior", "likelihood"],
+)
+def test_mixed_factory_treats_none_as_unset(factory_fn, model, name):
+    """The flat path dropped every None, so None must still mean omitted."""
+    mixed, theta = _mixed_batches()
+    args = (mixed, X) if factory_fn is posterior_nn else (theta, mixed)
+
+    torch.manual_seed(0)
+    omitted = factory_fn(model)(*args)
+    torch.manual_seed(0)
+    explicit_none = factory_fn(model, **{name: None})(*args)
+
+    _assert_same_net(omitted, explicit_none)
+
+
+@pytest.mark.parametrize("name", _NONE_IS_UNSET)
+def test_mixed_builder_treats_none_as_unset(name):
+    """`build_mnle` reads the same flat arguments as the factories."""
     mixed, theta = _mixed_batches()
 
     torch.manual_seed(0)
@@ -253,9 +284,7 @@ def test_mixed_treats_an_explicit_none_width_as_unset(name):
     torch.manual_seed(0)
     explicit_none = build_mnle(mixed, theta, **{name: None})
 
-    assert omitted.state_dict().keys() == explicit_none.state_dict().keys()
-    for key, value in omitted.state_dict().items():
-        assert torch.equal(value, explicit_none.state_dict()[key]), key
+    _assert_same_net(omitted, explicit_none)
 
 
 def test_mixed_none_width_does_not_change_the_other_width():
@@ -273,9 +302,7 @@ def test_mixed_none_width_does_not_change_the_other_width():
         mixed, theta, continuous_hidden_features=16, discrete_hidden_features=None
     )
 
-    assert omitted.state_dict().keys() == explicit_none.state_dict().keys()
-    for key, value in omitted.state_dict().items():
-        assert torch.equal(value, explicit_none.state_dict()[key]), key
+    _assert_same_net(omitted, explicit_none)
 
 
 _TAIL_BOUND_MODELS = sorted(

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -279,7 +279,11 @@ def test_mixed_treats_another_models_field_set_to_none_as_unset(flow_model, name
 
 @pytest.mark.parametrize(
     "flow_model,kwarg",
-    [("mdn", {"num_blocks": 3}), ("zuko_maf", {"num_blocks": 3})],
+    [
+        ("mdn", {"num_blocks": 3}),
+        ("zuko_maf", {"num_blocks": 3}),
+        ("nsf", {"num_components": 5}),
+    ],
 )
 def test_mixed_still_rejects_another_models_field_with_a_value(flow_model, kwarg):
     """Only a None is unset. A real value the model cannot read still raises."""

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -232,12 +232,8 @@ def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
 _NONE_IS_UNSET = [
     "flow_model",
     "hidden_features",
-    "num_transforms",
-    "num_bins",
     "continuous_hidden_features",
     "discrete_hidden_features",
-    "combined_embedding_features",
-    "num_categories_per_variable",
     "combined_embedding_net",
 ]
 

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -250,6 +250,7 @@ def _mixed_batches():
 
 
 def _assert_same_net(expected, actual):
+    """Whether two built estimators carry the same parameters, name by name."""
     assert expected.state_dict().keys() == actual.state_dict().keys()
     for key, value in expected.state_dict().items():
         assert torch.equal(value, actual.state_dict()[key]), key

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -35,6 +35,7 @@ from sbi.neural_nets.net_builders.estimator_configs import (
     _DENSITY_CONFIGS,
     MixedConfig,
     NSFConfig,
+    _mixed_config_from_factory_kwargs,
 )
 from sbi.neural_nets.net_builders.mixed_nets import build_mnle
 
@@ -186,6 +187,20 @@ def test_unknown_model_raises():
         build_fn(THETA, X)
 
 
+def _mixed_batches():
+    mixed = torch.cat(
+        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
+    )
+    return mixed, THETA
+
+
+def _assert_same_net(expected, actual):
+    """Whether two built estimators carry the same parameters, name by name."""
+    assert expected.state_dict().keys() == actual.state_dict().keys()
+    for key, value in expected.state_dict().items():
+        assert torch.equal(value, actual.state_dict()[key]), key
+
+
 @pytest.mark.parametrize(
     "factory_fn,model",
     [(posterior_nn, "mnpe"), (likelihood_nn, "mnle")],
@@ -193,9 +208,7 @@ def test_unknown_model_raises():
 )
 def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
     """Deprecated mixed strings must route their settings through MixedConfig."""
-    mixed = torch.cat(
-        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
-    )
+    mixed, theta = _mixed_batches()
     config = MixedConfig(
         continuous=NSFConfig(
             z_score_input="none",
@@ -207,8 +220,8 @@ def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
         z_score_condition="none",
         log_transform_x=True,
     )
-    factory_args = (mixed, X) if factory_fn is posterior_nn else (THETA, mixed)
-    config_args = (mixed, X) if factory_fn is posterior_nn else (mixed, THETA)
+    factory_args = (mixed, X) if factory_fn is posterior_nn else (theta, mixed)
+    config_args = (mixed, X) if factory_fn is posterior_nn else (mixed, theta)
 
     torch.manual_seed(0)
     expected = config.build(*config_args)
@@ -224,9 +237,7 @@ def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
     )(*factory_args)
 
     assert isinstance(actual, MixedDensityEstimator)
-    assert expected.state_dict().keys() == actual.state_dict().keys()
-    for name, value in expected.state_dict().items():
-        assert torch.equal(value, actual.state_dict()[name]), name
+    _assert_same_net(expected, actual)
 
 
 _NONE_IS_UNSET = [
@@ -236,20 +247,6 @@ _NONE_IS_UNSET = [
     "discrete_hidden_features",
     "combined_embedding_net",
 ]
-
-
-def _mixed_batches():
-    mixed = torch.cat(
-        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
-    )
-    return mixed, THETA
-
-
-def _assert_same_net(expected, actual):
-    """Whether two built estimators carry the same parameters, name by name."""
-    assert expected.state_dict().keys() == actual.state_dict().keys()
-    for key, value in expected.state_dict().items():
-        assert torch.equal(value, actual.state_dict()[key]), key
 
 
 @pytest.mark.parametrize(
@@ -287,6 +284,39 @@ def test_mixed_still_rejects_another_models_field_with_a_value(flow_model, kwarg
 
     with pytest.raises(ValueError, match="would be silently ignored"):
         build_mnle(mixed, theta, flow_model=flow_model, **kwarg)
+
+
+def test_mixed_factory_error_names_the_outer_model_and_config():
+    with pytest.raises(ValueError) as exc_info:
+        likelihood_nn("mnle", num_components=5)
+
+    message = str(exc_info.value)
+    assert "model='mnle'" in message
+    assert "MixedConfig(continuous=NSFConfig(...))" in message
+    assert "model='nsf'" not in message
+
+
+def test_mixed_factory_defaults_do_not_override_mixed_config_defaults():
+    embedding_net = torch.nn.Linear(3, 3)
+    family_args = {
+        "z_score_input": "independent",
+        "z_score_condition": "structured",
+        "hidden_features": 50,
+        "num_transforms": 5,
+        "num_bins": 10,
+        "embedding_net": embedding_net,
+        "num_components": 10,
+    }
+
+    config = _mixed_config_from_factory_kwargs(
+        model="mnle",
+        family_args=family_args,
+        factory_defaults=family_args,
+        extra={},
+    )
+
+    assert config.z_score_condition == MixedConfig().z_score_condition
+    assert type(config.embedding_net) is type(MixedConfig().embedding_net)
 
 
 @pytest.mark.parametrize("value", [64, None], ids=["value", "none"])
@@ -361,10 +391,8 @@ def test_mixed_keeps_the_flat_tail_bound_for_every_model(flow_model):
     not change the parameter count, so only reading it off the built net keeps
     the deprecated path honest.
     """
-    mixed = torch.cat(
-        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
-    )
-    estimator = build_mnle(mixed, THETA, flow_model=flow_model)
+    mixed, theta = _mixed_batches()
+    estimator = build_mnle(mixed, theta, flow_model=flow_model)
 
     bounds = {
         float(m.tail_bound)

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -255,6 +255,13 @@ def _assert_same_net(expected, actual):
         assert torch.equal(value, actual.state_dict()[key]), key
 
 
+@pytest.mark.parametrize("value", [64, None], ids=["value", "none"])
+def test_mixed_still_warns_on_an_unknown_name(value):
+    """Dropping a recognised None must not swallow a typo that carries one."""
+    with pytest.warns(UserWarning, match="Unknown kwargs"):
+        likelihood_nn("mnle", hiden_features=value)
+
+
 @pytest.mark.parametrize("name", _NONE_IS_UNSET)
 @pytest.mark.parametrize(
     "factory_fn,model",

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -229,6 +229,55 @@ def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
         assert torch.equal(value, actual.state_dict()[name]), name
 
 
+_UNSET_IF_NONE = [
+    "continuous_hidden_features",
+    "discrete_hidden_features",
+    "combined_embedding_features",
+]
+
+
+def _mixed_batches():
+    mixed = torch.cat(
+        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
+    )
+    return mixed, THETA
+
+
+@pytest.mark.parametrize("name", _UNSET_IF_NONE)
+def test_mixed_treats_an_explicit_none_width_as_unset(name):
+    """The flat API typed these as `Optional[int] = None`, so None means unset."""
+    mixed, theta = _mixed_batches()
+
+    torch.manual_seed(0)
+    omitted = build_mnle(mixed, theta)
+    torch.manual_seed(0)
+    explicit_none = build_mnle(mixed, theta, **{name: None})
+
+    assert omitted.state_dict().keys() == explicit_none.state_dict().keys()
+    for key, value in omitted.state_dict().items():
+        assert torch.equal(value, explicit_none.state_dict()[key]), key
+
+
+def test_mixed_none_width_does_not_change_the_other_width():
+    """A None width must not make a sibling width fall back to a new source.
+
+    With `continuous_hidden_features` set, the categorical net keeps falling
+    back to `hidden_features`, whether the discrete width is omitted or None.
+    """
+    mixed, theta = _mixed_batches()
+
+    torch.manual_seed(0)
+    omitted = build_mnle(mixed, theta, continuous_hidden_features=16)
+    torch.manual_seed(0)
+    explicit_none = build_mnle(
+        mixed, theta, continuous_hidden_features=16, discrete_hidden_features=None
+    )
+
+    assert omitted.state_dict().keys() == explicit_none.state_dict().keys()
+    for key, value in omitted.state_dict().items():
+        assert torch.equal(value, explicit_none.state_dict()[key]), key
+
+
 _TAIL_BOUND_MODELS = sorted(
     name
     for name, cls in _DENSITY_CONFIGS.items()

--- a/tests/factory_config_test.py
+++ b/tests/factory_config_test.py
@@ -12,6 +12,7 @@ library-specific parameters (e.g. Zuko flow kwargs) pass through.
 
 import inspect
 import warnings
+from dataclasses import fields as dc_fields
 
 import pytest
 import torch
@@ -32,8 +33,10 @@ from sbi.neural_nets.factory import (
 from sbi.neural_nets.net_builders.estimator_configs import (
     _CLASSIFIER_CONFIGS,
     _DENSITY_CONFIGS,
-    ConditionalFlowConfig,
+    MixedConfig,
+    NSFConfig,
 )
+from sbi.neural_nets.net_builders.mixed_nets import build_mnle
 
 THETA, X = torch.randn(100, 3), torch.randn(100, 5)
 
@@ -183,17 +186,75 @@ def test_unknown_model_raises():
         build_fn(THETA, X)
 
 
-def test_legacy_config_still_validates_the_mixed_string_path():
-    """MNLE and MNPE still reach `build_mnle` / `build_mnpe` with flat kwargs."""
-    cfg = ConditionalFlowConfig(hidden_features=64)
-    assert cfg.to_dict() == {"hidden_features": 64}
-
-    # The modeled variable carries the discrete column: theta for MNPE, x for MNLE.
+@pytest.mark.parametrize(
+    "factory_fn,model",
+    [(posterior_nn, "mnpe"), (likelihood_nn, "mnle")],
+    ids=["posterior", "likelihood"],
+)
+def test_mixed_string_path_builds_the_typed_config(factory_fn, model):
+    """Deprecated mixed strings must route their settings through MixedConfig."""
     mixed = torch.cat(
-        [torch.randn(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
+        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
     )
-    assert isinstance(posterior_nn("mnpe")(mixed, X), MixedDensityEstimator)
-    assert isinstance(likelihood_nn("mnle")(THETA, mixed), MixedDensityEstimator)
+    config = MixedConfig(
+        continuous=NSFConfig(
+            z_score_input="none",
+            hidden_features=16,
+            num_transforms=2,
+            num_bins=4,
+            tail_bound=10.0,
+        ),
+        z_score_condition="none",
+        log_transform_x=True,
+    )
+    factory_args = (mixed, X) if factory_fn is posterior_nn else (THETA, mixed)
+    config_args = (mixed, X) if factory_fn is posterior_nn else (mixed, THETA)
+
+    torch.manual_seed(0)
+    expected = config.build(*config_args)
+    torch.manual_seed(0)
+    actual = factory_fn(
+        model,
+        z_score_theta="none",
+        z_score_x="none",
+        hidden_features=16,
+        num_transforms=2,
+        num_bins=4,
+        log_transform_x=True,
+    )(*factory_args)
+
+    assert isinstance(actual, MixedDensityEstimator)
+    assert expected.state_dict().keys() == actual.state_dict().keys()
+    for name, value in expected.state_dict().items():
+        assert torch.equal(value, actual.state_dict()[name]), name
+
+
+_TAIL_BOUND_MODELS = sorted(
+    name
+    for name, cls in _DENSITY_CONFIGS.items()
+    if "tail_bound" in {f.name for f in dc_fields(cls)}
+)
+
+
+@pytest.mark.parametrize("flow_model", _TAIL_BOUND_MODELS)
+def test_mixed_keeps_the_flat_tail_bound_for_every_model(flow_model):
+    """The flat mixed API passed `tail_bound` to whichever model reads it.
+
+    Those models default to a narrower bound on their own, and the value does
+    not change the parameter count, so only reading it off the built net keeps
+    the deprecated path honest.
+    """
+    mixed = torch.cat(
+        [torch.rand(100, 2), torch.randint(0, 3, (100, 1)).float()], dim=-1
+    )
+    estimator = build_mnle(mixed, THETA, flow_model=flow_model)
+
+    bounds = {
+        float(m.tail_bound)
+        for m in estimator.continuous_net.modules()
+        if hasattr(m, "tail_bound")
+    }
+    assert bounds == {10.0}
 
 
 @pytest.mark.parametrize(

--- a/tests/npe_nle_builder_integration_test.py
+++ b/tests/npe_nle_builder_integration_test.py
@@ -13,7 +13,6 @@ from sbi.neural_nets import likelihood_nn, posterior_nn
 from sbi.neural_nets.estimators import MixedDensityEstimator
 from sbi.neural_nets.estimators.base import ConditionalDensityEstimator
 from sbi.neural_nets.net_builders.estimator_configs import (
-    _MIXED_CONTINUOUS_CONFIGS,
     MAFConfig,
     MDNConfig,
     MixedConfig,
@@ -155,17 +154,6 @@ def test_mixed_rejects_a_continuous_model_it_cannot_build(continuous):
         MixedConfig(continuous=continuous)
 
 
-def test_mixed_continuous_configs_match_the_build_functions():
-    """Guard against drift between the allowed set and `mixed_nets`."""
-    from sbi.neural_nets.net_builders.estimator_configs import _DENSITY_CONFIGS
-    from sbi.neural_nets.net_builders.mixed_nets import model_builders
-
-    assert (
-        frozenset(_DENSITY_CONFIGS[name] for name in model_builders)
-        == _MIXED_CONTINUOUS_CONFIGS
-    )
-
-
 def test_mixed_requires_explicit_auxiliary_widths_for_per_transform_widths():
     """Fallback widths require the continuous config to hold one integer."""
     with pytest.raises(ValueError, match="hidden_features"):
@@ -231,22 +219,15 @@ def test_mixed_default_keeps_the_previous_continuous_net():
     The mixed build function overrode the spline tail bound with its own value,
     so the default continuous config has to carry that rather than `NSFConfig`'s.
     """
-    import inspect
-
-    from sbi.neural_nets.net_builders.mixed_nets import (
-        _build_mixed_density_estimator,
-    )
-
-    params = inspect.signature(_build_mixed_density_estimator).parameters
     continuous = MixedConfig().continuous
 
     assert isinstance(continuous, NSFConfig)
-    assert continuous.z_score_input == params["z_score_x"].default
-    assert continuous.tail_bound == params["tail_bound"].default
-    assert continuous.hidden_features == params["hidden_features"].default
-    assert continuous.num_transforms == params["num_transforms"].default
-    assert continuous.num_bins == params["num_bins"].default
-    assert MixedConfig().dropout_probability == params["dropout_probability"].default
+    assert continuous.z_score_input == "independent"
+    assert continuous.tail_bound == 10.0
+    assert continuous.hidden_features == 50
+    assert continuous.num_transforms == 5
+    assert continuous.num_bins == 10
+    assert MixedConfig().dropout_probability == 0.0
 
 
 @pytest.mark.parametrize(

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -483,9 +483,6 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
             model_x = x
 
         implements_transform = model.startswith("zuko") or model == "mdn"
-        # `mnle` has no config yet, so it keeps the lenient factory path where
-        # an unusable setting is forwarded and ignored downstream.
-        legacy = model == "mnle"
 
         # The factories reject a setting the chosen model does not use, so only
         # the ones this model has are passed.
@@ -500,14 +497,12 @@ def test_z_scoring_structured(z_x, z_theta, build_fn):
             if model not in ("mdn", "made"):
                 kwargs["num_transforms"] = 1
             # `x_dist` is read only by the unconstrained transform.
-            if modeled_z == "transform_to_unconstrained" and (
-                implements_transform or legacy
-            ):
+            if modeled_z == "transform_to_unconstrained" and implements_transform:
                 kwargs["x_dist"] = dist
 
         unsupported = (
             modeled_z == "transform_to_unconstrained" and not implements_transform
-        ) or (condition_z == "transform_to_unconstrained" and not legacy)
+        ) or condition_z == "transform_to_unconstrained"
         if unsupported:
             with pytest.raises(ValueError, match="transform_to_unconstrained"):
                 build_fun = build_fn(**kwargs)


### PR DESCRIPTION
## What does this PR do?

This follows up on [a review comment from #1986](https://github.com/sbi-dev/sbi/pull/1986#discussion_r3810593705)

`_build_mixed_density_estimator` now accepts only `(batch_x, batch_y, config)` also deprecated `"mnle"` and `"mnpe"` factory paths translate their flat arguments into `MixedConfig`, removing the second construction path, flat internal parameters, duplicated `mixed_nets.model_builders` registry, and `TYPE_CHECKING` import

Not supported continuous model setting now raise instead of being silently ignored. Explicit `None` values retain the legacy unset behavior including `flow_model=None` selecting the default NSF

## Does this close any issues?

No but this is a follow-up to #1986

## Anything else we should know?

### AI Usage

I used Sol 5.6 via Codex to help audit compatibility cases and test coverage then I reviewed the resulting changes and verification results

## Checklist

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [x] New tests run within the existing fast test suites and do not require a slow marker.

<!-- I used an AI assistant to help audit compatibility cases and test coverage; I reviewed the resulting changes and verification results. -->