### PR TITLE
Fix L1 distance to use Manhattan sum

### DIFF
--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -524,8 +524,7 @@ def l2(x: Tensor, y: Tensor, axis: int = -1) -> Tensor:
 
 def l1(x: Tensor, y: Tensor, axis: int = -1) -> Tensor:
     """
-    Calculates the L1 (Manhattan) distance between two tensors, averaged over
-    the specified axis.
+    Calculates the L1 (Manhattan) distance between two tensors.
 
     Args:
         x (Tensor): The first tensor.
@@ -537,7 +536,7 @@ def l1(x: Tensor, y: Tensor, axis: int = -1) -> Tensor:
         Tensor: A tensor containing the L1 distance between x and y along the
             specified axis.
     """
-    return torch.mean(torch.abs(x - y), dim=axis)
+    return torch.sum(torch.abs(x - y), dim=axis)
 
 
 class Distance:

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -240,6 +240,29 @@ def test_distance_basic_functionality():
     assert wasserstein_distance(xo_stat, x_stat).min() >= 0
 
 
+def test_l1_matches_manhattan_distance_definition():
+    """l1 should sum absolute differences, matching l2's sum-based convention.
+
+    l1 and l2 are documented and used interchangeably as swappable pairwise
+    distance choices (see sbi.diagnostics.tarp and sbi.inference.abc.abc_base),
+    so they must scale consistently with dimensionality. l1 previously averaged
+    instead of summing, silently shrinking relative to l2 as dimensionality grew.
+    """
+    x = torch.zeros(10)
+    y = torch.zeros(10)
+    y[0] = 1.0
+
+    assert torch.allclose(l1(x, y), torch.tensor(1.0))
+    assert torch.allclose(l2(x, y), torch.tensor(1.0))
+
+    # Manhattan distance sums every dimension's contribution, so it should scale
+    # linearly with the number of differing dimensions, not shrink with more
+    # (identical) dimensions added.
+    y_wide = torch.zeros(20)
+    y_wide[0] = 1.0
+    assert torch.allclose(l1(torch.zeros(20), y_wide), torch.tensor(1.0))
+
+
 def test_distance_output_shapes():
     """Test that distance functions return correct output shapes."""
     # Test pairwise distances


### PR DESCRIPTION
## What does this PR do?

Changes `l1()` from the mean of absolute differences to their sum, implementing the standard Manhattan distance.

Updates the docstring and adds a regression test showing that a single differing coordinate contributes a distance of 1, including when additional identical coordinates are present.

## Does this close any issues?

Related discussion: #2008

## Anything else we should know?

The existing docstring explicitly describes averaging. This change therefore alters existing behavior: for an axis of length n, the new distance is n times the previous distance. The intended convention and compatibility approach need discussion before merging.

Previously reported validation:

* `ruff check sbi/utils/metrics.py tests/metrics_test.py`
* `ruff format --check sbi/utils/metrics.py tests/metrics_test.py`
* A direct L1/L2 regression check passed.
* The full metrics test module could not be collected in the reported environment because `pytest_harvest` and `nflows` were unavailable.

No tests were rerun for this description update. The broader checks below remain unverified.

## Checklist

* [ ] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
* [ ] `uv run pytest -n auto -m "not slow and not gpu"` passes.
* [ ] `uv run pre-commit run --all-files` passes (ruff and formatting).
* [ ] `uv run pyright sbi` passes.
* [x] I added or updated tests for the changed behavior.
* [ ] I used Google-style docstrings for new or changed public functions.
* [ ] (If applicable) I reported how long new tests run and marked slow ones with `pytest.mark.slow`.

