### PR TITLE
Fix NumPy array handling for plot limits

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -59,7 +59,7 @@ def marginal_plot(
     points: Optional[
         Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor]
     ] = None,
-    limits: Optional[Union[List, torch.Tensor]] = None,
+    limits: Optional[Union[List, torch.Tensor, np.ndarray]] = None,
     subset: Optional[List[int]] = None,
     diag: Optional[Union[List[Optional[str]], str]] = "hist",
     figsize: Optional[Tuple] = (10, 2),
@@ -158,7 +158,7 @@ def pairplot(
     points: Optional[
         Union[List[np.ndarray], List[torch.Tensor], np.ndarray, torch.Tensor]
     ] = None,
-    limits: Optional[Union[List, torch.Tensor]] = None,
+    limits: Optional[Union[List, torch.Tensor, np.ndarray]] = None,
     subset: Optional[List[int]] = None,
     upper: Optional[Union[List[Optional[UpperLiteral]], UpperLiteral]] = "hist",
     lower: Optional[Union[List[Optional[LowerLiteral]], LowerLiteral]] = None,
@@ -841,7 +841,7 @@ def prepare_for_plot(
 
     dim = samples[0].shape[1]
 
-    if limits is None or limits == []:
+    if limits is None or len(limits) == 0:
         limits = infer_limits(samples, dim, points)
     else:
         limits = [limits[0] for _ in range(dim)] if len(limits) == 1 else limits

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -32,6 +32,21 @@ def test_pairplot1D(samples, limits):
     close()
 
 
+def test_pairplot_accepts_numpy_limits():
+    limits = np.array([[-1.0, 1.0], [-2.0, 2.0]])
+
+    fig, axes = pairplot(
+        samples=torch.randn(100, 2),
+        limits=limits,
+        fig_kwargs=FigOptions(x_lim_add_eps=0.0),
+    )
+
+    assert axes[0, 0].get_xlim() == pytest.approx((-1.0, 1.0))
+    assert axes[0, 1].get_xlim() == pytest.approx((-2.0, 2.0))
+    assert axes[0, 1].get_ylim() == pytest.approx((-1.0, 1.0))
+    close(fig)
+
+
 @pytest.mark.parametrize("samples", (torch.randn(100, 2),))
 @pytest.mark.parametrize("limits", ([(-1, 1)], None))
 def test_nan_inf(samples, limits):


### PR DESCRIPTION
## What does this PR do?

`prepare_for_plot()` currently checks for empty limits using `limits == []`.
For NumPy arrays, this performs an element-wise comparison and can raise a
broadcasting error.

This PR replaces that comparison with a length check, updates the `pairplot()`
and `marginal_plot()` type hints to include NumPy arrays, and adds a regression
test verifying that NumPy limits are applied to the correct plot axes.

## Does this close any issues?

Addresses the NumPy limits item in #1978.

## Anything else we should know?

Validation performed:

- `uv run pytest tests/plot_test.py`: 496 passed, 9 xfailed.
- Ruff check and formatting checks passed for the changed files.
- `uv run pyright sbi`: 0 errors.
- Pre-commit hooks passed for the changed files.
- The non-slow, non-GPU suite completed with 6601 passed, 38 skipped, 120
  xfailed, and three environment-related PyTensor failures. Those three tests
  passed when rerun using PyTensor's Python fallback instead of the incompatible
  local MinGW compiler.
  
AI assistance was used for implementation and test preparation, I reviewed and
validated the final change.

## Checklist

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [ ] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [ ] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [ ] I used Google-style docstrings for new or changed public functions.
- [ ] (If applicable) I reported how long new tests run and marked slow ones
      with `pytest.mark.slow`.