### PR TITLE
Add NeuralInference.save() and .load()

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -1,7 +1,12 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import importlib
+import os
+import pickle
+import tempfile
 from abc import abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from warnings import warn
 
@@ -10,13 +15,14 @@ import torch.distributions.transforms as torch_tf
 from torch import Tensor
 from torch.distributions import Distribution
 
+from sbi import __version__
 from sbi.inference.potentials.base_potential import (
     BasePotential,
     CustomPotential,
     CustomPotentialWrapper,
 )
 from sbi.sbi_types import Array, Shape, TorchTransform
-from sbi.utils.sbiutils import gradient_ascent
+from sbi.utils.sbiutils import CPU_Unpickler, gradient_ascent
 from sbi.utils.torchutils import (
     assert_all_finite,
     canonical_device,
@@ -339,6 +345,131 @@ class NeuralPosterior:
     def __str__(self):
         desc = f"Posterior p(θ|x) of type {self.__class__.__name__}. {self._purpose}"
         return desc
+
+    def save(self, filename: Union[str, Path]) -> None:
+        """Save the posterior to a file.
+
+        This saves the full state of the posterior including the trained network,
+        prior, and transforms. The saved file can be loaded with
+        ``NeuralPosterior.load()``.
+
+        Args:
+            filename: Path to the file where the posterior will be saved.
+
+        Example:
+            >>> posterior = inference.build_posterior()
+            >>> posterior.save("my_posterior.pkl")
+        """
+        filepath = Path(filename)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        state = {
+            "sbi_version": __version__,
+            "class_name": self.__class__.__name__,
+            "class_module": self.__class__.__module__,
+            "state": self.__getstate__(),
+        }
+        fd, temp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                pickle.dump(state, handle)
+            os.replace(temp_path, filepath)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    @classmethod
+    def load(cls, filename: Union[str, Path]) -> "NeuralPosterior":
+        """Load a saved posterior from a file.
+
+        This method loads a posterior that was previously saved with ``save()``.
+
+        Note:
+            The file is loaded with ``pickle``, which can execute arbitrary code.
+            Only load files from trusted sources.
+
+        Args:
+            filename: Path to the file to load.
+
+        Returns:
+            The loaded posterior object.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file was not created with ``save()``.
+
+        Example:
+            >>> posterior = NeuralPosterior.load("my_posterior.pkl")
+            >>> samples = posterior.sample((1000,), x=x_o)
+        """
+        filepath = Path(filename)
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {filepath}")
+
+        with open(filepath, "rb") as handle:
+            state = CPU_Unpickler(handle).load()  # noqa: S301
+
+        if not isinstance(state, dict) or not all(
+            key in state
+            for key in ("sbi_version", "class_module", "class_name", "state")
+        ):
+            raise ValueError(
+                f"The file {filepath} was not created with "
+                "`NeuralPosterior.save()`. Use `pickle.load()` directly instead."
+            )
+
+        class_module = state["class_module"]
+        class_name = state["class_name"]
+        restored_state = state["state"]
+        if (
+            not isinstance(class_module, str)
+            or not class_module
+            or not isinstance(class_name, str)
+            or not class_name
+        ):
+            raise ValueError(
+                f"The file {filepath} contains invalid class metadata in "
+                f"`class_module` (`{class_module!r}`) or `class_name` "
+                f"(`{class_name!r}`)."
+            )
+        if not isinstance(restored_state, dict):
+            raise ValueError(
+                f"The file {filepath} contains an invalid `state` of type "
+                f"`{type(restored_state).__name__}`; expected a `dict`."
+            )
+
+        sbi_version = state["sbi_version"]
+        if sbi_version != __version__:
+            warn(
+                f"The file was saved with sbi version {sbi_version} but the "
+                f"current version is {__version__}. This may cause compatibility "
+                "issues.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        try:
+            loaded_class = getattr(importlib.import_module(class_module), class_name)
+        except (ImportError, AttributeError, TypeError) as error:
+            raise ValueError(
+                f"The file {filepath} references `{class_name}` in `{class_module}` "
+                "which cannot be resolved."
+            ) from error
+        if not isinstance(loaded_class, type) or not issubclass(loaded_class, cls):
+            raise ValueError(
+                f"The file {filepath} was saved by a {class_name} in "
+                f"{class_module} but was loaded with {cls.__name__}."
+            )
+        loaded = loaded_class.__new__(loaded_class)
+        try:
+            loaded.__setstate__(restored_state)
+        except (AttributeError, TypeError, ValueError, KeyError, ImportError) as error:
+            raise ValueError(
+                f"The file {filepath} contains a `state` that cannot restore a "
+                f"{cls.__name__}: {error}"
+            ) from error
+
+        return loaded
 
     def __getstate__(self) -> Dict:
         """Returns the state of the object that is supposed to be pickled.

--- a/sbi/inference/trainers/base.py
+++ b/sbi/inference/trainers/base.py
@@ -1,7 +1,10 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import importlib
 import os
+import pickle
+import tempfile
 import time
 import warnings
 from abc import ABC, abstractmethod
@@ -36,6 +39,8 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard.writer import SummaryWriter
 from typing_extensions import Self
+
+from sbi import __version__
 
 if TYPE_CHECKING:
     from sbi.neural_nets.net_builders.estimator_configs import (
@@ -78,7 +83,11 @@ from sbi.utils import (
     validate_theta_and_x,
     warn_if_invalid_for_zscoring,
 )
-from sbi.utils.sbiutils import ImproperEmpirical, get_simulations_since_round
+from sbi.utils.sbiutils import (
+    CPU_Unpickler,
+    ImproperEmpirical,
+    get_simulations_since_round,
+)
 from sbi.utils.simulation_utils import simulate_for_sbi
 from sbi.utils.torchutils import (
     check_if_prior_on_device,
@@ -91,6 +100,7 @@ from sbi.utils.user_input_checks import (
     process_prior,
     process_simulator,
 )
+from sbi.utils.user_input_checks_utils import move_distribution_to_device
 
 _SBI_ROOT = str(Path(__file__).parents[2]) + os.sep
 
@@ -1407,6 +1417,143 @@ class NeuralInference(ABC, Generic[ConditionalEstimatorType]):
             # https://stackoverflow.com/questions/3419984/. `\r` in the beginning due
             # to #330.
             print("\r", f"Training neural network. Epochs trained: {epoch}", end="")
+
+    def save(self, filename: Union[str, Path]) -> None:
+        """Save the inference object to a file.
+
+        This saves the full state of the inference object including trained neural
+        network weights, optimizer state, and all training metadata. The saved file
+        can be loaded with ``NeuralInference.load()`` or the class-specific ``load``
+        class method (e.g. ``NPE.load()``).
+
+        Args:
+            filename: Path to the file where the inference object will be saved.
+
+        Example:
+            >>> inference = NPE(prior=prior)
+            >>> inference.append_simulations(theta, x).train()
+            >>> inference.save("my_npe.pkl")
+        """
+        filepath = Path(filename)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        state = {
+            "sbi_version": __version__,
+            "class_name": self.__class__.__name__,
+            "class_module": self.__class__.__module__,
+            "state": self.__getstate__(),
+        }
+        fd, temp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                pickle.dump(state, handle)
+            os.replace(temp_path, filepath)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    @classmethod
+    def load(cls, filename: Union[str, Path]) -> "NeuralInference":
+        """Load a saved inference object from a file.
+
+        This method loads an inference object that was previously saved with
+        ``save()``. The loaded object retains trained network weights, optimizer
+        state, and training metadata.
+
+        Note:
+            The file is loaded with ``pickle``, which can execute arbitrary code.
+            Only load files from trusted sources.
+
+        Args:
+            filename: Path to the file to load.
+
+        Returns:
+            The loaded inference object.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file was not created with ``save()``.
+
+        Example:
+            >>> inference = NPE.load("my_npe.pkl")
+            >>> posterior = inference.build_posterior()
+        """
+        filepath = Path(filename)
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {filepath}")
+
+        with open(filepath, "rb") as handle:
+            state = CPU_Unpickler(handle).load()  # noqa: S301
+
+        if not isinstance(state, dict) or not all(
+            key in state
+            for key in ("sbi_version", "class_module", "class_name", "state")
+        ):
+            raise ValueError(
+                f"The file {filepath} was not created with "
+                "`NeuralInference.save()`. Use `pickle.load()` directly instead."
+            )
+
+        class_module = state["class_module"]
+        class_name = state["class_name"]
+        restored_state = state["state"]
+        if (
+            not isinstance(class_module, str)
+            or not class_module
+            or not isinstance(class_name, str)
+            or not class_name
+        ):
+            raise ValueError(
+                f"The file {filepath} contains invalid class metadata in "
+                f"`class_module` (`{class_module!r}`) or `class_name` "
+                f"(`{class_name!r}`)."
+            )
+        if not isinstance(restored_state, dict):
+            raise ValueError(
+                f"The file {filepath} contains an invalid `state` of type "
+                f"`{type(restored_state).__name__}`; expected a `dict`."
+            )
+
+        sbi_version = state["sbi_version"]
+        if sbi_version != __version__:
+            warn(
+                f"The file was saved with sbi version {sbi_version} but the "
+                f"current version is {__version__}. This may cause compatibility "
+                "issues.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        try:
+            loaded_class = getattr(importlib.import_module(class_module), class_name)
+        except (ImportError, AttributeError, TypeError) as error:
+            raise ValueError(
+                f"The file {filepath} references `{class_name}` in `{class_module}` "
+                "which cannot be resolved."
+            ) from error
+        if not isinstance(loaded_class, type) or not issubclass(loaded_class, cls):
+            raise ValueError(
+                f"The file {filepath} was saved by a {class_name} in "
+                f"{class_module} but was loaded with {cls.__name__}."
+            )
+        loaded = loaded_class.__new__(loaded_class)
+        try:
+            loaded.__setstate__(restored_state)
+        except (AttributeError, TypeError, ValueError, KeyError, ImportError) as error:
+            raise ValueError(
+                f"The file {filepath} contains a `state` that cannot restore a "
+                f"{cls.__name__}: {error}"
+            ) from error
+
+        neural_net = getattr(loaded, "_neural_net", None)
+        if neural_net is not None:
+            loaded._device = infer_module_device(neural_net, "cpu")
+
+        prior = getattr(loaded, "_prior", None)
+        if prior is not None:
+            loaded._prior = move_distribution_to_device(prior, loaded._device)
+
+        return loaded
 
     def __getstate__(self) -> Dict:
         """Returns the state of the object that is supposed to be pickled.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -2,6 +2,7 @@
 # under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 import logging
+import pickle
 import random
 import warnings
 from math import pi
@@ -34,6 +35,41 @@ from torch.distributions import (
 from torch.optim.adam import Adam
 
 from sbi.sbi_types import TorchTransform
+
+
+class CPU_Unpickler(pickle.Unpickler):
+    """A :class:`pickle.Unpickler` that restores tensors and storages on CPU.
+
+    PyTorch embeds the device a storage was created on in the pickle stream, so loading
+    a file saved on GPU raises an error on a host without that device. This unpickler
+    rebinds the helpers that create storages and tensors so they are always restored on
+    CPU. Loading a file that was saved on CPU is a no-op; loading one saved on another
+    device moves the tensors to CPU. Tensors on the requested device are preserved.
+    """
+
+    _STORAGE_HELPERS = {"_load_from_bytes"}
+    _TENSOR_HELPERS = {
+        "_rebuild_tensor",
+        "_rebuild_tensor_v2",
+        "_rebuild_tensor_v3",
+        "_rebuild_parameter",
+        "_rebuild_parameter_with_state",
+    }
+
+    def find_class(self, module: str, name: str):
+        func = super().find_class(module, name)
+        if module == "torch.storage" and name in self._STORAGE_HELPERS:
+            return lambda data: func(data).cpu()
+        if module == "torch._utils" and name in self._TENSOR_HELPERS:
+            return lambda *args, **kwargs: func(*args, **kwargs).cpu()
+        if (
+            module == "torch._utils"
+            and name == "_rebuild_device_tensor_from_cpu_tensor"
+        ):
+            return lambda data, dtype, device, requires_grad: func(
+                data, dtype, "cpu", requires_grad
+            )
+        return func
 
 
 def warn_if_invalid_for_zscoring(

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -8,8 +8,10 @@ import pytest
 import torch
 from torch.distributions import MultivariateNormal
 
+from sbi import __version__
 from sbi import utils as utils
 from sbi.inference import FMPE, NLE, NPE, NPSE, NRE
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.posteriors.ensemble_posterior import EnsemblePosterior
 from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
 from sbi.inference.posteriors.posterior_parameters import (
@@ -21,6 +23,7 @@ from sbi.inference.posteriors.posterior_parameters import (
     VectorFieldPosteriorParameters,
 )
 from sbi.inference.posteriors.vi_posterior import VIPosterior
+from sbi.inference.trainers.base import NeuralInference
 
 
 def _assert_survives_pickling(posterior, num_dim: int) -> None:
@@ -235,3 +238,217 @@ def test_torch_load_map_location_same_device_is_passthrough():
     assert loaded._device == "cpu"
     assert loaded.device == "cpu"
     assert loaded.sample((10,)).shape == (10, 2)
+
+
+@pytest.mark.parametrize("inference_method", (NPE, NPSE, FMPE))
+def test_save_and_load_inference(inference_method, tmp_path):
+    num_dim = 2
+    prior = utils.BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+
+    theta = prior.sample((500,))
+    x = theta + 1.0 + torch.randn_like(theta) * 0.1
+
+    inference = inference_method(prior=prior)
+    _ = inference.append_simulations(theta, x).train(max_num_epochs=1)
+
+    filepath = tmp_path / "inference.pkl"
+    inference.save(filepath)
+    loaded = NeuralInference.load(filepath)
+
+    assert isinstance(loaded, inference_method)
+    assert loaded._round == inference._round
+    assert loaded._neural_net is not None
+    loaded.append_simulations(theta, x)
+
+
+@pytest.mark.parametrize(
+    "inference_method, posterior_parameters",
+    (
+        (NPE, DirectPosteriorParameters),
+        (NPSE, VectorFieldPosteriorParameters),
+        (FMPE, VectorFieldPosteriorParameters),
+    ),
+)
+def test_save_and_load_posterior(inference_method, posterior_parameters, tmp_path):
+    num_dim = 2
+    prior = utils.BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    x_o = torch.zeros(1, num_dim)
+
+    theta = prior.sample((500,))
+    x = theta + 1.0 + torch.randn_like(theta) * 0.1
+
+    inference = inference_method(prior=prior)
+    _ = inference.append_simulations(theta, x).train(max_num_epochs=1)
+    posterior = inference.build_posterior(
+        posterior_parameters=posterior_parameters()
+    ).set_default_x(x_o)
+
+    filepath = tmp_path / "posterior.pkl"
+    posterior.save(filepath)
+    loaded = NeuralPosterior.load(filepath)
+
+    assert isinstance(loaded, type(posterior))
+    assert loaded._device == posterior._device
+    assert loaded.sample((10,), x=x_o).shape == (10, num_dim)
+
+
+def test_save_load_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        NeuralInference.load(tmp_path / "nonexistent.pkl")
+
+    with pytest.raises(FileNotFoundError):
+        NeuralPosterior.load(tmp_path / "nonexistent.pkl")
+
+
+@pytest.mark.parametrize(
+    "loader",
+    (NeuralInference.load, NeuralPosterior.load),
+)
+@pytest.mark.parametrize("payload", (None, [], {"foo": "bar"}))
+def test_save_load_rejects_invalid_payload(tmp_path, loader, payload):
+    filepath = tmp_path / "invalid.pkl"
+    with open(filepath, "wb") as handle:
+        pickle.dump(payload, handle)
+    with pytest.raises(ValueError):
+        loader(filepath)
+
+
+@pytest.mark.parametrize(
+    "loader",
+    (NeuralInference.load, NeuralPosterior.load),
+)
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"class_module": "does.not.exist", "class_name": "NPE"},
+        {"class_module": "math", "class_name": "missing_attribute"},
+        {
+            "class_module": "sbi.inference.trainers.npe",
+            "class_name": "NPE",
+            "state": [],
+        },
+    ),
+)
+def test_save_load_rejects_malformed_metadata(tmp_path, loader, overrides):
+    filepath = tmp_path / "malformed.pkl"
+    state = {
+        "sbi_version": __version__,
+        "class_module": "sbi.inference.trainers.npe",
+        "class_name": "NPE",
+        "state": {},
+    }
+    state.update(overrides)
+    with open(filepath, "wb") as handle:
+        pickle.dump(state, handle)
+    with pytest.raises(ValueError):
+        loader(filepath)
+
+
+@pytest.mark.parametrize(
+    "loader",
+    (NeuralInference.load, NeuralPosterior.load),
+)
+def test_save_load_rejects_non_class_metadata(tmp_path, loader):
+    filepath = tmp_path / "non_class.pkl"
+    state = {
+        "sbi_version": __version__,
+        "class_name": "pi",
+        "class_module": "math",
+        "state": {},
+    }
+    with open(filepath, "wb") as handle:
+        pickle.dump(state, handle)
+    with pytest.raises(ValueError):
+        loader(filepath)
+
+
+def test_save_load_maps_cuda_claimed_posterior_to_cpu(tmp_path):
+    """A file claiming CUDA loads on CPU and reconciles the claimed device.
+
+    The tensors are CPU-backed (saving cannot run on a device-less host); claiming
+    `cuda:0` simulates a GPU-saved file restored with a CPU-aware unpickler, so the
+    posterior's device-repair logic runs on CPU-only CI.
+    """
+    posterior = _build_posterior("direct", _box_uniform())
+    posterior._device = posterior.device = posterior.potential_fn.device = "cuda:0"
+    if hasattr(posterior.prior, "device"):
+        posterior.prior.device = "cuda:0"
+
+    filepath = tmp_path / "cuda_claimed.pkl"
+    state = {
+        "sbi_version": __version__,
+        "class_name": posterior.__class__.__name__,
+        "class_module": posterior.__class__.__module__,
+        "state": posterior.__getstate__(),
+    }
+    with open(filepath, "wb") as handle:
+        pickle.dump(state, handle)
+    loaded = NeuralPosterior.load(filepath)
+
+    assert loaded._device == "cpu"
+    assert loaded.device == "cpu"
+    assert loaded.potential_fn.device == "cpu"
+    assert getattr(loaded.prior, "device", "cpu") == "cpu"
+    samples = loaded.sample((10,))
+    assert samples.device.type == "cpu"
+    assert loaded.potential(samples).device.type == "cpu"
+
+
+def test_save_load_maps_cuda_claimed_inference_to_cpu(tmp_path):
+    """A CUDA-claiming inference file loads with its net and device on CPU."""
+    num_dim = 2
+    prior = utils.BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    theta = prior.sample((500,))
+    x = theta + 1.0 + torch.randn_like(theta) * 0.1
+
+    inference = NPE(prior=prior)
+    _ = inference.append_simulations(theta, x).train(max_num_epochs=1)
+    prior.device = "cuda:0"
+
+    filepath = tmp_path / "cuda_claimed.pkl"
+    state = {
+        "sbi_version": __version__,
+        "class_name": inference.__class__.__name__,
+        "class_module": inference.__class__.__module__,
+        "state": inference.__getstate__(),
+    }
+    state["state"]["_device"] = "cuda:0"
+    with open(filepath, "wb") as handle:
+        pickle.dump(state, handle)
+
+    loaded = NeuralInference.load(filepath)
+
+    assert isinstance(loaded, NPE)
+    assert loaded._device == "cpu"
+    assert next(loaded._neural_net.parameters()).device.type == "cpu"
+    assert loaded._prior.device == "cpu"
+    assert loaded._prior.sample((1,)).device.type == "cpu"
+
+
+@pytest.mark.parametrize(
+    "loader, class_name, class_module",
+    (
+        (
+            NeuralInference.load,
+            "NPE",
+            "sbi.inference.trainers.npe",
+        ),
+        (
+            NeuralPosterior.load,
+            "DirectPosterior",
+            "sbi.inference.posteriors.direct_posterior",
+        ),
+    ),
+)
+def test_save_load_version_mismatch_warns(tmp_path, loader, class_name, class_module):
+    filepath = tmp_path / "mismatch.pkl"
+    state = {
+        "sbi_version": "0.0.0",
+        "class_name": class_name,
+        "class_module": class_module,
+        "state": {},
+    }
+    with open(filepath, "wb") as handle:
+        pickle.dump(state, handle)
+    with pytest.warns(UserWarning, match="saved with sbi version"):
+        loader(filepath)


### PR DESCRIPTION
## changes

Closes #1980.

Adds a supported way to save and reload the trained inference object (trainer) via
`NeuralInference.save()` / `NeuralInference.load()`, and corresponding methods
`NeuralPosterior.save()` / `NeuralPosterior.load()` for the posterior.

This is a follow-up to #1525 which covered saving a posterior via the how-to guide. This PR
makes both trainable and posterior persistence a first-class, tested API

## Checklist

- [x] I have read the [contributing guide](https://sbi.readthedocs.io/en/latest/contributing.html).
- [x] `uv run pytest -n auto -m "not slow and not gpu"` passes.
- [x] `uv run pre-commit run --all-files` passes (ruff and formatting).
- [x] `uv run pyright sbi` passes.
- [x] I added or updated tests for the changed behavior.
- [x] I used Google-style docstrings for new or changed public functions.
- [x] (If applicable) I reported how long new tests run and marked slow ones
      with `pytest.mark.slow`.

## AI usage

 manually written and some tests are written by Claude. generated
code was reviewed line-by-line, understood, and tested by the me, who is fully
responsible for its correctness and quality.