### PR TITLE
Preserve posterior default observation during rebuild

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -64,6 +64,7 @@ class NeuralPosterior:
                 potential_fn, prior=None, x_o=None, device=potential_device
             )
 
+        previous_x = getattr(self, "_x", None)
         self._device = process_device(potential_fn.device if device is None else device)
         self._check_finite_x = check_finite_x
 
@@ -82,7 +83,11 @@ class NeuralPosterior:
         # If the sampler interface (#573) is used, the user might have passed `x_o`
         # already to the potential function builder. If so, this `x_o` will be used
         # as default x.
-        x_o = self.potential_fn.return_x_o()
+        x_o = (
+            previous_x.to(self._device)
+            if previous_x is not None
+            else self.potential_fn.return_x_o()
+        )
         if x_o is not None and self._check_finite_x:
             assert_all_finite(x_o, "Observed data x_o")
         self._x = x_o

--- a/tests/posterior_state_test.py
+++ b/tests/posterior_state_test.py
@@ -1,0 +1,32 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Apache License, Version 2.0, see <https://www.apache.org/licenses/licenses/>
+
+import torch
+
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.potentials.base_potential import BasePotential
+
+
+class DummyPotential(BasePotential):
+    def __call__(
+        self, theta: torch.Tensor, track_gradients: bool = True
+    ) -> torch.Tensor:
+        return -theta.square().sum(dim=-1)
+
+
+class DummyPosterior(NeuralPosterior):
+    def sample(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def sample_batched(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_reinitializing_posterior_preserves_default_x():
+    """A posterior rebuild must preserve its default observation."""
+    posterior = DummyPosterior(DummyPotential(prior=None))
+    posterior.set_default_x(torch.tensor([1.0, 2.0]))
+
+    NeuralPosterior.__init__(posterior, DummyPotential(prior=None), device="cpu")
+
+    assert torch.equal(posterior.default_x, torch.tensor([[1.0, 2.0]]))

--- a/tests/posterior_state_test.py
+++ b/tests/posterior_state_test.py
@@ -8,17 +8,24 @@ from sbi.inference.potentials.base_potential import BasePotential
 
 
 class DummyPotential(BasePotential):
+    """Minimal potential used to exercise posterior state rebuilding."""
+
     def __call__(
         self, theta: torch.Tensor, track_gradients: bool = True
     ) -> torch.Tensor:
+        """Return a simple negative squared norm for each parameter value."""
         return -theta.square().sum(dim=-1)
 
 
 class DummyPosterior(NeuralPosterior):
+    """Minimal posterior exposing the base class initialization behavior."""
+
     def sample(self, *args, **kwargs):
+        """Keep sampling outside the scope of this state regression test."""
         raise NotImplementedError
 
     def sample_batched(self, *args, **kwargs):
+        """Keep batched sampling outside the scope of this state regression test."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
## What does this PR do?

The base posterior initializer now preserves an existing default observation when a posterior is rebuilt during device changes. The observation is moved to the requested device. This prevents posterior rebuilds from silently clearing the default observation and adds a focused regression test.

## Does this close any issues?

Fixes #1995

## Anything else we should know?

The test covers a posterior rebuild with an existing default observation. The targeted test passes. Ruff check passes. Ruff format check passes.

## Checklist

* [x] I have read the contributing guide.
* [x] Targeted tests pass.
* [x] Ruff check and formatting pass.
* [x] I added a regression test for the changed behavior.
* [x] I used Google style docstrings for the new test.
