### PR TITLE
fix: validate plot kwargs and fix docstring refs (#1978)

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -968,7 +968,14 @@ def _prepare_kwargs(
         zip(plot_list, plot_kwargs_list, strict=False)
     ):
         plot_kwarg_filled_i = get_default_kwargs(plot_i, i)
-        # update the defaults dictionary with user provided values
+        if plot_kwargs_i is not None and plot_kwarg_filled_i:
+            unknown_keys = set(plot_kwargs_i.keys()) - set(plot_kwarg_filled_i.keys())
+            if unknown_keys:
+                raise ValueError(
+                    "Unknown keys in plot kwargs: "
+                    f"{sorted(unknown_keys)}. "
+                    f"Valid keys are: {sorted(plot_kwarg_filled_i.keys())}."
+                )
         plot_kwarg_filled_i = update(plot_kwarg_filled_i, plot_kwargs_i)
         plot_kwargs_filled.append(plot_kwarg_filled_i)
 
@@ -1317,11 +1324,11 @@ def _arrange_grid(
         lower_funcs: List of plotting function that will be executed for the
             lower-diagonal elements of the plot. None if we are in a 1D setting.
         diag_kwargs: Additional arguments to adjust the diagonal plot,
-            see the source code in `_get_default_diag_kwarg()`
+            see the source code in `get_default_diag_kwargs`
         upper_kwargs: Additional arguments to adjust the upper diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `get_default_offdiag_kwargs`
         lower_kwargs: Additional arguments to adjust the lower diagonal plot,
-            see the source code in `_get_default_offdiag_kwarg()`
+            see the source code in `get_default_offdiag_kwargs`
         samples: List of samples given to the plotting functions
         points: List of additional points to scatter.
         limits: Limits for each dimension / axis.
@@ -1333,7 +1340,7 @@ def _arrange_grid(
         fig: matplotlib figure to plot on.
         axes: matplotlib axes corresponding to fig.
         fig_kwargs: Additional arguments to adjust the overall figure,
-            see the source code in `_get_default_fig_kwargs()`
+            see the source code in `FigOptions`
         discrete_indices: Optional list of dimension indices treated as discrete.
             When provided, diagonal plots for these dimensions use bar charts,
             and off-diagonal plots involving these dimensions fall back to
@@ -2992,8 +2999,9 @@ def _arrange_plots(
 
 def _get_default_opts():
     warn(
-        "_get_default_opts will be deprecated, use _get_default_fig_kwargs,"
-        "get_default_diag_kwargs, get_default_offdiag_kwargs instead",
+        "_get_default_opts will be deprecated, use FigOptions through the "
+        "fig_kwargs argument, and get_default_diag_kwargs, "
+        "get_default_offdiag_kwargs instead",
         PendingDeprecationWarning,
         stacklevel=2,
     )

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -544,3 +544,35 @@ def test_pairplot_discrete_edge_cases(samples_fn, pairplot_kwargs):
     fig, _ = pairplot(samples_fn(), **pairplot_kwargs)
     assert isinstance(fig, Figure)
     close()
+
+
+@pytest.mark.parametrize(
+    "kwarg,plot_type",
+    (
+        ("diag_kwargs", "hist"),
+        ("upper_kwargs", "hist"),
+        ("lower_kwargs", "hist"),
+    ),
+)
+def test_pairplot_raises_on_unknown_kwarg_keys(kwarg, plot_type):
+    """A typo in diag/upper/lower kwargs must raise, not be silently ignored."""
+    posterior_samples = torch.randn(100, 3)
+
+    plot_arg = (
+        "diag"
+        if kwarg == "diag_kwargs"
+        else ("upper" if kwarg == "upper_kwargs" else "lower")
+    )
+    with pytest.raises(ValueError, match="Unknown keys in plot kwargs"):
+        _ = pairplot(
+            samples=posterior_samples, **{plot_arg: plot_type, kwarg: {"typo_kwarg": 1}}
+        )
+
+    close()
+
+
+def test_get_default_opts_deprecation_points_to_real_functions():
+    """The `_get_default_opts` deprecation message must not reference the
+    non-existent `_get_default_fig_kwargs`."""
+    with pytest.warns(PendingDeprecationWarning, match="FigOptions"):
+        _ = plt._get_default_opts()

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -574,5 +574,7 @@ def test_pairplot_raises_on_unknown_kwarg_keys(kwarg, plot_type):
 def test_get_default_opts_deprecation_points_to_real_functions():
     """The `_get_default_opts` deprecation message must not reference the
     non-existent `_get_default_fig_kwargs`."""
-    with pytest.warns(PendingDeprecationWarning, match="FigOptions"):
-        _ = plt._get_default_opts()
+    with pytest.warns(PendingDeprecationWarning) as record:
+        plt._get_default_opts()
+    assert "_get_default_fig_kwargs" not in str(record[0].message)
+    assert "FigOptions" in str(record[0].message)


### PR DESCRIPTION
## changes


1. `diag_kwargs` / `upper_kwargs` / `lower_kwargs` now raise a `ValueError` on unknown keys instead of silently ignoring typos.
2. Fixed docstring and deprecation references from the non-existent `_get_default_fig_kwargs` to the real `FigOptions` / `get_default_*` functions.


## closes #1978 
Addresses items 2 and 3 of #1978
. Item 1 (NumPy array limits handling) was already fixed and merged in #2000.

## checks 

Validation performed:
- `uv run pytest tests/plot_test.py` (non-tensorboard) passes.
- `uv run ruff check` and `uv run ruff format --check` pass for the changed files.

## Checklist

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [x] (If applicable) I reported how long new tests run and marked slow ones
      with `pytest.mark.slow`.

